### PR TITLE
🐛 fix default value 0 not rendered in doc

### DIFF
--- a/src/lib/graphql.js
+++ b/src/lib/graphql.js
@@ -74,21 +74,21 @@ function getDefaultValue(argument) {
     return undefined;
   }
 
-  if (isListType(argument.type)) {
-    const defaultValues = Array.isArray(argument.defaultValue)
-      ? argument.defaultValue
-      : [argument.defaultValue];
-
-    const defaultValuesString = defaultValues
-      .map((defaultValue) => {
-        return printDefaultValue(argument.type.ofType, defaultValue);
-      })
-      .join(", ");
-
-    return `[${defaultValuesString}]`;
+  if (!isListType(argument.type)) {
+    return printDefaultValue(argument.type, argument.defaultValue);
   }
 
-  return printDefaultValue(argument.type, argument.defaultValue);
+  const defaultValues = Array.isArray(argument.defaultValue)
+    ? argument.defaultValue
+    : [argument.defaultValue];
+
+  const defaultValuesString = defaultValues
+    .map((defaultValue) => {
+      return printDefaultValue(argument.type.ofType, defaultValue);
+    })
+    .join(", ");
+
+  return `[${defaultValuesString}]`;
 }
 
 function printDefaultValue(type, value) {

--- a/src/lib/printer.js
+++ b/src/lib/printer.js
@@ -141,12 +141,15 @@ module.exports = class Printer {
     if (hasProperty(type, "args") && type.args.length > 0) {
       code += `(\n`;
       code += type.args.reduce((r, v) => {
-        const defaultValue = getDefaultValue(v)
+        const defaultValue = getDefaultValue(v);
+        const hasDefaultValue =
+          typeof defaultValue !== "undefined" && defaultValue !== null;
+        const printedDefault = hasDefaultValue
           ? ` = ${getDefaultValue(v)}`
           : "";
         const propType = v.type.toString();
         const propName = v.name.toString();
-        return `${r}  ${propName}: ${propType}${defaultValue}\n`;
+        return `${r}  ${propName}: ${propType}${printedDefault}\n`;
       }, "");
       code += `)`;
     }

--- a/tests/__data__/schema_with_grouping.graphql
+++ b/tests/__data__/schema_with_grouping.graphql
@@ -1,7 +1,6 @@
 directive @doc(
   category: String
-) on OBJECT |  INPUT_OBJECT | UNION | ENUM | INTERFACE | FIELD_DEFINITION | ARGUMENT_DEFINITION
-
+) on OBJECT | INPUT_OBJECT | UNION | ENUM | INTERFACE | FIELD_DEFINITION | ARGUMENT_DEFINITION
 
 scalar Date
 scalar EmailAddress
@@ -24,13 +23,11 @@ type Mutation{
   DropCourse(input: String): String  @doc(category: "Course") 
 }
 
-
 type Query {
-  GPA(input: String): Int  @doc(category: "Grade") 
-  WeightedGPA(input: String): Int  @doc(category: "Grade") 
-  UnWeightedGPA(input: String): Int  @doc(category: "Grade") 
+  GPA(skip: Int = 0): Int  @doc(category: "Grade") 
+  WeightedGPA(input: String, skip: Int): Int  @doc(category: "Grade") 
+  UnWeightedGPA(input: String, skip: Int): Int  @doc(category: "Grade") 
 }
-
 
 type Query {
   allCourses: [String]  @doc(category: "Course") 

--- a/tests/integration/lib/__expect__/unix/generator.spec.js/generateDocFromSchemaOutputFolder.hash
+++ b/tests/integration/lib/__expect__/unix/generator.spec.js/generateDocFromSchemaOutputFolder.hash
@@ -224,7 +224,7 @@
         {
           "path": "output/queries/tweets.mdx",
           "name": "tweets.mdx",
-          "size": 505,
+          "size": 509,
           "type": "file",
           "extension": ".mdx"
         },
@@ -243,7 +243,7 @@
           "extension": ".mdx"
         }
       ],
-      "size": 1639,
+      "size": 1643,
       "type": "directory"
     },
     {
@@ -340,6 +340,6 @@
       "type": "directory"
     }
   ],
-  "size": 9284,
+  "size": 9288,
   "type": "directory"
 }

--- a/tests/integration/lib/__expect__/unix/generator.spec.js/generateDocFromSchemaWithGroupingOutputFolder
+++ b/tests/integration/lib/__expect__/unix/generator.spec.js/generateDocFromSchemaWithGroupingOutputFolder
@@ -143,30 +143,30 @@
             {
               "path": "output/grade/queries/gpa.mdx",
               "name": "gpa.mdx",
-              "size": 391,
+              "size": 384,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/grade/queries/un-weighted-gpa.mdx",
               "name": "un-weighted-gpa.mdx",
-              "size": 423,
+              "size": 492,
               "type": "file",
               "extension": ".mdx"
             },
             {
               "path": "output/grade/queries/weighted-gpa.mdx",
               "name": "weighted-gpa.mdx",
-              "size": 416,
+              "size": 485,
               "type": "file",
               "extension": ".mdx"
             }
           ],
-          "size": 1247,
+          "size": 1378,
           "type": "directory"
         }
       ],
-      "size": 2157,
+      "size": 2288,
       "type": "directory"
     },
     {
@@ -335,6 +335,6 @@
       "extension": ".js"
     }
   ],
-  "size": 8259,
+  "size": 8390,
   "type": "directory"
 }

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printCodeArguments.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printCodeArguments.md
@@ -2,4 +2,5 @@
   ParamWithDefault: string = defaultValue
   ParamNoDefault: any
   ParamIntZero: int = 0
