### PR TITLE
:bug:  remove blank line from code block

### DIFF
--- a/src/lib/printer.js
+++ b/src/lib/printer.js
@@ -250,8 +250,7 @@ ${HEADER_SECTION_LEVEL} Specification<a className="link" style={specifiedByLinkC
       default:
         code += `"${getTypeName(type)}" not supported`;
     }
-    code += "\n```\n";
-    return code;
+    return code.trim() + "\n```\n";
   }
 
   printType(name, type) {

--- a/tests/integration/lib/__expect__/unix/generator.spec.js/generateDocFromSchemaOutputFolder.hash
+++ b/tests/integration/lib/__expect__/unix/generator.spec.js/generateDocFromSchemaOutputFolder.hash
@@ -16,33 +16,33 @@
         {
           "path": "output/directives/deprecated.mdx",
           "name": "deprecated.mdx",
-          "size": 477,
+          "size": 476,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/directives/include.mdx",
           "name": "include.mdx",
-          "size": 279,
+          "size": 278,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/directives/skip.mdx",
           "name": "skip.mdx",
-          "size": 261,
+          "size": 260,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/directives/specified-by.mdx",
           "name": "specified-by.mdx",
-          "size": 289,
+          "size": 288,
           "type": "file",
           "extension": ".mdx"
         }
       ],
-      "size": 1326,
+      "size": 1322,
       "type": "directory"
     },
     {
@@ -66,12 +66,12 @@
         {
           "path": "output/inputs/tweet-content.mdx",
           "name": "tweet-content.mdx",
-          "size": 271,
+          "size": 270,
           "type": "file",
           "extension": ".mdx"
         }
       ],
-      "size": 287,
+      "size": 286,
       "type": "directory"
     },
     {
@@ -88,12 +88,12 @@
         {
           "path": "output/interfaces/node.mdx",
           "name": "node.mdx",
-          "size": 156,
+          "size": 155,
           "type": "file",
           "extension": ".mdx"
         }
       ],
-      "size": 176,
+      "size": 175,
       "type": "directory"
     },
     {
@@ -110,26 +110,26 @@
         {
           "path": "output/mutations/create-tweet.mdx",
           "name": "create-tweet.mdx",
-          "size": 368,
+          "size": 366,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/mutations/delete-tweet.mdx",
           "name": "delete-tweet.mdx",
-          "size": 236,
+          "size": 234,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/mutations/mark-tweet-read.mdx",
           "name": "mark-tweet-read.mdx",
-          "size": 304,
+          "size": 302,
           "type": "file",
           "extension": ".mdx"
         }
       ],
-      "size": 927,
+      "size": 921,
       "type": "directory"
     },
     {
@@ -146,47 +146,47 @@
         {
           "path": "output/objects/media.mdx",
           "name": "media.mdx",
-          "size": 222,
+          "size": 221,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/objects/meta.mdx",
           "name": "meta.mdx",
-          "size": 159,
+          "size": 158,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/objects/notification.mdx",
           "name": "notification.mdx",
-          "size": 314,
+          "size": 313,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/objects/stat.mdx",
           "name": "stat.mdx",
-          "size": 445,
+          "size": 444,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/objects/tweet.mdx",
           "name": "tweet.mdx",
-          "size": 665,
+          "size": 664,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/objects/user.mdx",
           "name": "user.mdx",
-          "size": 787,
+          "size": 786,
           "type": "file",
           "extension": ".mdx"
         }
       ],
-      "size": 2609,
+      "size": 2603,
       "type": "directory"
     },
     {
@@ -203,47 +203,47 @@
         {
           "path": "output/queries/notifications-meta.mdx",
           "name": "notifications-meta.mdx",
-          "size": 175,
+          "size": 173,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/queries/tweet.mdx",
           "name": "tweet.mdx",
-          "size": 217,
+          "size": 215,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/queries/tweets-meta.mdx",
           "name": "tweets-meta.mdx",
-          "size": 154,
+          "size": 152,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/queries/tweets.mdx",
           "name": "tweets.mdx",
-          "size": 477,
+          "size": 475,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/queries/user.mdx",
           "name": "user.mdx",
-          "size": 211,
+          "size": 209,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/queries/users.mdx",
           "name": "users.mdx",
-          "size": 220,
+          "size": 218,
           "type": "file",
           "extension": ".mdx"
         }
       ],
