### PR TITLE
:bug:  fix undefined css class returned types and related types badges

### DIFF
--- a/packages/printer-legacy/src/index.js
+++ b/packages/printer-legacy/src/index.js
@@ -151,7 +151,7 @@ module.exports = class Printer {
       return "";
     }
     const link = this.toLink(type, type.name, category);
-    return `[\`${link.text}\`](${link.url})  <Badge className="secondary" text="${category.singular}"/>`;
+    return `[\`${link.text}\`](${link.url})  <Badge class="secondary" text="${category.singular}"/>`;
   }
 
   printSection(
@@ -454,7 +454,7 @@ module.exports = class Printer {
     const reason = type.deprecationReason
       ? ": " + escapeMDX(type.deprecationReason)
       : "";
-    return `<Badge className="warning" text="DEPRECATED${reason}"/>${MARKDOWN_EOP}`;
+    return `<Badge class="warning" text="DEPRECATED${reason}"/>${MARKDOWN_EOP}`;
   }
 
   printDescription(type, noText = NO_DESCRIPTION_TEXT) {

--- a/packages/printer-legacy/tests/unit/__snapshots__/printer.test.js.snap
+++ b/packages/printer-legacy/tests/unit/__snapshots__/printer.test.js.snap
@@ -144,7 +144,7 @@ exports[`lib printer class Printer printCodeType() returns an object with its fi
 exports[`lib printer class Printer printCodeUnion() returns union code structure 1`] = `"union UnionTypeName = one | two"`;
 
 exports[`lib printer class Printer printDescription() return DEPRECATED tag if deprecated 1`] = `
-"<Badge className="warning" text="DEPRECATED: Foobar"/>
+"<Badge class="warning" text="DEPRECATED: Foobar"/>
 
 Lorem ipsum"
 `;

--- a/packages/printer-legacy/tests/unit/printer.test.js
+++ b/packages/printer-legacy/tests/unit/printer.test.js
@@ -807,7 +807,7 @@ describe("lib", () => {
           const deprecation = printerInstance.printDeprecation(type);
 
           expect(deprecation).toMatchInlineSnapshot(`
-            "<Badge className="warning" text="DEPRECATED"/>
+            "<Badge class="warning" text="DEPRECATED"/>
 
             "
           `);
@@ -824,7 +824,7 @@ describe("lib", () => {
           const deprecation = printerInstance.printDeprecation(type);
 
           expect(deprecation).toMatchInlineSnapshot(`
-            "<Badge className="warning" text="DEPRECATED: foobar"/>
+            "<Badge class="warning" text="DEPRECATED: foobar"/>
 
             "
           `);
@@ -912,7 +912,7 @@ describe("lib", () => {
           expect(deprecation).toMatchInlineSnapshot(`
             "### RelationOf
 
-            [\`Bar\`](#)  <Badge className="secondary" text="interface"/><Bullet />[\`Baz\`](#)  <Badge className="secondary" text="subscription"/><Bullet />[\`Foo\`](#)  <Badge className="secondary" text="query"/>
+            [\`Bar\`](#)  <Badge class="secondary" text="interface"/><Bullet />[\`Baz\`](#)  <Badge class="secondary" text="subscription"/><Bullet />[\`Foo\`](#)  <Badge class="secondary" text="query"/>
 
             "
           `);


### PR DESCRIPTION
# Description

Fix undefined css class for returned types and related types badges.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
