### PR TITLE
:bug:  remove @graphql-tools/graphql-file-loader as default loader

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -55,6 +55,7 @@ build-docusaurus:
 
 smoke-init:
   FROM +build-docusaurus
+  WORKDIR /docusaurus2
   RUN npm install graphql @graphql-tools/url-loader @graphql-tools/graphql-file-loader
   COPY (+build-package/graphql-markdown-utils.tgz --package=utils) ./
   RUN npm install ./graphql-markdown-utils.tgz

--- a/docs/advanced/schema-loading.md
+++ b/docs/advanced/schema-loading.md
@@ -5,11 +5,35 @@ pagination_next: null
 
 # Schema loading
 
-By default, the `schema` default loading expects a local GraphQL schema definition file (`*.graphql`).
+GraphQL-Markdown use external loaders for loading GraphQL schemas (see [full list](https://github.com/ardatan/graphql-tools/tree/master/packages/loaders)).
 
-Additional GraphQL document loaders can be used (see [full list](https://github.com/ardatan/graphql-tools/tree/master/packages/loaders)).
+## Local schema (file)
 
-For example, if you want to load a schema from a URL, you first need to add the package `@graphql-tools/url-loader` to your Docusaurus project:
+Use `@graphql-tools/graphql-file-loader` if you want to load a local schema:
+
+```shell
+npm install @graphql-tools/graphql-file-loader
+```
+
+Once done, you can declare the loader into `docusaurus2-graphql-doc-generator` configuration:
+
+```js
+plugins: [
+  [
+    "@graphql-markdown/docusaurus",
+    {
+      // ... other options
+      loaders: {
+        GraphQLFileLoader: "@graphql-tools/graphql-file-loader"
+      }
+    },
+  ],
+],
+```
+
+## Remote schema (url)
+
+Use `@graphql-tools/url-loader`, if you want to load a schema from a URL:
 
 ```shell
 npm install @graphql-tools/url-loader

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,9 @@ module.exports = {
         rootPath: "./docs", // docs will be generated under './docs/swapi' (rootPath/baseURL)
         baseURL: "swapi",
         homepage: "./docs/swapi.md",
+        loaders: {
+          GraphQLFileLoader: "@graphql-tools/graphql-file-loader" // local file schema
+        }
       },
     ],
   ],

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -29,6 +29,10 @@ You can type this command into Command Prompt, Powershell, Terminal, or any othe
 
 The command also installs all necessary dependencies you need to run Docusaurus.
 
+### Add a GraphQL schema loader
+
+See [schema loading](/docs/advanced/schema-loading)).
+
 ### Start your site
 
 Run the development server:
@@ -65,6 +69,10 @@ npm install @graphql-markdown/docusaurus graphql
 :::info
 The `graphql` package is a peer-dependency, and it should be installed if not yet present.
 :::
+
+### Add a GraphQL schema loader
+
+See [schema loading](/docs/advanced/schema-loading)).
 
 ### Configure the plugin
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -106,11 +106,11 @@ The root for links in documentation. It depends on the entry for the schema main
 
 ## `loaders`
 
-GraphQL schema loader to be used (see [schema loading](/docs/advanced/schema-loading)).
+GraphQL schema loaders to use (see [schema loading](/docs/advanced/schema-loading)).
 
-| Setting   | CLI flag        | Default                                                      |
-| --------- | --------------- | ------------------------------------------------------------ |
-| `loaders` | _not supported_ | `{ GraphQLFileLoader: "@graphql-tools/graphql-file-loader" }` |
+| Setting   | CLI flag        | Default   |
+| --------- | --------------- | --------- |
+| `loaders` | _not supported_ | `{ }`     |
 
 ## `printTypeOptions`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9445,7 +9445,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.0.0"
+        "@graphql-markdown/utils": "^1.0.1"
       },
       "engines": {
         "node": ">=16.14"
@@ -9473,7 +9473,7 @@
       "license": "MIT",
       "dependencies": {
         "@graphql-inspector/core": "^3.4.0",
-        "@graphql-markdown/utils": "^1.0.0",
+        "@graphql-markdown/utils": "^1.0.1",
         "@graphql-tools/graphql-file-loader": "^7.5.5",
         "@graphql-tools/load": "^7.7.7"
       },
@@ -9483,7 +9483,7 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/core": "^1.0.0",
@@ -9498,7 +9498,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "1.0.0"
+        "@graphql-markdown/utils": "1.0.1"
       },
       "engines": {
         "node": ">=16.14"
@@ -9506,7 +9506,7 @@
     },
     "packages/utils": {
       "name": "@graphql-markdown/utils",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/load": "^7.7.7"
@@ -10170,14 +10170,14 @@
     "@graphql-markdown/core": {
       "version": "file:packages/core",
       "requires": {
-        "@graphql-markdown/utils": "^1.0.0"
+        "@graphql-markdown/utils": "^1.0.1"
       }
     },
     "@graphql-markdown/diff": {
       "version": "file:packages/diff",
       "requires": {
         "@graphql-inspector/core": "^3.4.0",
-        "@graphql-markdown/utils": "^1.0.0",
+        "@graphql-markdown/utils": "^1.0.1",
         "@graphql-tools/graphql-file-loader": "^7.5.5",
         "@graphql-tools/load": "^7.7.7"
       }
@@ -10192,7 +10192,7 @@
     "@graphql-markdown/printer-legacy": {
       "version": "file:packages/printer-legacy",
       "requires": {
-        "@graphql-markdown/utils": "1.0.0"
+        "@graphql-markdown/utils": "1.0.1"
       }
     },
     "@graphql-markdown/tools-config": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.0.0"
+    "@graphql-markdown/utils": "^1.0.1"
   },
   "peerDependencies": {
     "@graphql-markdown/printer-legacy": "^1.0.0",

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -32,11 +32,11 @@ const DEFAULT_OPTIONS = {
 function buildConfig(configFileOpts, cliOpts) {
   let config = DEFAULT_OPTIONS;
 
-  if (typeof configFileOpts != "undefined" && configFileOpts != null) {
+  if (typeof configFileOpts !== "undefined" && configFileOpts != null) {
     config = { ...DEFAULT_OPTIONS, ...configFileOpts };
   }
 
-  if (typeof cliOpts == "undefined" || cliOpts == null) {
+  if (typeof cliOpts === "undefined" || cliOpts == null) {
     cliOpts = {};
   }
 

--- a/packages/core/src/lib/generator.js
+++ b/packages/core/src/lib/generator.js
@@ -11,14 +11,14 @@ const hasChanges = async (
   diffMethod,
   diffModule = "@graphql-markdown/diff",
 ) => {
-  if (typeof diffMethod == "undefined" || diffMethod == null) {
+  if (typeof diffMethod === "undefined" || diffMethod == null) {
     return true;
   }
 
   try {
     const { checkSchemaChanges } = require(diffModule);
     return await checkSchemaChanges(schema, tmpDir, diffMethod);
-  } catch (e) {
+  } catch (error) {
     console.warn(
       `Cannot find module '${diffModule}' from @graphql-markdown/core!`,
     );
@@ -35,7 +35,7 @@ const getPrinter = (
   printTypeOptions,
   printerModule,
 ) => {
-  if (typeof printerModule != "string") {
+  if (typeof printerModule !== "string") {
     throw new Error(
       "Invalid printer module name in printTypeOptions settings.",
     );
@@ -47,7 +47,7 @@ const getPrinter = (
       groups,
       printTypeOptions,
     });
-  } catch (e) {
+  } catch (error) {
     throw new Error(
       `Cannot find module '${printerModule}' from @graphql-markdown/core in printTypeOptions settings.`,
     );
@@ -62,14 +62,15 @@ const generateDocFromSchema = async ({
   homepageLocation,
   diffMethod,
   tmpDir,
-  loaders,
+  loaders: loadersList,
   groupByDirective,
   prettify,
   docOptions,
   printTypeOptions,
   printer: printerModule,
 }) => {
-  const schema = await loadSchema(schemaLocation, getDocumentLoaders(loaders));
+  const loaders = getDocumentLoaders(loadersList);
+  const schema = await loadSchema(schemaLocation, loaders);
 
   const changed = await hasChanges(schema, tmpDir, diffMethod);
   if (!changed) {

--- a/packages/core/src/lib/group-info.js
+++ b/packages/core/src/lib/group-info.js
@@ -13,7 +13,7 @@ function parseGroupByOption(groupOptions) {
 
   const parsedOptions = OPTION_REGEX.exec(groupOptions);
 
-  if (typeof parsedOptions == "undefined" || parsedOptions == null) {
+  if (typeof parsedOptions === "undefined" || parsedOptions == null) {
     throw new Error(`Invalid "${groupOptions}"`);
   }
 
@@ -24,7 +24,7 @@ function parseGroupByOption(groupOptions) {
 function getGroups(rootTypes, groupByDirective) {
   let groups = {};
 
-  if (typeof groupByDirective == "undefined" || groupByDirective == null) {
+  if (typeof groupByDirective === "undefined" || groupByDirective == null) {
     return undefined;
   }
 
@@ -47,7 +47,7 @@ function getGroups(rootTypes, groupByDirective) {
 function getGroupName(type, groupByDirective) {
   let group = groupByDirective.fallback; // default value is fallback, and it will be only overridden if a group is found
 
-  if (typeof type.astNode == "undefined" || type.astNode == null) {
+  if (typeof type.astNode === "undefined" || type.astNode == null) {
     return group;
   }
 

--- a/packages/core/tests/integration/lib/generator.spec.js
+++ b/packages/core/tests/integration/lib/generator.spec.js
@@ -35,7 +35,7 @@ describe("lib", () => {
           homepageLocation: "/assets/generated.md",
           diffMethod: "NONE",
           tmpDir: "/temp",
-          loaders: {},
+          loaders: { GraphQLFileLoader: "@graphql-tools/graphql-file-loader" },
           printer: "@graphql-markdown/printer-legacy",
         };
 
@@ -57,6 +57,7 @@ describe("lib", () => {
           homepageLocation: "/assets/generated.md",
           diffMethod: "SCHEMA-HASH",
           tmpDir: "/temp",
+          loaders: { GraphQLFileLoader: "@graphql-tools/graphql-file-loader" },
           printer: "@graphql-markdown/printer-legacy",
         };
 
@@ -79,7 +80,7 @@ describe("lib", () => {
           homepageLocation: "/assets/generated.md",
           diffMethod: "NONE",
           tmpDir: "/temp",
-          loaders: {},
+          loaders: { GraphQLFileLoader: "@graphql-tools/graphql-file-loader" },
           groupByDirective: {
             directive: "doc",
             field: "category",

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@graphql-inspector/core": "^3.4.0",
-    "@graphql-markdown/utils": "^1.0.0",
+    "@graphql-markdown/utils": "^1.0.1",
     "@graphql-tools/graphql-file-loader": "^7.5.5",
     "@graphql-tools/load": "^7.7.7"
   },

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.15.0",
+  "version": "1.15.1",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {

--- a/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator-groups.config.js
+++ b/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator-groups.config.js
@@ -5,6 +5,7 @@ module.exports = {
   baseURL: ".",
   linkRoot: "/schema",
   diffMethod: "SCHEMA-HASH",
+  loaders: { GraphQLFileLoader: "@graphql-tools/graphql-file-loader" },
   groupByDirective: {
     directive: "doc",
     field: "category",

--- a/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator.config.js
+++ b/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator.config.js
@@ -5,6 +5,7 @@ module.exports = {
   linkRoot: "/group-by",
   diffMethod: "SCHEMA-DIFF",
   loaders: {
+    GraphQLFileLoader: "@graphql-tools/graphql-file-loader",
     UrlLoader: {
       module: "@graphql-tools/url-loader",
       options: { method: "POST" },

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -22,7 +22,7 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "1.0.0"
+    "@graphql-markdown/utils": "1.0.1"
   },
   "directories": {
     "test": "tests"

--- a/packages/printer-legacy/src/index.js
+++ b/packages/printer-legacy/src/index.js
@@ -190,7 +190,7 @@ module.exports = class Printer {
   }
 
   printLinkAttributes(type, text) {
-    if (typeof type == "undefined") {
+    if (typeof type === "undefined") {
       return text ?? "";
     }
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {

--- a/packages/utils/src/helpers/prettier.js
+++ b/packages/utils/src/helpers/prettier.js
@@ -4,7 +4,7 @@ function prettify(content, parser) {
   try {
     const { format } = require("prettier");
     return format(content, { parser });
-  } catch (e) {
+  } catch (error) {
     console.debug("Prettier is not found");
   }
 }

--- a/packages/utils/src/lib/graphql.js
+++ b/packages/utils/src/lib/graphql.js
@@ -35,9 +35,7 @@ const OperationTypeNodes = [
   OperationTypeNode.SUBSCRIPTION,
 ];
 
-const DefaultLoaders = {
-  GraphQLFileLoader: "@graphql-tools/graphql-file-loader",
-};
+const DefaultLoaders = {};
 
 async function loadSchema(schemaLocation, options) {
   let rootTypes = undefined;

--- a/packages/utils/src/lib/graphql.js
+++ b/packages/utils/src/lib/graphql.js
@@ -35,8 +35,6 @@ const OperationTypeNodes = [
   OperationTypeNode.SUBSCRIPTION,
 ];
 
-const DefaultLoaders = {};
-
 async function loadSchema(schemaLocation, options) {
   let rootTypes = undefined;
 
@@ -61,36 +59,32 @@ async function loadSchema(schemaLocation, options) {
   return new GraphQLSchema(config);
 }
 
-function getDocumentLoaders(extraLoaders = {}) {
-  const loadersList = { ...DefaultLoaders, ...extraLoaders };
-
+function getDocumentLoaders(loadersList = {}) {
   const loaders = [];
   const loaderOptions = {};
 
   Object.entries(loadersList).forEach(([className, graphqlDocumentLoader]) => {
-    try {
-      if (typeof graphqlDocumentLoader === "string") {
-        const { [className]: Loader } = require(graphqlDocumentLoader);
-        loaders.push(new Loader());
-      } else {
-        if (!graphqlDocumentLoader.module) {
-          throw new Error(
-            `Wrong format for plugin loader "${className}", it should be {module: String, options?: Object}`,
-          );
-        }
-        const { [className]: Loader } = require(graphqlDocumentLoader.module);
-        loaders.push(new Loader());
-        Object.assign(loaderOptions, graphqlDocumentLoader.options);
+    if (typeof graphqlDocumentLoader === "string") {
+      const { [className]: Loader } = require(graphqlDocumentLoader);
+      loaders.push(new Loader());
+    } else {
+      if (
+        typeof graphqlDocumentLoader.module !== "string" ||
+        graphqlDocumentLoader.module == null
+      ) {
+        throw new Error(
+          `Wrong format for plugin loader "${className}", it should be {module: String, options?: Object}`,
+        );
       }
-    } catch (error) {
-      console.warn(graphqlDocumentLoader, error.message);
+      const { [className]: Loader } = require(graphqlDocumentLoader.module);
+      loaders.push(new Loader());
+      Object.assign(loaderOptions, graphqlDocumentLoader.options);
     }
   });
 
   if (loaders.length < 1) {
     throw new Error("No GraphQL document loaders available.");
   }
-
   return { loaders, loaderOptions };
 }
 
@@ -105,7 +99,7 @@ function getListDefaultValues(type, value) {
 }
 
 function getDefaultValue({ type, defaultValue }) {
-  if (defaultValue === null || typeof defaultValue === "undefined") {
+  if (typeof defaultValue === "undefined" || defaultValue === null) {
     return undefined;
   }
 
@@ -135,7 +129,7 @@ function formatDefaultValue(type, defaultValue) {
 }
 
 function getTypeFromSchema(schema, type) {
-  if (typeof schema == "undefined" || schema == null) {
+  if (typeof schema === "undefined" || schema == null) {
     return undefined;
   }
 
@@ -163,7 +157,7 @@ function getTypeFromSchema(schema, type) {
 
 function getIntrospectionFieldsList(queryType) {
   if (
-    typeof queryType == "undefined" ||
+    typeof queryType === "undefined" ||
     queryType == null ||
     !hasMethod(queryType, "getFields")
   ) {


### PR DESCRIPTION
# Description

Breaking change is required to fix the issue linked to `@graphql-tools/graphql-file-loader`.

The package is no more provided as a dependency, but must be installed separately.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
