### PR TITLE
:bookmark: prepare to release packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9469,7 +9469,7 @@
     },
     "packages/diff": {
       "name": "@graphql-markdown/diff",
-      "version": "1.14.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-inspector/core": "^3.4.0",
@@ -9483,7 +9483,7 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/core": "^1.0.0",

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.14.0",
+  "version": "1.0.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.14.0",
+  "version": "1.15.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
# Description

Release all packages:
 - docusaurus `1.15.0`
 - core `1.0.0`
 - diff `1.0.0`
 - utils `1.0.0`
 - printer-legacy `1.0.0`

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
