### PR TITLE
:bug:  fix incorrect link format for arg array ypes

### DIFF
--- a/src/lib/printer.js
+++ b/src/lib/printer.js
@@ -56,9 +56,7 @@ module.exports = class Printer {
   }
 
   toLink(type, name) {
-    const graphLQLNamedType = isListType(type)
-      ? getNamedType(type.ofType)
-      : getNamedType(type);
+    const graphLQLNamedType = getNamedType(type);
 
     const category = this.getLinkCategory(graphLQLNamedType);
 
@@ -80,7 +78,7 @@ module.exports = class Printer {
       this.baseURL,
       group,
       category,
-      toSlug(name),
+      toSlug(text),
     );
 
     return {
@@ -116,11 +114,13 @@ module.exports = class Printer {
       return `[\`${link.text}\`](${link.url})`;
     }
 
+    let text = `${link.text}`;
+    if (isListType(type)) {
+      text = `[${text}${isNullableType(type.ofType) ? "" : "!"}]`;
+    }
     const nullableFlag = isNullableType(type) ? "" : "!";
-    const text = isListType(type)
-      ? `[${link.text}${nullableFlag}]`
-      : `${link.text}${nullableFlag}`;
-    return `[\`${text}\`](${link.url})`;
+
+    return `[\`${text}${nullableFlag}\`](${link.url})`;
   }
 
   printSectionItem(type, level = HEADER_SECTION_SUB_LEVEL) {

--- a/tests/integration/lib/__expect__/unix/generator.spec.js/generateDocFromSchemaWithGroupingOutputFolder
+++ b/tests/integration/lib/__expect__/unix/generator.spec.js/generateDocFromSchemaWithGroupingOutputFolder
@@ -295,12 +295,12 @@
             {
               "path": "output/misc/queries/search-role.mdx",
               "name": "search-role.mdx",
-              "size": 428,
+              "size": 429,
               "type": "file",
               "extension": ".mdx"
             }
           ],
-          "size": 445,
+          "size": 446,
           "type": "directory"
         },
         {
@@ -368,7 +368,7 @@
           "type": "directory"
         }
       ],
-      "size": 4524,
+      "size": 4525,
       "type": "directory"
     },
     {
@@ -379,6 +379,6 @@
       "extension": ".js"
     }
   ],
-  "size": 9135,
+  "size": 9136,
   "type": "directory"
 }

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printSectionItemListNonEmpty.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printSectionItemListNonEmpty.md
@@ -1,0 +1,3 @@
+#### [`EntityTypeNameList`](#) ([`Int!`](docs/graphql/scalars/int))
+
+

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printSectionItemWithSubTypeNonNullableList.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printSectionItemWithSubTypeNonNullableList.md
@@ -1,3 +1,3 @@
-#### [`EntityTypeName`](#) ([`[NonNullableListObjectType!]`](#))
+#### [`EntityTypeName`](#) ([`[NonNullableListObjectType!]!`](docs/graphql/objects/non-nullable-list-object-type))
 
 

--- a/tests/unit/lib/__expect__/unix/printer.test.js/printSectionItemWithSubTypeNullableList.md
+++ b/tests/unit/lib/__expect__/unix/printer.test.js/printSectionItemWithSubTypeNullableList.md
@@ -1,3 +1,3 @@
-#### [`EntityTypeName`](#) ([`[NullableListObjectType]`](#))
+#### [`EntityTypeName`](#) ([`[NullableListObjectType]`](docs/graphql/objects/nullable-list-object-type))
 
 


### PR DESCRIPTION
# Description

Fix the issues when argument type of array link is not correctly rendered:
- incorrect link: `#` instead of page location
- incorrect array nullability for `[type!]` and `[type]!`

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
