### PR TITLE
:bug:  fix missing [] for list entity type

### DIFF
--- a/src/lib/printer.js
+++ b/src/lib/printer.js
@@ -102,20 +102,28 @@ module.exports = class Printer {
     return "";
   }
 
+  printLink(type, withAttributes = false) {
+    const link = this.toLink(type, getTypeName(type));
+    if (!withAttributes) {
+      return link.link;
+    }
+    const nullableFlag = isNullableType(type) ? "" : "!";
+    const text = isListType(type)
+      ? `[${link.text}${nullableFlag}]`
+      : `${link.text}${nullableFlag}`;
+    return `[\`${text}\`](${link.url})`;
+  }
+
   printSectionItem(type, level = HEADER_SECTION_SUB_LEVEL) {
     if (typeof type === "undefined" || type === null) {
       return "";
     }
 
-    const typeNameLink = this.toLink(type, getTypeName(type)).link;
+    const typeNameLink = this.printLink(type);
     const description = this.printDescription(type, "");
-    let parentTypeLink = "";
-    if (hasProperty(type, "type")) {
-      const parentTypeName = getTypeName(type.type);
-      const link = this.toLink(type.type, parentTypeName);
-      const nullableFlag = isNullableType(type.type) ? "" : "!";
-      parentTypeLink = ` ([\`${link.text}${nullableFlag}\`](${link.url}))`;
-    }
+    const parentTypeLink = hasProperty(type, "type")
+      ? ` (${this.printLink(type.type, true)})`
+      : "";
 
     let section = `${level} ${typeNameLink}${parentTypeLink}\n\n${description}\n`;
     if (isParametrizedField(type)) {

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printSectionItemWithSubTypeNonNullableList.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printSectionItemWithSubTypeNonNullableList.md
@@ -1,0 +1,3 @@
+#### [`EntityTypeName`](#) ([`[NonNullableListObjectType!]`](#))
+
+

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printSectionItemWithSubTypeNullableList.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printSectionItemWithSubTypeNullableList.md
@@ -1,0 +1,3 @@
+#### [`EntityTypeName`](#) ([`[NullableListObjectType]`](#))
+
+

--- a/tests/unit/lib/printer.test.js
+++ b/tests/unit/lib/printer.test.js
@@ -195,12 +195,18 @@ describe("lib", () => {
           );
         });
 
-        test.each([{ nullable: true }, { nullable: false }])(
+        test.each([
+          { nullable: true, is_list: true },
+          { nullable: true, is_list: false },
+          { nullable: false, is_list: true },
+          { nullable: false, is_list: false },
+        ])(
           "returns Markdown #### link section with sub type list is $is_list and nullable is $nullable",
-          ({ nullable }) => {
+          ({ nullable, is_list }) => {
             expect.hasAssertions();
 
-            const label = nullable ? "Nullable" : "NonNullable";
+            let label = nullable ? "Nullable" : "NonNullable";
+            label += is_list ? "List" : "";
 
             const type = {
               name: "EntityTypeName",
@@ -208,6 +214,7 @@ describe("lib", () => {
             };
 
             jest.spyOn(graphql, "isNullableType").mockReturnValue(nullable);
+            jest.spyOn(graphql, "isListType").mockReturnValue(is_list);
             jest
               .spyOn(graphql, "getTypeName")
               .mockImplementation((paramType) => paramType.name);
@@ -243,6 +250,7 @@ describe("lib", () => {
           jest
             .spyOn(graphql, "getNamedType")
             .mockImplementation((paramType) => paramType.name);
+          jest.spyOn(graphql, "isNullableType").mockReturnValue(true);
           jest.spyOn(graphql, "isObjectType").mockReturnValueOnce(true);
           jest.spyOn(graphql, "isParametrizedField").mockReturnValueOnce(true);
           const printSectionItems = jest.spyOn(


### PR DESCRIPTION
# Description

Similar to #536. This PR fixes missing `[]` when entity type is of list.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
