### PR TITLE
use prepare script for husky install

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test:integration": "jest --projects tests/integration",
     "test:smoke": "earthly +smoke-test",
     "test:coverage": "sh ./scripts/coverage.sh",
-    "postinstall": "husky install",
+    "prepare": "husky install",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable"
   },


### PR DESCRIPTION
# Description

I think the `prepare` script is husky's recommended usage and it makes installing this package via github (pointing at a branch or commit) actually possible (because the `postinstall` hook always fails without husky installed in the repo I'm trying to test changes in).

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
<!-- not applicable
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
-->