### PR TITLE
:test_tube:  fix smoke test Url loader config

### DIFF
--- a/tests/__data__/anilist.md
+++ b/tests/__data__/anilist.md
@@ -19,7 +19,10 @@ This documentation has been automatically generated using [AniList APIv2](https:
   "linkRoot": "/",
   "homepage": "data/anilist.md",
   "loaders": {
-    "UrlLoader": "@graphql-tools/url-loader"
+    "UrlLoader": {
+      "module": "@graphql-tools/url-loader",
+      "options": { "method": "POST" }
+    }
   },
   "docOptions": {
     "pagination": false,

--- a/tests/__data__/docusaurus2-graphql-doc-generator.config.js
+++ b/tests/__data__/docusaurus2-graphql-doc-generator.config.js
@@ -4,6 +4,9 @@ module.exports = {
   baseURL: "schema",
   linkRoot: "/",
   loaders: {
-    UrlLoader: "@graphql-tools/url-loader",
+    UrlLoader: {
+      module: "@graphql-tools/url-loader",
+      options: { method: "POST" },
+    },
   },
 };


### PR DESCRIPTION
# Description

Fix issue where smoke tests failed when using UrlLoader, if the GraphQL server only supports POST.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
