### PR TITLE
:bookmark:  release 1.18.0

### DIFF
--- a/docs/advanced/custom-directive.md
+++ b/docs/advanced/custom-directive.md
@@ -27,7 +27,7 @@ type Query {
 }
 ```
 
-Add the option `customDirective` to the `docusaurus2-graphql-doc-generator` configuration.
+Add the option [`customDirective`](/docs/settings#customdirective) to the `@graphql-markdown/docusaurus` configuration.
 
 ```js {6-19}
 plugins: [

--- a/docs/advanced/custom-root-types.md
+++ b/docs/advanced/custom-root-types.md
@@ -15,7 +15,7 @@ type rootTypes = { query?: string, mutation?: string, subscription?: string };
 - use a empty string to disable the GraphQL standard type
 - unset root types will use the GraphQL standard type
 
-Add the option `rootTypes` to the loader options under `docusaurus2-graphql-doc-generator` configuration (see also [schema loading](/docs/advanced/schema-loading)):
+Add the option `rootTypes` to the loader options under `@graphql-markdown/docusaurus` configuration (see also [schema loading](/docs/advanced/schema-loading)):
 
 ```js
 plugins: [

--- a/docs/advanced/schema-loading.md
+++ b/docs/advanced/schema-loading.md
@@ -34,7 +34,7 @@ Use `@graphql-tools/graphql-file-loader` if you want to load a local schema:
 npm install @graphql-tools/graphql-file-loader
 ```
 
-Once done, you can declare the loader into `docusaurus2-graphql-doc-generator` configuration:
+Once done, you can declare the loader into `@graphql-markdown/docusaurus` configuration:
 
 ```js
 plugins: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1067,17 +1067,15 @@
     },
     "node_modules/@eslint/js": {
       "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.39.0.tgz",
-      "integrity": "sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@graphql-inspector/core": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-inspector/core/-/core-4.2.1.tgz",
-      "integrity": "sha512-2aXRvILVy0qsGK9dJKeR/lqg5VW9oAr0ANDMcyzA1fuKZRXKR58bXMoLR6+NCV8dMg/Xjfi2imBbmx1ZhYrs/g==",
+      "license": "MIT",
       "dependencies": {
         "dependency-graph": "0.11.0",
         "object-inspect": "1.12.3",
@@ -3888,9 +3886,8 @@
     },
     "node_modules/eslint": {
       "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.39.0.tgz",
-      "integrity": "sha512-mwiok6cy7KTW7rBpo05k6+p4YVZByLNjAZ/ACB9DRCu4YDRwjXI01tWHp6KAUWelsBetTxKK/2sHB0vdS8Z2Og==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -4181,9 +4178,8 @@
     },
     "node_modules/eslint-scope": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -4230,9 +4226,8 @@
     },
     "node_modules/eslint/node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4246,9 +4241,8 @@
     },
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4261,9 +4255,8 @@
     },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4271,9 +4264,8 @@
     },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4287,9 +4279,8 @@
     },
     "node_modules/eslint/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4299,15 +4290,13 @@
     },
     "node_modules/eslint/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/globals": {
       "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -4320,15 +4309,13 @@
     },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4338,9 +4325,8 @@
     },
     "node_modules/eslint/node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -7725,9 +7711,8 @@
     },
     "node_modules/memfs": {
       "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.1.tgz",
-      "integrity": "sha512-UWbFJKvj5k+nETdteFndTpYxdeTMox/ULeqX5k/dpaQJCCFmj5EeKv3dBcyO2xmkRAx2vppRu5dVG7SOtsGOzA==",
       "dev": true,
+      "license": "Unlicense",
       "dependencies": {
         "fs-monkey": "^1.0.3"
       },
@@ -8287,9 +8272,8 @@
     },
     "node_modules/prettier": {
       "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "devOptional": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -9790,10 +9774,10 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.3.0"
+        "@graphql-markdown/utils": "^1.4.0"
       },
       "devDependencies": {
         "@graphql-markdown/printer-legacy": "^1.1.3"
@@ -9802,8 +9786,8 @@
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@graphql-markdown/diff": "^1.0.9",
-        "@graphql-markdown/printer-legacy": "^1.2.3",
+        "@graphql-markdown/diff": "^1.0.10",
+        "@graphql-markdown/printer-legacy": "^1.3.0",
         "prettier": "^2.8"
       },
       "peerDependenciesMeta": {
@@ -9820,11 +9804,11 @@
     },
     "packages/diff": {
       "name": "@graphql-markdown/diff",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "MIT",
       "dependencies": {
         "@graphql-inspector/core": "^4.2.1",
-        "@graphql-markdown/utils": "^1.3.0",
+        "@graphql-markdown/utils": "^1.4.0",
         "@graphql-tools/graphql-file-loader": "^7.5.15",
         "@graphql-tools/load": "^7.8.14"
       },
@@ -9834,11 +9818,11 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.17.3",
+      "version": "1.18.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.3.0",
-        "@graphql-markdown/printer-legacy": "^1.2.3"
+        "@graphql-markdown/core": "^1.4.0",
+        "@graphql-markdown/printer-legacy": "^1.3.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -9846,10 +9830,10 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.2.3",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.3.0"
+        "@graphql-markdown/utils": "^1.4.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -9857,7 +9841,7 @@
     },
     "packages/utils": {
       "name": "@graphql-markdown/utils",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/load": "^7.8.14"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -29,11 +29,11 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.3.0"
+    "@graphql-markdown/utils": "^1.4.0"
   },
   "peerDependencies": {
-    "@graphql-markdown/printer-legacy": "^1.2.3",
-    "@graphql-markdown/diff": "^1.0.9",
+    "@graphql-markdown/printer-legacy": "^1.3.0",
+    "@graphql-markdown/diff": "^1.0.10",
     "prettier": "^2.8"
   },
   "peerDependenciesMeta": {

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.9",
+  "version": "1.0.10",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@graphql-inspector/core": "^4.2.1",
-    "@graphql-markdown/utils": "^1.3.0",
+    "@graphql-markdown/utils": "^1.4.0",
     "@graphql-tools/graphql-file-loader": "^7.5.15",
     "@graphql-tools/load": "^7.8.14"
   },

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.17.3",
+  "version": "1.18.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -31,8 +31,8 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.3.0",
-    "@graphql-markdown/printer-legacy": "^1.2.3"
+    "@graphql-markdown/core": "^1.4.0",
+    "@graphql-markdown/printer-legacy": "^1.3.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/docusaurus/tests/__data__/schema_with_grouping.graphql
+++ b/packages/docusaurus/tests/__data__/schema_with_grouping.graphql
@@ -22,7 +22,7 @@ directive @doc(
 """
 Example of custom directive for `customDirective`.
 
-See [documentation](https://graphql-markdown.github.io/docs/settings#customDirective)
+See [documentation](https://graphql-markdown.github.io/docs/settings#customdirective)
 """
 directive @complexity(
   """
@@ -42,7 +42,7 @@ directive @complexity(
 """
 Example of custom directive for `customDirective`.
 
-See [documentation](https://graphql-markdown.github.io/docs/settings#customDirective)
+See [documentation](https://graphql-markdown.github.io/docs/settings#customdirective)
 """
 directive @auth(
   """

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.2.3",
+  "version": "1.3.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -22,7 +22,7 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.3.0"
+    "@graphql-markdown/utils": "^1.4.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
# Description

Release #844 

---
:star_struck: A new really cool feature by @ljiang-ti, [**`customDirective`**](https://graphql-markdown.github.io/docs/settings#customdirective) provides documentation of schema directives at type level. One can now choose to print a custom description for schema directive applying to a type or field. :sparkles: 

```js {6-19}
plugins: [
  [
    "@graphql-markdown/docusaurus",
    {
      // ... other options
      customDirective: {
        auth: {
          descriptor: (directive, type) =>
            directiveDescriptor(
              directive,
              type,
              "This requires the current user to be in `${requires}` role.",
            ),
        },
        // ... other custom directive options
      },
    },
  ],
],
```

![Screenshot from 2023-05-05 10-21-14](https://user-images.githubusercontent.com/324670/236418483-81387261-72d2-4a7d-b8e0-1b0c8c1376d9.png)

If you want to see it live, the [`group-by` example documentation](https://graphql-markdown.github.io/examples/group-by) has been update to make use of this feature.

You can find more examples and information regarding helpers to get you started in the [documentation](https://graphql-markdown.github.io/docs/advanced/custom-directive).

## What's Changed

### @graphql-markdown/docusaurus@1.18.0
* :sparkles: Support custom directives by @ljiang-ti in https://github.com/graphql-markdown/graphql-markdown/pull/844
* :package: bump dependency @graphql-markdown/core from 1.3.0 to 1.4.0
* :package: bump dependency @graphql-markdown/printer-legacy from 1.2.3 to 1.3.0

### @graphql-markdown/core@1.4.0
* :technologist:  tidy up core package by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/837
* :sparkles: Support custom directives by @ljiang-ti in https://github.com/graphql-markdown/graphql-markdown/pull/844
* :package: bump dependency @graphql-markdown/utils from 1.3.0 to 1.4.0
* :package: bump peerDependency @graphql-markdown/printer-legacy from 1.2.3 to 1.3.0
* :package: bump peerDependency @graphql-markdown/diff from 1.0.9 to 1.0.10

### @graphql-markdown/printer-legacy@1.3.0
* :sparkles: Support custom directives by @ljiang-ti in https://github.com/graphql-markdown/graphql-markdown/pull/844
* :package: bump dependency @graphql-markdown/utils from 1.3.0 to 1.4.0

### @graphql-markdown/utils@1.2.0
* :sparkles: Support custom directives by @ljiang-ti in https://github.com/graphql-markdown/graphql-markdown/pull/844

### @graphql-markdown/diff@1.0.10
* 📦 npm(deps): Bump @graphql-inspector/core from 4.0.3 to 4.2.1 by @dependabot in https://github.com/graphql-markdown/graphql-markdown/pull/842
* :package: bump dependency @graphql-markdown/utils from 1.3.0 to 1.4.0
---

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] ~I have added tests that prove my fix is effective or that my changes work.~
- [x] New and existing unit tests pass locally with my changes.