-      "size": 1471,
+      "size": 1459,
       "type": "directory"
     },
     {
@@ -260,54 +260,54 @@
         {
           "path": "output/scalars/boolean.mdx",
           "name": "boolean.mdx",
-          "size": 129,
+          "size": 128,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/scalars/date.mdx",
           "name": "date.mdx",
-          "size": 79,
+          "size": 78,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/scalars/id.mdx",
           "name": "id.mdx",
-          "size": 391,
+          "size": 390,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/scalars/int.mdx",
           "name": "int.mdx",
-          "size": 193,
+          "size": 192,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/scalars/sri.mdx",
           "name": "sri.mdx",
-          "size": 76,
+          "size": 75,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/scalars/string.mdx",
           "name": "string.mdx",
-          "size": 252,
+          "size": 251,
           "type": "file",
           "extension": ".mdx"
         },
         {
           "path": "output/scalars/url.mdx",
           "name": "url.mdx",
-          "size": 76,
+          "size": 75,
           "type": "file",
           "extension": ".mdx"
         }
       ],
-      "size": 1213,
+      "size": 1206,
       "type": "directory"
     },
     {
@@ -331,15 +331,15 @@
         {
           "path": "output/subscriptions/notifications.mdx",
           "name": "notifications.mdx",
-          "size": 273,
+          "size": 271,
           "type": "file",
           "extension": ".mdx"
         }
       ],
-      "size": 296,
+      "size": 294,
       "type": "directory"
     }
   ],
-  "size": 8453,
+  "size": 8414,
   "type": "directory"
 }

--- a/tests/integration/lib/__expect__/unix/generator.spec.js/generateDocFromSchemaWithGroupingOutputFolder
+++ b/tests/integration/lib/__expect__/unix/generator.spec.js/generateDocFromSchemaWithGroupingOutputFolder
@@ -27,19 +27,19 @@
             {
               "path": "output/course/mutations/add-course.mdx",
               "name": "add-course.mdx",
-              "size": 441,
+              "size": 439,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/course/mutations/drop-course.mdx",
               "name": "drop-course.mdx",
-              "size": 444,
+              "size": 442,
               "type": "file",
               "extension": ".mdx"
             }
           ],
-          "size": 904,
+          "size": 900,
           "type": "directory"
         },
         {
@@ -56,30 +56,30 @@
             {
               "path": "output/course/queries/all-courses.mdx",
               "name": "all-courses.mdx",
-              "size": 348,
+              "size": 346,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/course/queries/math-courses.mdx",
               "name": "math-courses.mdx",
-              "size": 351,
+              "size": 349,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/course/queries/science-courses.mdx",
               "name": "science-courses.mdx",
-              "size": 360,
+              "size": 358,
               "type": "file",
               "extension": ".mdx"
             }
           ],
-          "size": 1076,
+          "size": 1070,
           "type": "directory"
         }
       ],
-      "size": 1996,
+      "size": 1986,
       "type": "directory"
     },
     {
@@ -114,19 +114,19 @@
             {
               "path": "output/grade/mutations/update-gpa.mdx",
               "name": "update-gpa.mdx",
-              "size": 373,
+              "size": 371,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/grade/mutations/update-grade.mdx",
               "name": "update-grade.mdx",
-              "size": 447,
+              "size": 445,
               "type": "file",
               "extension": ".mdx"
             }
           ],
-          "size": 839,
+          "size": 835,
           "type": "directory"
         },
         {
@@ -143,30 +143,30 @@
             {
               "path": "output/grade/queries/gpa.mdx",
               "name": "gpa.mdx",
-              "size": 363,
+              "size": 361,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/grade/queries/un-weighted-gpa.mdx",
               "name": "un-weighted-gpa.mdx",
-              "size": 395,
+              "size": 393,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/grade/queries/weighted-gpa.mdx",
               "name": "weighted-gpa.mdx",
-              "size": 388,
+              "size": 386,
               "type": "file",
               "extension": ".mdx"
             }
           ],
-          "size": 1163,
+          "size": 1157,
           "type": "directory"
         }
       ],
