### PR TITLE
🔖 release 1.16.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9670,7 +9670,7 @@
       },
       "peerDependencies": {
         "@graphql-markdown/diff": "^1.0.5",
-        "@graphql-markdown/printer-legacy": "^1.1.4",
+        "@graphql-markdown/printer-legacy": "^1.1.5",
         "prettier": "^2.8"
       },
       "peerDependenciesMeta": {
@@ -9705,7 +9705,7 @@
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/core": "^1.1.4",
-        "@graphql-markdown/printer-legacy": "^1.1.4"
+        "@graphql-markdown/printer-legacy": "^1.1.5"
       },
       "engines": {
         "node": ">=16.14"
@@ -9713,7 +9713,7 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/utils": "^1.1.3"
@@ -10425,7 +10425,7 @@
       "version": "file:packages/docusaurus",
       "requires": {
         "@graphql-markdown/core": "^1.1.4",
-        "@graphql-markdown/printer-legacy": "^1.1.4"
+        "@graphql-markdown/printer-legacy": "^1.1.5"
       }
     },
     "@graphql-markdown/printer-legacy": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9701,7 +9701,7 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.16.4",
+      "version": "1.16.5",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/core": "^1.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9660,7 +9660,7 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/utils": "^1.1.3"
@@ -9704,7 +9704,7 @@
       "version": "1.16.4",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.1.4",
+        "@graphql-markdown/core": "^1.1.5",
         "@graphql-markdown/printer-legacy": "^1.1.5"
       },
       "engines": {
@@ -10424,7 +10424,7 @@
     "@graphql-markdown/docusaurus": {
       "version": "file:packages/docusaurus",
       "requires": {
-        "@graphql-markdown/core": "^1.1.4",
+        "@graphql-markdown/core": "^1.1.5",
         "@graphql-markdown/printer-legacy": "^1.1.5"
       }
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.4",
+  "version": "1.1.5",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -32,7 +32,7 @@
     "@graphql-markdown/utils": "^1.1.3"
   },
   "peerDependencies": {
-    "@graphql-markdown/printer-legacy": "^1.1.4",
+    "@graphql-markdown/printer-legacy": "^1.1.5",
     "@graphql-markdown/diff": "^1.0.5",
     "prettier": "^2.8"
   },

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -31,8 +31,8 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.1.4",
-    "@graphql-markdown/printer-legacy": "^1.1.4"
+    "@graphql-markdown/core": "^1.1.5",
+    "@graphql-markdown/printer-legacy": "^1.1.5"
   },
   "directories": {
     "test": "tests"

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.16.4",
+  "version": "1.16.5",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.4",
+  "version": "1.1.5",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
# Description

Release 1.16.5 with fix #772 

---

## What's Changed

### @graphql-markdown/printer-legacy@1.1.5

* :bug:  fix undefined css class returned types and related types badges by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/772

### @graphql-markdown/core@1.1.5

* 📦 update dependency @graphql-markdown/printer-legacy to 1.1.5 by @edno in #773

### @graphql-markdown/docusaurus@1.16.5

* 📦 update dependency @graphql-markdown/core to 1.1.5 by @edno in #773
* 📦 update dependency @graphql-markdown/printer-legacy to 1.1.5 by @edno in #773


**Full Changelog**: https://github.com/graphql-markdown/graphql-markdown/compare/1.16.4...1.16.5

---

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