+  ParamIntNoDefault: int
 )

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printCodeArguments.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printCodeArguments.md
@@ -1,4 +1,5 @@
 (
   ParamWithDefault: string = defaultValue
   ParamNoDefault: any
+  ParamIntZero: int = 0
 )

--- a/tests/unit/lib/graphql.test.js
+++ b/tests/unit/lib/graphql.test.js
@@ -80,103 +80,47 @@ describe("lib", () => {
     });
 
     describe("getDefaultValue()", () => {
-      test("returns default value as an integer when defined", () => {
+      test.each([
+        { type: GraphQLInt, value: 5 },
+        { type: GraphQLInt, value: 0 },
+        { type: GraphQLFloat, value: 5.3 },
+        { type: GraphQLFloat, value: 0.0 },
+      ])("returns $value value as default for $type", ({ type, value }) => {
         expect.hasAssertions();
 
         const argument = {
           name: "foobar",
           description: undefined,
-          type: GraphQLInt,
-          defaultValue: 5,
+          type: type,
+          defaultValue: value,
           extensions: undefined,
         };
 
-        expect(getDefaultValue(argument)).toBe(5);
+        expect(getDefaultValue(argument)).toEqual(value);
       });
 
-      test("returns default value as a float when defined", () => {
-        expect.hasAssertions();
+      test.each([
+        { type: GraphQLInt },
+        { type: GraphQLID },
+        { type: GraphQLFloat },
+        { type: GraphQLString },
+        { type: new GraphQLList(GraphQLID) },
+      ])(
+        "returns undefined for type $type if not default value defined",
+        ({ type }) => {
+          expect.hasAssertions();
 
-        const argument = {
-          name: "foobar",
-          description: undefined,
-          type: GraphQLFloat,
-          defaultValue: 5.3,
-          extensions: undefined,
-        };
+          const argument = {
+            name: "foobar",
+            description: undefined,
+            type: type,
+            defaultValue: undefined,
+            extensions: undefined,
+          };
 
-        expect(getDefaultValue(argument)).toBe(5.3);
-      });
-
-      test("returns undefined for type GraphQLInt if not default value defined", () => {
-        expect.hasAssertions();
-
-        const argument = {
-          name: "foobar",
-          description: undefined,
-          type: GraphQLInt,
-          defaultValue: undefined,
-          extensions: undefined,
-        };
-
-        expect(getDefaultValue(argument)).toBeUndefined();
-      });
-
-      test("returns undefined for type GraphQLID if not default value defined", () => {
-        expect.hasAssertions();
-
-        const argument = {
-          name: "foobar",
-          description: undefined,
-          type: GraphQLID,
-          defaultValue: undefined,
-          extensions: undefined,
-        };
-
-        expect(getDefaultValue(argument)).toBeUndefined();
-      });
-
-      test("returns undefined for type GraphQLFloat if not default value defined", () => {
-        expect.hasAssertions();
-
-        const argument = {
-          name: "foobar",
-          description: undefined,
-          type: GraphQLFloat,
-          defaultValue: undefined,
-          extensions: undefined,
-        };
-
-        expect(getDefaultValue(argument)).toBeUndefined();
-      });
-
-      test("returns undefined for type GraphQLString if not default value defined", () => {
-        expect.hasAssertions();
-
-        const argument = {
-          name: "foobar",
-          description: undefined,
-          type: GraphQLString,
-          defaultValue: undefined,
-          extensions: undefined,
-        };
-
-        expect(getDefaultValue(argument)).toBeUndefined();
-      });
-
-      test("returns undefined for type GraphQLList without default value", () => {
-        expect.hasAssertions();
-
-        const argument = {
-          name: "id",
-          description: undefined,
-          type: new GraphQLList(GraphQLID),
-          defaultValue: undefined,
-          extensions: undefined,
-        };
-
-        expect(getDefaultValue(argument)).toBeUndefined();
-      });
+          expect(getDefaultValue(argument)).toBeUndefined();
+        },
+      );
 
       test("returns array default value as string for type GraphQLList(GraphQLID)", () => {
         expect.hasAssertions();

--- a/tests/unit/lib/printer.test.js
+++ b/tests/unit/lib/printer.test.js
@@ -341,6 +341,7 @@ describe("lib", () => {
                 default: "defaultValue",
               },
               { name: "ParamNoDefault", type: "any" },
+              { name: "ParamIntZero", type: "int", default: 0 },
             ],
           };
 

--- a/tests/unit/lib/printer.test.js
+++ b/tests/unit/lib/printer.test.js
@@ -342,17 +342,18 @@ describe("lib", () => {
               },
               { name: "ParamNoDefault", type: "any" },
               { name: "ParamIntZero", type: "int", default: 0 },
+              { name: "ParamIntNoDefault", type: "int" },
             ],
           };
 
           jest
             .spyOn(graphql, "getDefaultValue")
-            .mockImplementation((paramType) => paramType.default || null);
+            .mockImplementation((paramType) => paramType.default);
 
           const code = printerInstance.printCodeArguments(type);
 
           expect(code).toMatchFile(
-            path.join(EXPECT_PATH, `printCodeArguments.md`),
+            path.join(EXPECT_PATH, "printCodeArguments.md"),
           );
         });
 


### PR DESCRIPTION
# Description

Closes #535. 

The issue was an incorrect evaluation of `0` when checking if a default value exists.

In addition, the new tests spotted an issue with the mocking used for the printer unit tests.

Integration schema (used also for demo) has also been updated to include this use case.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