-      "size": 2017,
+      "size": 2007,
       "type": "directory"
     },
     {
@@ -194,40 +194,40 @@
             {
               "path": "output/misc/directives/deprecated.mdx",
               "name": "deprecated.mdx",
-              "size": 482,
+              "size": 481,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/misc/directives/doc.mdx",
               "name": "doc.mdx",
-              "size": 184,
+              "size": 183,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/misc/directives/include.mdx",
               "name": "include.mdx",
-              "size": 284,
+              "size": 283,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/misc/directives/skip.mdx",
               "name": "skip.mdx",
-              "size": 266,
+              "size": 265,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/misc/directives/specified-by.mdx",
               "name": "specified-by.mdx",
-              "size": 294,
+              "size": 293,
               "type": "file",
               "extension": ".mdx"
             }
           ],
-          "size": 1530,
+          "size": 1525,
           "type": "directory"
         },
         {
@@ -244,19 +244,19 @@
             {
               "path": "output/misc/objects/department-information.mdx",
               "name": "department-information.mdx",
-              "size": 544,
+              "size": 543,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/misc/objects/semester.mdx",
               "name": "semester.mdx",
-              "size": 353,
+              "size": 352,
               "type": "file",
               "extension": ".mdx"
             }
           ],
-          "size": 914,
+          "size": 912,
           "type": "directory"
         },
         {
@@ -273,58 +273,58 @@
             {
               "path": "output/misc/scalars/boolean.mdx",
               "name": "boolean.mdx",
-              "size": 129,
+              "size": 128,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/misc/scalars/date.mdx",
               "name": "date.mdx",
-              "size": 79,
+              "size": 78,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/misc/scalars/email-address.mdx",
               "name": "email-address.mdx",
-              "size": 104,
+              "size": 103,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/misc/scalars/int.mdx",
               "name": "int.mdx",
-              "size": 193,
+              "size": 192,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/misc/scalars/phone-number.mdx",
               "name": "phone-number.mdx",
-              "size": 101,
+              "size": 100,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/misc/scalars/string.mdx",
               "name": "string.mdx",
-              "size": 252,
+              "size": 251,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/misc/scalars/time.mdx",
               "name": "time.mdx",
-              "size": 79,
+              "size": 78,
               "type": "file",
               "extension": ".mdx"
             }
           ],
-          "size": 954,
+          "size": 947,
           "type": "directory"
         }
       ],
-      "size": 3412,
+      "size": 3398,
       "type": "directory"
     },
     {
@@ -335,6 +335,6 @@
       "extension": ".js"
     }
   ],
-  "size": 7573,
+  "size": 7539,
   "type": "directory"
 }

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithDirective.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithDirective.md
@@ -1,4 +1,3 @@
-
 ```graphql
 TestDirective
 ```

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithEnum.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithEnum.md
@@ -1,4 +1,3 @@
-
 ```graphql
 TestEnum
 ```

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithInput.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithInput.md
@@ -1,4 +1,3 @@
-
 ```graphql
 TestInput
 ```

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithInterface.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithInterface.md
@@ -1,4 +1,3 @@
-
 ```graphql
 TestInterface
 ```

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithObject.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithObject.md
@@ -1,4 +1,3 @@
-
 ```graphql
 TestObject
 ```

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithQuery.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithQuery.md
@@ -1,4 +1,3 @@
-
 ```graphql
 TestQuery
 ```

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithScalar.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithScalar.md
@@ -1,4 +1,3 @@
-
 ```graphql
 TestScalar
 ```

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithUnion.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithUnion.md
@@ -1,4 +1,3 @@
-
 ```graphql
 TestUnion
 ```

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithUnsupported.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printCodeWithUnsupported.md
@@ -1,4 +1,3 @@
-
 ```graphql
 "TestFooBarType" not supported
 ```

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printTypeWithScalarWithSpecifiedBy.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printTypeWithScalarWithSpecifiedBy.md
@@ -6,7 +6,6 @@ title: undefined
 
 Lorem Ipsum
 
-
 ```graphql
 scalar undefined
 ```


### PR DESCRIPTION
# Description

Remove extra line that appears at the end of some code blocks

Before:
<img width="838" alt="Screenshot 2022-04-09 at 17 17 36" src="https://user-images.githubusercontent.com/324670/162580269-b7263f53-c360-4df1-b1ab-0631dd64e4c1.png">

After:
<img width="845" alt="Screenshot 2022-04-09 at 17 18 02" src="https://user-images.githubusercontent.com/324670/162580282-e163ccb5-bf12-4c1f-9efa-b6d11b2213e3.png">


# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
