### PR TITLE
:bug: fix skipDocDirective on fields

### DIFF
--- a/packages/printer-legacy/src/index.js
+++ b/packages/printer-legacy/src/index.js
@@ -294,7 +294,11 @@ module.exports = class Printer {
       parentType: undefined,
     },
   ) {
-    if (typeof type === "undefined" || type === null) {
+    if (
+      typeof type === "undefined" ||
+      type === null ||
+      hasDirective(type, this.skipDocDirective)
+    ) {
       return "";
     }
 

--- a/packages/printer-legacy/tests/unit/printer.test.js
+++ b/packages/printer-legacy/tests/unit/printer.test.js
@@ -359,6 +359,58 @@ describe("lib", () => {
 
           expect(section).toMatchSnapshot();
         });
+
+        test("returns no section if item matches skipDocDirective", () => {
+          expect.hasAssertions();
+
+          printerInstance.skipDocDirective = "@noDoc";
+
+          const type = {
+            name: "EntityTypeNameList",
+            astNode: {
+              directives: [{ name: { value: "@noDoc" } }],
+            },
+          };
+
+          const section = printerInstance.printSectionItem(type);
+
+          expect(section).toBe("");
+        });
+
+        test("returns Markdown #### link section without field parameters matching skipDocDirective", () => {
+          expect.hasAssertions();
+
+          printerInstance.skipDocDirective = "@noDoc";
+
+          const type = {
+            name: "EntityTypeName",
+            args: [
+              {
+                name: "ParameterTypeName",
+                type: GraphQLString,
+              },
+              {
+                name: "ParameterSkipDoc",
+                type: GraphQLString,
+                astNode: {
+                  directives: [{ name: { value: "@noDoc" } }],
+                },
+              },
+            ],
+          };
+
+          const section = printerInstance.printSectionItem(type);
+
+          expect(section).toMatchInlineSnapshot(`
+            "#### [\`EntityTypeName\`](#) 
+            > 
+            > ##### [\`ParameterTypeName\`](#)<Bullet />[\`String\`](docs/graphql/scalars/string) <Badge class="secondary" text="scalar"/>
+            > 
+            > 
+
+            "
+          `);
+        });
       });
 
       describe("printCodeEnum()", () => {


### PR DESCRIPTION
# Description

Add support for `skipDocDirective` on fields (closes #777)

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
