### PR TITLE
:sparkles:  add printTypeOptions deprecated 'skip'

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -129,7 +129,7 @@ Use these options to toggle type information rendered on pages:
 - `deprecated`: set display of deprecated entities (fields, values, operations)
   - `default`: deprecated entities are displayed with other entities
   - `group`: deprecated entities are grouped together
-  - `skip`: deprecated entities are not displayed
+  - `skip`: deprecated entities are not displayed (same as [`skipDocDirective`](#skipdocdirective))
 
 | Setting                               | CLI flag          | Default   |
 | ------------------------------------- | ----------------- | --------- |
@@ -162,6 +162,8 @@ plugins: [
     ],
   ],
 ```
+
+<br/>
 
 :::info
 See [customize deprecated groups](/docs/advanced/custom-deprecated-section) to customize the rendering of `printTypeOptions.deprecated: "group"`.
@@ -206,6 +208,12 @@ The option supports multiple values separated by a space character, eg `--skipDo
 | Setting            | CLI flag                 | Default |
 | ------------------ | ------------------------ | ------- |
 | `skipDocDirective` | `--skip <@directive...>` | -       |
+
+<br/>
+
+:::info
+Types with `@deprecated` directive can also be skipped by setting [`printTypeOptions.deprecated`](#printtypeoptions) to `skip`.
+:::
 
 ## `tmpDir`
 

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -46,14 +46,6 @@ function buildConfig(configFileOpts, cliOpts) {
     cliOpts = {};
   }
 
-  if (
-    (hasProperty(config, "printTypeOptions") &&
-      config.printTypeOptions.deprecated === "skip") ||
-    (hasProperty(cliOpts, "deprecated") && cliOpts.deprecated === "skip")
-  ) {
-    config.skipDocDirective.push("@deprecated");
-  }
-
   const baseURL = cliOpts.base ?? config.baseURL;
 
   return {
@@ -71,10 +63,7 @@ function buildConfig(configFileOpts, cliOpts) {
     docOptions: getDocOptions(cliOpts, config.docOptions),
     printTypeOptions: gePrintTypeOptions(cliOpts, config.printTypeOptions),
     printer: config.printer,
-    skipDocDirective: getSkipDocDirectives(
-      cliOpts.skip,
-      config.skipDocDirective,
-    ),
+    skipDocDirective: getSkipDocDirectives(cliOpts, config),
   };
 }
 
@@ -103,12 +92,23 @@ function gePrintTypeOptions(cliOpts, configOptions) {
   };
 }
 
-function getSkipDocDirectives(cliOpts, configFileOpts) {
-  const directiveList = [].concat(cliOpts ?? [], configFileOpts ?? []);
+function getSkipDocDirectives(cliOpts = {}, configFileOpts = {}) {
+  const directiveList = [].concat(
+    cliOpts.skip ?? [],
+    configFileOpts.skipDocDirective ?? [],
+  );
 
   const skipDirectives = directiveList.map((option) =>
     getSkipDocDirective(option),
   );
+
+  if (
+    (hasProperty(configFileOpts, "printTypeOptions") &&
+      configFileOpts.printTypeOptions.deprecated === "skip") ||
+    (hasProperty(cliOpts, "deprecated") && cliOpts.deprecated === "skip")
+  ) {
+    skipDirectives.push("deprecated");
+  }
 
   return skipDirectives;
 }

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -1,6 +1,10 @@
 const { join } = require("path");
 const { tmpdir } = require("os");
 
+const {
+  object: { hasProperty },
+} = require("@graphql-markdown/utils");
+
 const { parseGroupByOption } = require("./group-info");
 
 const PACKAGE_NAME = "@graphql-markdown/docusaurus";
@@ -42,6 +46,14 @@ function buildConfig(configFileOpts, cliOpts) {
     cliOpts = {};
   }
 
+  if (
+    (hasProperty(config, "printTypeOptions") &&
+      config.printTypeOptions.deprecated === "skip") ||
+    (hasProperty(cliOpts, "deprecated") && cliOpts.deprecated === "skip")
+  ) {
+    config.skipDocDirective.push("@deprecated");
+  }
+
   const baseURL = cliOpts.base ?? config.baseURL;
 
   return {
@@ -60,7 +72,8 @@ function buildConfig(configFileOpts, cliOpts) {
     printTypeOptions: gePrintTypeOptions(cliOpts, config.printTypeOptions),
     printer: config.printer,
     skipDocDirective: getSkipDocDirectives(
-      cliOpts.skip ?? config.skipDocDirective,
+      cliOpts.skip,
+      config.skipDocDirective,
     ),
   };
 }
@@ -90,8 +103,8 @@ function gePrintTypeOptions(cliOpts, configOptions) {
   };
 }
 
-function getSkipDocDirectives(options) {
-  const directiveList = Array.isArray(options) ? options : [options]; //backward_compatibility
+function getSkipDocDirectives(cliOpts, configFileOpts) {
+  const directiveList = [].concat(cliOpts ?? [], configFileOpts ?? []);
 
   const skipDirectives = directiveList.map((option) =>
     getSkipDocDirective(option),

--- a/packages/core/tests/unit/config.test.js
+++ b/packages/core/tests/unit/config.test.js
@@ -21,16 +21,28 @@ describe("config", () => {
     test("returns a list of directive names", () => {
       expect.hasAssertions();
 
-      expect(getSkipDocDirectives(["@noDoc"], ["@deprecated"])).toStrictEqual([
-        "noDoc",
-        "deprecated",
-      ]);
+      expect(
+        getSkipDocDirectives(
+          { skip: ["@noDoc"] },
+          { skipDocDirective: ["@deprecated"] },
+        ),
+      ).toStrictEqual(["noDoc", "deprecated"]);
     });
 
     test("supports string as input", () => {
       expect.hasAssertions();
 
-      expect(getSkipDocDirectives("@noDoc")).toStrictEqual(["noDoc"]);
+      expect(getSkipDocDirectives({ skip: "@noDoc" })).toStrictEqual(["noDoc"]);
+    });
+
+    test("supports deprecated skip option", () => {
+      expect.hasAssertions();
+
+      expect(
+        getSkipDocDirectives(undefined, {
+          printTypeOptions: { deprecated: "skip" },
+        }),
+      ).toStrictEqual(["deprecated"]);
     });
   });
 

--- a/packages/core/tests/unit/config.test.js
+++ b/packages/core/tests/unit/config.test.js
@@ -21,7 +21,7 @@ describe("config", () => {
     test("returns a list of directive names", () => {
       expect.hasAssertions();
 
-      expect(getSkipDocDirectives(["@noDoc", "@deprecated"])).toStrictEqual([
+      expect(getSkipDocDirectives(["@noDoc"], ["@deprecated"])).toStrictEqual([
         "noDoc",
         "deprecated",
       ]);

--- a/packages/printer-legacy/src/section.js
+++ b/packages/printer-legacy/src/section.js
@@ -95,6 +95,10 @@ const printSection = (values, section, options) => {
     level: levelPosition > -1 ? sectionLevels[levelPosition + 1] : undefined,
   });
 
+  if (items === "") {
+    return ""; // do not print section is no items printed
+  }
+
   return `${level} ${section}${openSection}${items}${closeSection}`;
 };
 
@@ -134,9 +138,7 @@ const printSectionItem = (type, options) => {
     typeof type === "undefined" ||
     type === null ||
     (hasProperty(options, "skipDocDirective") &&
-      hasDirective(type, options.skipDocDirective) === true) ||
-    (hasProperty(options, "onlyDocDirective") &&
-      hasDirective(type, options.onlyDocDirective) === false)
+      hasDirective(type, options.skipDocDirective) === true)
   ) {
     return "";
   }

--- a/packages/printer-legacy/tests/unit/section.test.js
+++ b/packages/printer-legacy/tests/unit/section.test.js
@@ -365,47 +365,5 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.`,
         "
       `);
     });
-
-    test("returns Markdown #### link section with only type matching onlyDocDirective", () => {
-      expect.hasAssertions();
-
-      const type = {
-        name: "ParameterOnlyDoc",
-        type: GraphQLString,
-        astNode: {
-          directives: [{ name: { value: "@doc" } }],
-        },
-      };
-
-      const section = printSectionItem(type, {
-        ...DEFAULT_OPTIONS,
-        onlyDocDirective: "@doc",
-      });
-
-      expect(section).toMatchInlineSnapshot(`
-        "#### [\`ParameterOnlyDoc\`](#)<Bullet />[\`String\`](/scalars/string) <Badge class="secondary" text="scalar"/>
-        > 
-        > "
-      `);
-    });
-
-    test("returns Markdown #### link section empty if type does not match onlyDocDirective", () => {
-      expect.hasAssertions();
-
-      const type = {
-        name: "ParameterOnlyDoc",
-        type: GraphQLString,
-        astNode: {
-          directives: [{ name: { value: "@noDoc" } }],
-        },
-      };
-
-      const section = printSectionItem(type, {
-        ...DEFAULT_OPTIONS,
-        onlyDocDirective: "@doc",
-      });
-
-      expect(section).toMatchInlineSnapshot(`""`);
-    });
   });
 });


### PR DESCRIPTION
# Description

Continue implementation of `printTypeOptions.deprecated`. This PR adds the option `skip` that behaves as a shortcut for `--skip "@deprecated"`.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
