### PR TITLE
✨ improve handling of deprecated directive

### DIFF
--- a/packages/printer-legacy/src/code.js
+++ b/packages/printer-legacy/src/code.js
@@ -1,14 +1,25 @@
 const {
   object: { hasProperty },
-  graphql: { getDefaultValue, getTypeName },
+  graphql: { getDefaultValue, getTypeName, isDeprecated },
 } = require("@graphql-markdown/utils");
 
-const { MARKDOWN_EOL } = require("./const/strings");
+const { MARKDOWN_EOL, DEPRECATED } = require("./const/strings");
+const { OPTION_DEPRECATED } = require("./const/options");
 
-const printCodeField = (type) => {
+const printCodeField = (type, options = {}) => {
+  if (
+    hasProperty(options, "printDeprecated") &&
+    options.printDeprecated === OPTION_DEPRECATED.SKIP &&
+    isDeprecated(type)
+  ) {
+    return "";
+  }
+
   let code = `${getTypeName(type)}`;
   code += printCodeArguments(type);
-  code += `: ${getTypeName(type.type)}${MARKDOWN_EOL}`;
+  code += `: ${getTypeName(type.type)}`;
+  code += isDeprecated(type) ? ` @${DEPRECATED}` : "";
+  code += MARKDOWN_EOL;
 
   return code;
 };

--- a/packages/printer-legacy/src/code.js
+++ b/packages/printer-legacy/src/code.js
@@ -1,17 +1,20 @@
 const {
   object: { hasProperty },
-  graphql: { getDefaultValue, getTypeName, isDeprecated },
+  graphql: { getDefaultValue, getTypeName, isDeprecated, hasDirective },
 } = require("@graphql-markdown/utils");
 
 const { MARKDOWN_EOL, DEPRECATED } = require("./const/strings");
 const { OPTION_DEPRECATED } = require("./const/options");
 
 const printCodeField = (type, options = {}) => {
-  if (
+  const skipDirective =
+    hasProperty(options, "skipDocDirective") &&
+    hasDirective(type, options.skipDocDirective) === true;
+  const skipDeprecated =
     hasProperty(options, "printDeprecated") &&
     options.printDeprecated === OPTION_DEPRECATED.SKIP &&
-    isDeprecated(type)
-  ) {
+    isDeprecated(type) === true;
+  if (skipDirective === true || skipDeprecated === true) {
     return "";
   }
 

--- a/packages/printer-legacy/src/const/options.js
+++ b/packages/printer-legacy/src/const/options.js
@@ -1,6 +1,7 @@
 const OPTION_DEPRECATED = {
   DEFAULT: "default",
   GROUP: "group",
+  SKIP: "skip",
 };
 
 const DEFAULT_OPTIONS = {

--- a/packages/printer-legacy/src/graphql/enum.js
+++ b/packages/printer-legacy/src/graphql/enum.js
@@ -1,6 +1,6 @@
 const {
   object: { hasProperty },
-  graphql: { isEnumType, getTypeName, isDeprecated },
+  graphql: { isEnumType, getTypeName, isDeprecated, hasDirective },
 } = require("@graphql-markdown/utils");
 
 const { MARKDOWN_EOL, DEPRECATED } = require("../const/strings");
@@ -20,15 +20,18 @@ const printCodeEnum = (type, options) => {
   code += type
     .getValues()
     .map((value) => {
-      if (
+      const skipDirective =
+        hasProperty(options, "skipDocDirective") &&
+        hasDirective(value, options.skipDocDirective) === true;
+      const skipDeprecated =
         hasProperty(options, "printDeprecated") &&
         options.printDeprecated === OPTION_DEPRECATED.SKIP &&
-        isDeprecated(value)
-      ) {
+        isDeprecated(value) === true;
+      if (skipDirective === true || skipDeprecated === true) {
         return "";
       }
       const v = getTypeName(value);
-      const d = isDeprecated(value) ? ` @${DEPRECATED}` : "";
+      const d = isDeprecated(value) === true ? ` @${DEPRECATED}` : "";
       return `  ${v}${d}`;
     })
     .filter((value) => value.length > 0)

--- a/packages/printer-legacy/src/graphql/enum.js
+++ b/packages/printer-legacy/src/graphql/enum.js
@@ -1,12 +1,11 @@
 const {
   object: { hasProperty },
-  graphql: { isEnumType, getTypeName },
+  graphql: { isEnumType, getTypeName, isDeprecated },
 } = require("@graphql-markdown/utils");
 
 const { MARKDOWN_EOL, DEPRECATED } = require("../const/strings");
 const { OPTION_DEPRECATED } = require("../const/options");
 const { printMetadataSection } = require("../section");
-const { isDeprecated } = require("@graphql-markdown/utils/src/graphql");
 
 const printEnumMetadata = (type, options) => {
   return printMetadataSection(type, type.getValues(), "Values", options);

--- a/packages/printer-legacy/src/graphql/enum.js
+++ b/packages/printer-legacy/src/graphql/enum.js
@@ -1,15 +1,18 @@
 const {
+  object: { hasProperty },
   graphql: { isEnumType, getTypeName },
 } = require("@graphql-markdown/utils");
 
-const { MARKDOWN_EOL } = require("../const/strings");
+const { MARKDOWN_EOL, DEPRECATED } = require("../const/strings");
+const { OPTION_DEPRECATED } = require("../const/options");
 const { printMetadataSection } = require("../section");
+const { isDeprecated } = require("@graphql-markdown/utils/src/graphql");
 
 const printEnumMetadata = (type, options) => {
   return printMetadataSection(type, type.getValues(), "Values", options);
 };
 
-const printCodeEnum = (type) => {
+const printCodeEnum = (type, options) => {
   if (!isEnumType(type)) {
     return "";
   }
@@ -17,7 +20,19 @@ const printCodeEnum = (type) => {
   let code = `enum ${getTypeName(type)} {${MARKDOWN_EOL}`;
   code += type
     .getValues()
-    .map((v) => `  ${getTypeName(v)}`)
+    .map((value) => {
+      if (
+        hasProperty(options, "printDeprecated") &&
+        options.printDeprecated === OPTION_DEPRECATED.SKIP &&
+        isDeprecated(value)
+      ) {
+        return "";
+      }
+      const v = getTypeName(value);
+      const d = isDeprecated(value) ? ` @${DEPRECATED}` : "";
+      return `  ${v}${d}`;
+    })
+    .filter((value) => value.length > 0)
     .join(MARKDOWN_EOL);
   code += `${MARKDOWN_EOL}}`;
 

--- a/packages/printer-legacy/src/graphql/input.js
+++ b/packages/printer-legacy/src/graphql/input.js
@@ -2,7 +2,7 @@ const { printObjectMetadata, printCodeType } = require("./object");
 
 const printInputMetadata = printObjectMetadata;
 
-const printCodeInput = (type) => printCodeType(type, "input");
+const printCodeInput = (type, options) => printCodeType(type, "input", options);
 
 module.exports = {
   printInputMetadata,

--- a/packages/printer-legacy/src/graphql/object.js
+++ b/packages/printer-legacy/src/graphql/object.js
@@ -27,7 +27,7 @@ const printObjectMetadata = (type, options) => {
   return `${metadata}${interfaceMeta}`;
 };
 
-const printCodeType = (type, entity) => {
+const printCodeType = (type, entity, options) => {
   const name = getTypeName(type);
   const extendsInterface =
     hasMethod(type, "getInterfaces") && type.getInterfaces().length > 0
@@ -37,13 +37,17 @@ const printCodeType = (type, entity) => {
           .join(", ")}`
       : "";
   const typeFields = getFields(type)
-    .map((v) => `  ${printCodeField(v)}`)
+    .map((field) => {
+      const f = printCodeField(field, options);
+      return f.length > 0 ? `  ${f}` : "";
+    })
+    .filter((field) => field.length > 0)
     .join("");
 
   return `${entity} ${name}${extendsInterface} {${MARKDOWN_EOL}${typeFields}}`;
 };
 
-const printCodeObject = (type) => printCodeType(type, "type");
+const printCodeObject = (type, options) => printCodeType(type, "type", options);
 
 module.exports = {
   printObjectMetadata,

--- a/packages/printer-legacy/src/printer.js
+++ b/packages/printer-legacy/src/printer.js
@@ -103,33 +103,33 @@ class Printer {
 
   static printDescription = printDescription;
 
-  static printCode = (type) => {
+  static printCode = (type, options) => {
     let code = "";
 
     switch (true) {
       case isOperation(type):
-        code += printCodeOperation(type);
+        code += printCodeOperation(type, options);
         break;
       case isEnumType(type):
-        code += printCodeEnum(type);
+        code += printCodeEnum(type, options);
         break;
-      case isUnionType(type):
-        code += printCodeUnion(type);
+      case isUnionType(type, options):
+        code += printCodeUnion(type, options);
         break;
-      case isInterfaceType(type):
-        code += printCodeInterface(type);
+      case isInterfaceType(type, options):
+        code += printCodeInterface(type, options);
         break;
       case isObjectType(type):
-        code += printCodeObject(type);
+        code += printCodeObject(type, options);
         break;
       case isInputType(type):
-        code += printCodeInput(type);
+        code += printCodeInput(type, options);
         break;
       case isScalarType(type):
-        code += printCodeScalar(type);
+        code += printCodeScalar(type, options);
         break;
       case isDirectiveType(type):
-        code += printCodeDirective(type);
+        code += printCodeDirective(type, options);
         break;
       default:
         code += `"${getTypeName(type)}" not supported`;
@@ -192,7 +192,7 @@ class Printer {
       header: options,
     });
     const description = Printer.printDescription(type);
-    const code = Printer.printCode(type);
+    const code = Printer.printCode(type, printTypeOptions);
     const metadata = Printer.printTypeMetadata(type, printTypeOptions);
     const relations = Printer.printRelations(type, printTypeOptions);
 

--- a/packages/printer-legacy/src/section.js
+++ b/packages/printer-legacy/src/section.js
@@ -134,14 +134,19 @@ const printSectionItem = (type, options) => {
       ? options.level
       : HEADER_SECTION_SUB_LEVEL;
 
+  const skipDirective =
+    hasProperty(options, "skipDocDirective") &&
+    hasDirective(type, options.skipDocDirective) === true;
+  const skipDeprecated =
+    hasProperty(options, "printDeprecated") &&
+    options.printDeprecated === OPTION_DEPRECATED.SKIP &&
+    isDeprecated(type) === true;
+
   if (
     typeof type === "undefined" ||
     type === null ||
-    (hasProperty(options, "skipDocDirective") &&
-      hasDirective(type, options.skipDocDirective) === true) ||
-    (hasProperty(options, "printDeprecated") &&
-      options.printDeprecated === OPTION_DEPRECATED.SKIP &&
-      isDeprecated(type))
+    skipDirective === true ||
+    skipDeprecated === true
   ) {
     return "";
   }

--- a/packages/printer-legacy/src/section.js
+++ b/packages/printer-legacy/src/section.js
@@ -138,7 +138,10 @@ const printSectionItem = (type, options) => {
     typeof type === "undefined" ||
     type === null ||
     (hasProperty(options, "skipDocDirective") &&
-      hasDirective(type, options.skipDocDirective) === true)
+      hasDirective(type, options.skipDocDirective) === true) ||
+    (hasProperty(options, "printDeprecated") &&
+      options.printDeprecated === OPTION_DEPRECATED.SKIP &&
+      isDeprecated(type))
   ) {
     return "";
   }

--- a/packages/printer-legacy/tests/unit/code.test.js
+++ b/packages/printer-legacy/tests/unit/code.test.js
@@ -100,5 +100,25 @@ describe("code", () => {
         "
       `);
     });
+
+    test("returns an empty string in @deprecated and SKIP", () => {
+      expect.hasAssertions();
+
+      const type = {
+        name: "TypeFooBar",
+        type: GraphQLString,
+        isDeprecated: true,
+        args: [
+          {
+            name: "ArgFooBar",
+            type: GraphQLString,
+          },
+        ],
+      };
+
+      const code = printCodeField(type, { printDeprecated: "skip" });
+
+      expect(code).toBe("");
+    });
   });
 });

--- a/packages/printer-legacy/tests/unit/graphql/enum.test.js
+++ b/packages/printer-legacy/tests/unit/graphql/enum.test.js
@@ -83,7 +83,19 @@ describe("enum", () => {
       expect(code).toMatchInlineSnapshot(`
         "enum EnumTypeName {
           one
-          two
+          two @deprecated
+        }"
+      `);
+    });
+
+    test("returns enum code structure without deprecated if SKIP", () => {
+      expect.hasAssertions();
+
+      const code = printCodeEnum(type, { printDeprecated: "skip" });
+
+      expect(code).toMatchInlineSnapshot(`
+        "enum EnumTypeName {
+          one
         }"
       `);
     });

--- a/packages/printer-legacy/tests/unit/graphql/object.test.js
+++ b/packages/printer-legacy/tests/unit/graphql/object.test.js
@@ -101,7 +101,19 @@ describe("object", () => {
       expect(code).toMatchInlineSnapshot(`
         "type TestName implements TestInterfaceName {
           one: String
-          two: Boolean
+          two: Boolean @deprecated
+        }"
+      `);
+    });
+
+    test("returns an object with no deprecated fields if SKIP", () => {
+      expect.hasAssertions();
+
+      const code = printCodeObject(type, { printDeprecated: "skip" });
+
+      expect(code).toMatchInlineSnapshot(`
+        "type TestName implements TestInterfaceName {
+          one: String
         }"
       `);
     });

--- a/packages/printer-legacy/tests/unit/section.test.js
+++ b/packages/printer-legacy/tests/unit/section.test.js
@@ -327,6 +327,26 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.`,
       expect(section).toBe("");
     });
 
+    test("returns no section if item deprecated and SKIP", () => {
+      expect.hasAssertions();
+
+      const type = {
+        name: "EntityTypeNameList",
+        isDeprecated: true,
+        astNode: {
+          directives: [{ name: { value: "@noDoc" } }],
+        },
+      };
+
+      const section = printSectionItem(type, {
+        ...DEFAULT_OPTIONS,
+        skipDocDirective: ["@noDoc"],
+        printDeprecated: "skip",
+      });
+
+      expect(section).toBe("");
+    });
+
     test("returns Markdown #### link section without field parameters matching skipDocDirective", () => {
       expect.hasAssertions();
 

--- a/packages/printer-legacy/tests/unit/section.test.js
+++ b/packages/printer-legacy/tests/unit/section.test.js
@@ -352,6 +352,7 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.`,
 
       const type = {
         name: "EntityTypeName",
+        isDeprecated: true,
         args: [
           {
             name: "ParameterTypeName",
@@ -376,7 +377,9 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.`,
       });
 
       expect(section).toMatchInlineSnapshot(`
-        "#### [\`EntityTypeName\`](#) 
+        "#### [\`EntityTypeName\`](#) <Badge class="secondary" text="deprecated"/>
+        > <Badge class="warning" text="DEPRECATED"/>
+        > 
         > 
         > ##### [<code style={{ fontWeight: 'normal' }}>EntityTypeName.<b>ParameterTypeName</b></code>](#)<Bullet />[\`String\`](/scalars/string) <Badge class="secondary" text="scalar"/>
         > 


### PR DESCRIPTION
# Description

Improved handling of `@deprecated` directive:

- Print `@deprecated` in code snippet
- Do not print deprecated field and enum (snippet and metadata) if `printDeprecated` is set to `skip`

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] ~I have made corresponding changes to the documentation.~
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
