### PR TITLE
✨ option skipDocDirective supports multiple values

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -189,11 +189,13 @@ The GraphQL schema location.
 
 ## `skipDocDirective`
 
-The schema directive used for skipping types from documentation.
+The schema directive/s used for skipping types from documentation.
 
-| Setting            | CLI flag              | Default |
-| ------------------ | --------------------- | ------- |
-| `skipDocDirective` | `--skip <@directive>` | -       |
+The option supports multiple values, eg `--skipDocDirective @noDoc @deprecated`.
+
+| Setting            | CLI flag                 | Default |
+| ------------------ | ------------------------ | ------- |
+| `skipDocDirective` | `--skip <@directive...>` | -       |
 
 ## `tmpDir`
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -191,7 +191,7 @@ The GraphQL schema location.
 
 The schema directive/s used for skipping types from documentation.
 
-The option supports multiple values, eg `--skipDocDirective @noDoc @deprecated`.
+The option supports multiple values separated by a space character, eg `--skipDocDirective @noDoc @deprecated`.
 
 | Setting            | CLI flag                 | Default |
 | ------------------ | ------------------------ | ------- |

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -27,7 +27,7 @@ const DEFAULT_OPTIONS = {
     relatedTypeSection: true,
     typeBadges: true,
   },
-  skipDocDirective: undefined,
+  skipDocDirective: [],
 };
 
 function buildConfig(configFileOpts, cliOpts) {
@@ -58,7 +58,7 @@ function buildConfig(configFileOpts, cliOpts) {
     docOptions: getDocOptions(cliOpts, config.docOptions),
     printTypeOptions: gePrintTypeOptions(cliOpts, config.printTypeOptions),
     printer: config.printer,
-    skipDocDirective: getSkipDocDirective(
+    skipDocDirective: getSkipDocDirectives(
       cliOpts.skip ?? config.skipDocDirective,
     ),
   };
@@ -85,11 +85,21 @@ function gePrintTypeOptions(cliOpts, configOptions) {
   };
 }
 
+function getSkipDocDirectives(options) {
+  const directiveList = Array.isArray(options) ? options : [options];
+
+  const skipDirectives = directiveList.map((option) =>
+    getSkipDocDirective(option),
+  );
+
+  return skipDirectives;
+}
+
 function getSkipDocDirective(option) {
   const OPTION_REGEX = /^@(?<directive>\w+)$/;
 
   if (typeof option !== "string") {
-    return undefined;
+    throw new Error(`Invalid "${option}"`);
   }
 
   const parsedOption = OPTION_REGEX.exec(option);
@@ -101,4 +111,10 @@ function getSkipDocDirective(option) {
   return parsedOption.groups.directive;
 }
 
-module.exports = { buildConfig, DEFAULT_OPTIONS, ASSETS_LOCATION };
+module.exports = {
+  buildConfig,
+  getSkipDocDirectives,
+  getSkipDocDirective,
+  DEFAULT_OPTIONS,
+  ASSETS_LOCATION,
+};

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -86,7 +86,7 @@ function gePrintTypeOptions(cliOpts, configOptions) {
 }
 
 function getSkipDocDirectives(options) {
-  const directiveList = Array.isArray(options) ? options : [options];
+  const directiveList = Array.isArray(options) ? options : [options]; //backward_compatibily
 
   const skipDirectives = directiveList.map((option) =>
     getSkipDocDirective(option),

--- a/packages/core/tests/unit/config.test.js
+++ b/packages/core/tests/unit/config.test.js
@@ -2,7 +2,12 @@ const { join } = require("path");
 
 const { COMPARE_METHOD } = require("@graphql-markdown/diff");
 
-const { buildConfig, DEFAULT_OPTIONS } = require("../../src/config");
+const {
+  buildConfig,
+  getSkipDocDirectives,
+  getSkipDocDirective,
+  DEFAULT_OPTIONS,
+} = require("../../src/config");
 
 jest.mock("../../src/group-info");
 const groupInfo = require("../../src/group-info");
@@ -12,8 +17,47 @@ describe("config", () => {
     jest.resetAllMocks();
   });
 
+  describe("getSkipDocDirectives", () => {
+    test("returns a list of directive names", () => {
+      expect.hasAssertions();
+
+      expect(getSkipDocDirectives(["@noDoc", "@deprecated"])).toStrictEqual([
+        "noDoc",
+        "deprecated",
+      ]);
+    });
+
+    test("supports string as input", () => {
+      expect.hasAssertions();
+
+      expect(getSkipDocDirectives("@noDoc")).toStrictEqual(["noDoc"]);
+    });
+  });
+
+  describe("getSkipDocDirective", () => {
+    test("returns a directive name", () => {
+      expect.hasAssertions();
+
+      expect(getSkipDocDirective("@noDoc")).toBe("noDoc");
+    });
+
+    test("throws an error if not a string", () => {
+      expect.hasAssertions();
+
+      expect(() => getSkipDocDirective("+NotADirective@")).toThrow(Error);
+    });
+
+    test("throws an error if format is not a directive", () => {
+      expect.hasAssertions();
+
+      expect(() => getSkipDocDirective("+NotADirective@")).toThrow(Error);
+    });
+  });
+
   describe("buildConfig()", () => {
     test("returns default options is no config set", () => {
+      expect.hasAssertions();
+
       jest.spyOn(groupInfo, "parseGroupByOption").mockReturnValue(undefined);
 
       const config = buildConfig();
@@ -39,6 +83,8 @@ describe("config", () => {
     });
 
     test("override default options is config set in docusaurus", () => {
+      expect.hasAssertions();
+
       jest.spyOn(groupInfo, "parseGroupByOption").mockReturnValue(undefined);
 
       const configFileOpts = {
@@ -68,7 +114,7 @@ describe("config", () => {
           relatedTypeSection: false,
           typeBadges: false,
         },
-        skipDocDirective: "@noDoc",
+        skipDocDirective: ["@noDoc"],
       };
 
       const config = buildConfig(configFileOpts);
@@ -87,11 +133,13 @@ describe("config", () => {
         docOptions: configFileOpts.docOptions,
         printTypeOptions: configFileOpts.printTypeOptions,
         printer: DEFAULT_OPTIONS.printer,
-        skipDocDirective: "noDoc",
+        skipDocDirective: ["noDoc"],
       });
     });
 
     test("override config set in docusaurus if cli options set", () => {
+      expect.hasAssertions();
+
       const configFileOpts = {
         baseURL: "docs/schema",
         schema: "assets/my-schema.graphql",
@@ -155,11 +203,13 @@ describe("config", () => {
         },
         printTypeOptions: DEFAULT_OPTIONS.printTypeOptions,
         printer: DEFAULT_OPTIONS.printer,
-        skipDocDirective: "noDoc",
+        skipDocDirective: ["noDoc"],
       });
     });
 
     test("schema option from CLI overrides that of config file", () => {
+      expect.hasAssertions();
+
       jest.spyOn(groupInfo, "parseGroupByOption").mockReturnValue(undefined);
 
       const configFileOpts = {
@@ -189,6 +239,8 @@ describe("config", () => {
     });
 
     test("force flag from CLI switches diff method to FORCE", () => {
+      expect.hasAssertions();
+
       jest.spyOn(groupInfo, "parseGroupByOption").mockReturnValue(undefined);
 
       const cliOpts = { force: true };

--- a/packages/docusaurus/src/index.js
+++ b/packages/docusaurus/src/index.js
@@ -41,7 +41,7 @@ module.exports = function pluginGraphQLDocGenerator(_, configOptions) {
           "-gbd, --groupByDirective <@directive(field|=fallback)>",
           "Group documentation by directive",
         )
-        .option("--skip <@directive>", "Skip type with matching directive")
+        .option("--skip <@directive...>", "Skip type with matching directive")
         .option("--pretty", "Prettify generated files")
         .action(async (cliOptions) => {
           await generateDocFromSchema(

--- a/packages/docusaurus/tests/__data__/groups.md
+++ b/packages/docusaurus/tests/__data__/groups.md
@@ -31,7 +31,7 @@ This is an example of documentation grouping with GraphQL directive using the `g
     "relatedTypeSection": false,
     "typeBadges": false
   },
-  "skipDocDirective": "@noDoc"
+  "skipDocDirective": ["@noDoc"]
 }
 ```
 

--- a/packages/printer-legacy/tests/unit/printer.test.js
+++ b/packages/printer-legacy/tests/unit/printer.test.js
@@ -156,7 +156,7 @@ describe("Printer", () => {
           relatedTypeSection: false,
           typeBadges: false,
         },
-        skipDocDirective: "test",
+        skipDocDirective: ["test"],
       });
 
       expect(Printer.options).toMatchInlineSnapshot(`
@@ -166,7 +166,9 @@ describe("Printer", () => {
           "parentTypePrefix": false,
           "relatedTypeSection": false,
           "schema": {},
-          "skipDocDirective": "test",
+          "skipDocDirective": [
+            "test",
+          ],
           "typeBadges": false,
         }
       `);

--- a/packages/printer-legacy/tests/unit/printer.test.js
+++ b/packages/printer-legacy/tests/unit/printer.test.js
@@ -156,7 +156,7 @@ describe("Printer", () => {
           relatedTypeSection: false,
           typeBadges: false,
         },
-        skipDocDirective: false,
+        skipDocDirective: "test",
       });
 
       expect(Printer.options).toMatchInlineSnapshot(`
@@ -166,7 +166,7 @@ describe("Printer", () => {
           "parentTypePrefix": false,
           "relatedTypeSection": false,
           "schema": {},
-          "skipDocDirective": false,
+          "skipDocDirective": "test",
           "typeBadges": false,
         }
       `);

--- a/packages/printer-legacy/tests/unit/section.test.js
+++ b/packages/printer-legacy/tests/unit/section.test.js
@@ -290,7 +290,7 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.`,
 
       const section = printSectionItem(type, {
         ...DEFAULT_OPTIONS,
-        skipDocDirective: "@noDoc",
+        skipDocDirective: ["@noDoc"],
       });
 
       expect(section).toBe("");
@@ -318,7 +318,7 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.`,
 
       const section = printSectionItem(type, {
         ...DEFAULT_OPTIONS,
-        skipDocDirective: "@noDoc",
+        skipDocDirective: ["@noDoc"],
       });
 
       expect(section).toMatchInlineSnapshot(`

--- a/packages/utils/src/graphql.js
+++ b/packages/utils/src/graphql.js
@@ -166,7 +166,7 @@ function hasDirective(type, directives) {
     return false;
   }
 
-  const directiveList = Array.isArray(directives) ? directives : [directives];
+  const directiveList = Array.isArray(directives) ? directives : [directives]; // backward_compatibility
 
   return (
     type.astNode.directives.findIndex((directive) =>

--- a/packages/utils/src/graphql.js
+++ b/packages/utils/src/graphql.js
@@ -156,19 +156,21 @@ function getTypeFromSchema(schema, type) {
     .reduce((res, key) => ({ ...res, [key]: typeMap[key] }), {});
 }
 
-function hasDirective(type, directiveName) {
+function hasDirective(type, directives) {
   if (
     typeof type.astNode === "undefined" ||
     type.astNode == null ||
-    typeof directiveName !== "string" ||
+    typeof directives === "undefined" ||
     !Array.isArray(type.astNode.directives)
   ) {
     return false;
   }
 
+  const directiveList = Array.isArray(directives) ? directives : [directives];
+
   return (
-    type.astNode.directives.findIndex(
-      (directive) => directive.name.value === directiveName,
+    type.astNode.directives.findIndex((directive) =>
+      directiveList.includes(directive.name.value),
     ) > -1
   );
 }

--- a/packages/utils/tests/unit/graphql.test.js
+++ b/packages/utils/tests/unit/graphql.test.js
@@ -762,6 +762,14 @@ describe("getRelationOfInterface()", () => {
 
         expect(hasDirective(type, "foobaz")).toBeTruthy();
       });
+
+      test("return true is the type has one matching directive", () => {
+        expect.hasAssertions();
+
+        const type = schema.getType("StudyItem");
+
+        expect(hasDirective(type, ["foobar", "foobaz"])).toBeTruthy();
+      });
     });
   });
 });


### PR DESCRIPTION
# Description

Add multiple value supports for `skipDocDirective` option. This a preparatory work for #806 

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
