### PR TITLE
:bug: Merge loaderOptions into loader object passed to graphql-tools

### DIFF
--- a/packages/utils/src/graphql.js
+++ b/packages/utils/src/graphql.js
@@ -86,7 +86,7 @@ function getDocumentLoaders(loadersList = {}) {
   if (loaders.length < 1) {
     throw new Error("No GraphQL document loaders available.");
   }
-  return { loaders, loaderOptions };
+  return { ...loaderOptions, loaders };
 }
 
 function getListDefaultValues(type, value) {

--- a/packages/utils/tests/unit/graphql.test.js
+++ b/packages/utils/tests/unit/graphql.test.js
@@ -86,7 +86,7 @@ describe("graphql", () => {
       const loaders = {
         GraphQLFileLoader: "@graphql-tools/graphql-file-loader",
       };
-      const { loaders: documentLoaders, loaderOptions } =
+      const { loaders: documentLoaders, ...loaderOptions } =
         getDocumentLoaders(loaders);
 
       expect(documentLoaders).toMatchObject([new GraphQLFileLoader()]);
@@ -104,7 +104,7 @@ describe("graphql", () => {
           },
         },
       };
-      const { loaders: documentLoaders, loaderOptions } =
+      const { loaders: documentLoaders, ...loaderOptions } =
         getDocumentLoaders(loaders);
 
       expect(documentLoaders).toMatchObject([new GraphQLFileLoader()]);


### PR DESCRIPTION
The properties of `loaderOptions` need to be at the same level as the `loader` object to be properly passed down to `graphql-tools`'s loaders.

# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] ~~I have made corresponding changes to the documentation.~~ (not applicable)
- [x] I have modified tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.