### PR TITLE
🔖 release 1.17.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1067,9 +1067,8 @@
     },
     "node_modules/@eslint/js": {
       "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.38.0.tgz",
-      "integrity": "sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -1113,8 +1112,7 @@
     },
     "node_modules/@graphql-tools/graphql-file-loader": {
       "version": "7.5.17",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-7.5.17.tgz",
-      "integrity": "sha512-hVwwxPf41zOYgm4gdaZILCYnKB9Zap7Ys9OhY1hbwuAuC4MMNY9GpUjoTU3CQc3zUiPoYStyRtUGkHSJZ3HxBw==",
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/import": "6.7.18",
         "@graphql-tools/utils": "^9.2.1",
@@ -1128,8 +1126,7 @@
     },
     "node_modules/@graphql-tools/import": {
       "version": "6.7.18",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.7.18.tgz",
-      "integrity": "sha512-XQDdyZTp+FYmT7as3xRWH/x8dx0QZA2WZqfMF5EWb36a0PiH7WwlRQYIdyYXj8YCLpiWkeBXgBRHmMnwEYR8iQ==",
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "^9.2.1",
         "resolve-from": "5.0.0",
@@ -1141,9 +1138,8 @@
     },
     "node_modules/@graphql-tools/json-file-loader": {
       "version": "7.4.18",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-7.4.18.tgz",
-      "integrity": "sha512-AJ1b6Y1wiVgkwsxT5dELXhIVUPs/u3VZ8/0/oOtpcoyO/vAeM5rOvvWegzicOOnQw8G45fgBRMkkRfeuwVt6+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "^9.2.1",
         "globby": "^11.0.3",
@@ -3894,9 +3890,8 @@
     },
     "node_modules/eslint": {
       "version": "8.38.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.38.0.tgz",
-      "integrity": "sha512-pIdsD2jwlUGf/U38Jv97t8lq6HpaU/G9NKbYmpWpZGw3LdTNhZLbJePqxOXGB5+JEKfOPU/XLxYxFh03nr1KTg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -7729,9 +7724,8 @@
     },
     "node_modules/memfs": {
       "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.0.tgz",
-      "integrity": "sha512-yK6o8xVJlQerz57kvPROwTMgx5WtGwC2ZxDtOUsnGl49rHjYkfQoPNZPCKH73VdLE1BwBu/+Fx/NL8NYMUw2aA==",
       "dev": true,
+      "license": "Unlicense",
       "dependencies": {
         "fs-monkey": "^1.0.3"
       },
@@ -9794,10 +9788,10 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.2.0"
+        "@graphql-markdown/utils": "^1.2.1"
       },
       "devDependencies": {
         "@graphql-markdown/printer-legacy": "^1.1.3"
@@ -9806,8 +9800,8 @@
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@graphql-markdown/diff": "^1.0.7",
-        "@graphql-markdown/printer-legacy": "^1.2.1",
+        "@graphql-markdown/diff": "^1.0.8",
+        "@graphql-markdown/printer-legacy": "^1.2.2",
         "prettier": "^2.8"
       },
       "peerDependenciesMeta": {
@@ -9824,11 +9818,11 @@
     },
     "packages/diff": {
       "name": "@graphql-markdown/diff",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
         "@graphql-inspector/core": "^4.0.3",
-        "@graphql-markdown/utils": "^1.2.0",
+        "@graphql-markdown/utils": "^1.2.1",
         "@graphql-tools/graphql-file-loader": "^7.5.15",
         "@graphql-tools/load": "^7.8.14"
       },
@@ -9838,11 +9832,11 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.17.1",
+      "version": "1.17.2",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.2.1",
-        "@graphql-markdown/printer-legacy": "^1.2.1"
+        "@graphql-markdown/core": "^1.2.2",
+        "@graphql-markdown/printer-legacy": "^1.2.2"
       },
       "engines": {
         "node": ">=16.14"
@@ -9850,10 +9844,10 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.2.0"
+        "@graphql-markdown/utils": "^1.2.1"
       },
       "engines": {
         "node": ">=16.14"
@@ -9861,7 +9855,7 @@
     },
     "packages/utils": {
       "name": "@graphql-markdown/utils",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/load": "^7.8.14"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -29,11 +29,11 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.2.0"
+    "@graphql-markdown/utils": "^1.2.1"
   },
   "peerDependencies": {
-    "@graphql-markdown/printer-legacy": "^1.2.1",
-    "@graphql-markdown/diff": "^1.0.7",
+    "@graphql-markdown/printer-legacy": "^1.2.2",
+    "@graphql-markdown/diff": "^1.0.8",
     "prettier": "^2.8"
   },
   "peerDependenciesMeta": {

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.7",
+  "version": "1.0.8",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@graphql-inspector/core": "^4.0.3",
-    "@graphql-markdown/utils": "^1.2.0",
+    "@graphql-markdown/utils": "^1.2.1",
     "@graphql-tools/graphql-file-loader": "^7.5.15",
     "@graphql-tools/load": "^7.8.14"
   },

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.17.1",
+  "version": "1.17.2",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -31,8 +31,8 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.2.1",
-    "@graphql-markdown/printer-legacy": "^1.2.1"
+    "@graphql-markdown/core": "^1.2.2",
+    "@graphql-markdown/printer-legacy": "^1.2.2"
   },
   "directories": {
     "test": "tests"

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -22,7 +22,7 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.2.0"
+    "@graphql-markdown/utils": "^1.2.1"
   },
   "directories": {
     "test": "tests"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
# Description

Publish fix for #815 

---

## What's Changed

### @graphql-markdown/core@1.17.2

* 📦 Bump dependency @graphql-markdown/core from 1.2.1 to 1.2.2 by @edno
* 📦 Bump peerDependency @graphql-markdown/printer-legacy from 1.2.1 to 1.2.2 by @edno 

### @graphql-markdown/core@1.2.2

* 📦 Bump dependency @graphql-markdown/utils from 1.2.0 to 1.2.1 by @edno
* 📦 Bump peerDependency @graphql-markdown/printer-legacy from 1.2.1 to 1.2.2 by @edno
* 📦 Bump peerDependency @graphql-markdown/diff from 1.0.7 to 1.0.8 by @edno

### @graphql-markdown/printer-legacy@1.2.2

* 📦 Bump @graphql-markdown/utils from 1.2.0 to 1.2.1 by @edno

### @graphql-markdown/diff@1.0.8

* 📦 npm(deps): Bump @graphql-inspector/core from 4.0.2 to 4.0.3 by @dependabot in https://github.com/graphql-markdown/graphql-markdown/pull/826
* 📦 npm(deps): Bump @graphql-tools/load from 7.8.13 to 7.8.14 by @dependabot in https://github.com/graphql-markdown/graphql-markdown/pull/827
* 📦 Bump dependency @graphql-markdown/utils from 1.2.0 to 1.2.1 by @edno

### @graphql-markdown/utils@1.2.1

* 📦 npm(deps): Bump @graphql-tools/load from 7.8.13 to 7.8.14 by @dependabot in https://github.com/graphql-markdown/graphql-markdown/pull/827
* :bug: Merge loaderOptions into loader object passed to graphql-tools by @chmanie in https://github.com/graphql-markdown/graphql-markdown/pull/814

---

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] ~I have made corresponding changes to the documentation.~
- [x] ~I have added tests that prove my fix is effective or that my changes work.~
- [x] New and existing unit tests pass locally with my changes.
