### PR TITLE
🔖 release 1.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10649,10 +10649,10 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.1.7",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.1.4"
+        "@graphql-markdown/utils": "^1.2.0"
       },
       "devDependencies": {
         "@graphql-markdown/printer-legacy": "^1.1.3"
@@ -10661,8 +10661,8 @@
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@graphql-markdown/diff": "^1.0.6",
-        "@graphql-markdown/printer-legacy": "^1.1.7",
+        "@graphql-markdown/diff": "^1.0.7",
+        "@graphql-markdown/printer-legacy": "^1.2.0",
         "prettier": "^2.8"
       },
       "peerDependenciesMeta": {
@@ -10679,11 +10679,11 @@
     },
     "packages/diff": {
       "name": "@graphql-markdown/diff",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "MIT",
       "dependencies": {
         "@graphql-inspector/core": "^4.0.0",
-        "@graphql-markdown/utils": "^1.1.4",
+        "@graphql-markdown/utils": "^1.2.0",
         "@graphql-tools/graphql-file-loader": "^7.5.15",
         "@graphql-tools/load": "^7.8.13"
       },
@@ -10693,11 +10693,11 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.16.7",
+      "version": "1.17.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.1.7",
-        "@graphql-markdown/printer-legacy": "^1.1.7"
+        "@graphql-markdown/core": "^1.2.0",
+        "@graphql-markdown/printer-legacy": "^1.2.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -10705,10 +10705,10 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.1.7",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.1.4"
+        "@graphql-markdown/utils": "^1.2.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -10716,7 +10716,7 @@
     },
     "packages/utils": {
       "name": "@graphql-markdown/utils",
-      "version": "1.1.4",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/load": "^7.8.13"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.7",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -29,11 +29,11 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.1.4"
+    "@graphql-markdown/utils": "^1.2.0"
   },
   "peerDependencies": {
-    "@graphql-markdown/printer-legacy": "^1.1.7",
-    "@graphql-markdown/diff": "^1.0.6",
+    "@graphql-markdown/printer-legacy": "^1.2.0",
+    "@graphql-markdown/diff": "^1.0.7",
     "prettier": "^2.8"
   },
   "peerDependenciesMeta": {

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@graphql-inspector/core": "^4.0.0",
-    "@graphql-markdown/utils": "^1.1.4",
+    "@graphql-markdown/utils": "^1.2.0",
     "@graphql-tools/graphql-file-loader": "^7.5.15",
     "@graphql-tools/load": "^7.8.13"
   },

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.16.7",
+  "version": "1.17.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -31,8 +31,8 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.1.7",
-    "@graphql-markdown/printer-legacy": "^1.1.7"
+    "@graphql-markdown/core": "^1.2.0",
+    "@graphql-markdown/printer-legacy": "^1.2.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.7",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -22,7 +22,7 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.1.4"
+    "@graphql-markdown/utils": "^1.2.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.4",
+  "version": "1.2.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
# Description

Release 1.17.0

---
## What's Changed

Lot of changes in this release 🚀 
 * :bug: fix multiline description formatting reported by @patrys in https://github.com/graphql-markdown/graphql-markdown/issues/808
 * ✨ update of the option `skipDocDirective` and `--skip` to support multiple values
 * 🔮  new option `printTypeOptions.deprecated` gives more control on `deprecated` types from an initial request from @patrys in https://github.com/graphql-markdown/graphql-markdown/issues/735

### @graphql-markdown/docusaurus 1.17.0
* ✨ option skipDocDirective supports multiple values by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/810
* ✨ printTypeOptions group deprecated by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/806
* :sparkles:  add printTypeOptions deprecated 'skip' by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/811
* 📦 bump dependency @graphql-markdown/core from 1.1.7 to 1.2.0
* 📦 bump dependency @graphql-markdown/printer-legacy from 1.1.7 to 1.2.0

### @graphql-markdown/core 1.2.0
* ✨ option skipDocDirective supports multiple values by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/810
* ✨ printTypeOptions group deprecated by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/806
* :sparkles:  add printTypeOptions deprecated 'skip' by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/811
* 📦 bump dependency @graphql-markdown/utils from 1.1.4 to 1.2.0
* 📦 bump peerDependency @graphql-markdown/printer-legacy from 1.1.7 to 1.2.0
* 📦 bump peerDependency @graphql-markdown/diff from 1.0.6 to 1.0.7

### @graphql-markdown/printer-legacy 1.2.0
* :bug:  fix multiline description formatting by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/809
* ✨ option skipDocDirective supports multiple values by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/810
* ✨ printTypeOptions group deprecated by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/806
* :sparkles:  add printTypeOptions deprecated 'skip' by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/811
* 📦 bump dependency @graphql-markdown/utils from 1.1.4 to 1.2.0

### @graphql-markdown/utils 1.2.0
* :sparkles: add `isDeprecated` in graphql utils
* :sparkles: `hasDirective` now supports array in graphql utils

### @graphql-markdown/diff 1.0.7
* 📦 bump dependency @graphql-markdown/utils from 1.1.4 to 1.2.0

---

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
