### PR TITLE
:bug:  update so the keyword input displays

### DIFF
--- a/src/lib/printer.js
+++ b/src/lib/printer.js
@@ -167,7 +167,12 @@ module.exports = class Printer {
   }
 
   printCodeType(type) {
-    const entity = isInterfaceType(type) ? "interface" : "type";
+    let entity;
+    if (isInputType(type)) {
+      entity = "input";
+    } else {
+      entity = isInterfaceType(type) ? "interface" : "type";
+    }
     const name = getTypeName(type);
     const extendsInterface =
       hasMethod(type, "getInterfaces") && type.getInterfaces().length > 0

--- a/tests/integration/lib/__expect__/unix/generator.spec.js/generateDocFromSchemaOutputFolder.hash
+++ b/tests/integration/lib/__expect__/unix/generator.spec.js/generateDocFromSchemaOutputFolder.hash
@@ -66,12 +66,12 @@
         {
           "path": "output/inputs/tweet-content.mdx",
           "name": "tweet-content.mdx",
-          "size": 270,
+          "size": 271,
           "type": "file",
           "extension": ".mdx"
         }
       ],
-      "size": 286,
+      "size": 287,
       "type": "directory"
     },
     {
@@ -340,6 +340,6 @@
       "type": "directory"
     }
   ],
-  "size": 8452,
+  "size": 8453,
   "type": "directory"
 }

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printCodeTypeWithInput.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printCodeTypeWithInput.md
@@ -1,0 +1,4 @@
+input TestName {
+  one
+  two
+}

--- a/tests/unit/lib/printer.test.js
+++ b/tests/unit/lib/printer.test.js
@@ -500,6 +500,26 @@ describe("lib", () => {
             path.join(EXPECT_PATH, "printCodeTypeWithObject.md"),
           );
         });
+        test("returns an input with its fields", () => {
+          expect.hasAssertions();
+
+          const type = {
+            name: "TestName",
+            fields: ["one", "two"],
+          };
+          jest.spyOn(graphql, "isInputType").mockReturnValueOnce(true);
+          jest
+            .spyOn(graphql, "getTypeName")
+            .mockImplementation((entityType) => entityType.name);
+          jest.spyOn(graphql, "getFields").mockReturnValueOnce(type.fields);
+          jest
+            .spyOn(printerInstance, "printCodeField")
+            .mockImplementation((codeField) => `${codeField}\n`);
+          const code = printerInstance.printCodeType(type);
+          expect(code).toMatchFile(
+            path.join(EXPECT_PATH, "printCodeTypeWithInput.md"),
+          );
+        });
       });
 
       describe("printHeader()", () => {


### PR DESCRIPTION
# Description

For any generated documentation for input types, the keyword that is displayed is `type` instead of `input`. An example of this issue can be found in https://codesandbox.io/s/edno-graphql-markdown-demo-iiyj3c?file=/graphql-markdown.config.js mentioned in the README. When you view the docs for the input types, there is a `type` keyword instead of an `input` keyword.
<img width="736" alt="Screen Shot 2022-03-24 at 7 20 06 PM" src="https://user-images.githubusercontent.com/92743401/160030658-fff3b785-464e-48d9-9720-f363ccc256d6.png">


# Checklist

-  [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
