### PR TITLE
Fix indentation level in code section

### DIFF
--- a/packages/docusaurus/tests/__data__/schema_with_grouping.graphql
+++ b/packages/docusaurus/tests/__data__/schema_with_grouping.graphql
@@ -132,6 +132,7 @@ type DepartmentInformation implements Record @auth {
   departmentOpenTime: Time
   departmentCloseTime: Time
   website: URL
+  employees(skip: Int): [String!]!
 }
 
 type Course {

--- a/packages/printer-legacy/src/code.js
+++ b/packages/printer-legacy/src/code.js
@@ -3,10 +3,14 @@ const {
   graphql: { getDefaultValue, getTypeName, isDeprecated, hasDirective },
 } = require("@graphql-markdown/utils");
 
-const { MARKDOWN_EOL, DEPRECATED } = require("./const/strings");
+const {
+  MARKDOWN_EOL,
+  DEPRECATED,
+  MARKDOWN_CODE_INDENTATION,
+} = require("./const/strings");
 const { OPTION_DEPRECATED } = require("./const/options");
 
-const printCodeField = (type, options = {}) => {
+const printCodeField = (type, options = {}, indentationLevel = 0) => {
   const skipDirective =
     hasProperty(options, "skipDocDirective") &&
     hasDirective(type, options.skipDocDirective) === true;
@@ -19,7 +23,7 @@ const printCodeField = (type, options = {}) => {
   }
 
   let code = `${getTypeName(type)}`;
-  code += printCodeArguments(type);
+  code += printCodeArguments(type, indentationLevel + 1);
   code += `: ${getTypeName(type.type)}`;
   code += isDeprecated(type) ? ` @${DEPRECATED}` : "";
   code += MARKDOWN_EOL;
@@ -27,11 +31,14 @@ const printCodeField = (type, options = {}) => {
   return code;
 };
 
-const printCodeArguments = (type) => {
+const printCodeArguments = (type, indentationLevel = 1) => {
   if (!hasProperty(type, "args") || type.args.length === 0) {
     return "";
   }
 
+  const argIndentation = MARKDOWN_CODE_INDENTATION.repeat(indentationLevel);
+  const parentIndentation =
+    indentationLevel === 1 ? "" : MARKDOWN_CODE_INDENTATION;
   let code = `(${MARKDOWN_EOL}`;
   code += type.args.reduce((r, v) => {
     const defaultValue = getDefaultValue(v);
@@ -40,9 +47,9 @@ const printCodeArguments = (type) => {
     const printedDefault = hasDefaultValue ? ` = ${getDefaultValue(v)}` : "";
     const propType = v.type.toString();
     const propName = v.name.toString();
-    return `${r}  ${propName}: ${propType}${printedDefault}${MARKDOWN_EOL}`;
+    return `${r}${argIndentation}${propName}: ${propType}${printedDefault}${MARKDOWN_EOL}`;
   }, "");
-  code += `)`;
+  code += `${parentIndentation})`;
 
   return code;
 };

--- a/packages/printer-legacy/src/const/strings.js
+++ b/packages/printer-legacy/src/const/strings.js
@@ -20,6 +20,7 @@ const MARKDOWN_EOL = "\n";
 const MARKDOWN_EOP = "\n\n";
 const MARKDOWN_SOC = `${MARKDOWN_EOL}\`\`\`graphql${MARKDOWN_EOL}`;
 const MARKDOWN_EOC = `${MARKDOWN_EOL}\`\`\`${MARKDOWN_EOL}`;
+const MARKDOWN_CODE_INDENTATION = "  ";
 const FRONT_MATTER = "---";
 
 const DEPRECATED = "deprecated";
@@ -34,6 +35,7 @@ module.exports = {
   MARKDOWN_EOP,
   MARKDOWN_SOC,
   MARKDOWN_EOC,
+  MARKDOWN_CODE_INDENTATION,
   FRONT_MATTER,
   DEPRECATED,
 };

--- a/packages/printer-legacy/src/graphql/object.js
+++ b/packages/printer-legacy/src/graphql/object.js
@@ -5,7 +5,7 @@ const {
 
 const { printSection, printMetadataSection } = require("../section");
 const { printCodeField } = require("../code");
-const { MARKDOWN_EOL } = require("../const/strings");
+const { MARKDOWN_EOL, MARKDOWN_CODE_INDENTATION } = require("../const/strings");
 
 const printInterfaceMetadata = (type, options) => {
   if (hasMethod(type, "getInterfaces") === false) {
@@ -38,8 +38,8 @@ const printCodeType = (type, entity, options) => {
       : "";
   const typeFields = getFields(type)
     .map((field) => {
-      const f = printCodeField(field, options);
-      return f.length > 0 ? `  ${f}` : "";
+      const f = printCodeField(field, options, 1);
+      return f.length > 0 ? `${MARKDOWN_CODE_INDENTATION}${f}` : "";
     })
     .filter((field) => field.length > 0)
     .join("");

--- a/packages/printer-legacy/tests/unit/graphql/interface.test.js
+++ b/packages/printer-legacy/tests/unit/graphql/interface.test.js
@@ -12,17 +12,25 @@ const {
 } = require("../../../src/graphql/interface");
 
 describe("interface", () => {
+  const type = new GraphQLInterfaceType({
+    name: "TestInterfaceName",
+    fields: {
+      one: { type: GraphQLString },
+      two: { type: GraphQLBoolean },
+      three: {
+        type: GraphQLString,
+        args: {
+          four: {
+            type: GraphQLString,
+          },
+        },
+      },
+    },
+  });
+
   describe("printInterfaceMetadata()", () => {
     test("returns interface metadata", () => {
       expect.hasAssertions();
-
-      const type = new GraphQLInterfaceType({
-        name: "TestInterfaceName",
-        fields: {
-          one: { type: GraphQLString },
-          two: { type: GraphQLBoolean },
-        },
-      });
 
       const metadata = printInterfaceMetadata(type, DEFAULT_OPTIONS);
 
@@ -37,6 +45,12 @@ describe("interface", () => {
         > 
         > 
 
+        #### [<code style={{ fontWeight: 'normal' }}>TestInterfaceName.<b>three</b></code>](#)<Bullet />[\`String\`](/scalars/string) <Badge class="secondary" text="scalar"/>
+        > 
+        > ##### [<code style={{ fontWeight: 'normal' }}>TestInterfaceName.three.<b>four</b></code>](#)<Bullet />[\`String\`](/scalars/string) <Badge class="secondary" text="scalar"/>
+        > 
+        > 
+
         "
       `);
     });
@@ -46,20 +60,15 @@ describe("interface", () => {
     test("returns an interface with its fields", () => {
       expect.hasAssertions();
 
-      const type = new GraphQLInterfaceType({
-        name: "TestInterfaceName",
-        fields: {
-          one: { type: GraphQLString },
-          two: { type: GraphQLBoolean },
-        },
-      });
-
       const code = printCodeInterface(type);
 
       expect(code).toMatchInlineSnapshot(`
         "interface TestInterfaceName {
           one: String
           two: Boolean
+          three(
+            four: String
+          ): String
         }"
       `);
     });

--- a/packages/printer-legacy/tests/unit/graphql/object.test.js
+++ b/packages/printer-legacy/tests/unit/graphql/object.test.js
@@ -21,6 +21,14 @@ describe("object", () => {
     fields: {
       one: { type: GraphQLString },
       two: { type: GraphQLBoolean, deprecationReason: "Deprecated" },
+      three: {
+        type: GraphQLString,
+        args: {
+          four: {
+            type: GraphQLString,
+          },
+        },
+      },
     },
     interfaces: () => [new GraphQLInterfaceType({ name: "TestInterfaceName" })],
   });
@@ -41,6 +49,12 @@ describe("object", () => {
         #### [<code style={{ fontWeight: 'normal' }}>TestName.<b>two</b></code>](#)<Bullet />[\`Boolean\`](/scalars/boolean) <Badge class="secondary" text="deprecated"/> <Badge class="secondary" text="scalar"/>
         > <Badge class="warning" text="DEPRECATED: Deprecated"/>
         > 
+        > 
+        > 
+
+        #### [<code style={{ fontWeight: 'normal' }}>TestName.<b>three</b></code>](#)<Bullet />[\`String\`](/scalars/string) <Badge class="secondary" text="scalar"/>
+        > 
+        > ##### [<code style={{ fontWeight: 'normal' }}>TestName.three.<b>four</b></code>](#)<Bullet />[\`String\`](/scalars/string) <Badge class="secondary" text="scalar"/>
         > 
         > 
 
@@ -66,6 +80,12 @@ describe("object", () => {
         "### Fields
 
         #### [<code style={{ fontWeight: 'normal' }}>TestName.<b>one</b></code>](#)<Bullet />[\`String\`](/scalars/string) <Badge class="secondary" text="scalar"/>
+        > 
+        > 
+
+        #### [<code style={{ fontWeight: 'normal' }}>TestName.<b>three</b></code>](#)<Bullet />[\`String\`](/scalars/string) <Badge class="secondary" text="scalar"/>
+        > 
+        > ##### [<code style={{ fontWeight: 'normal' }}>TestName.three.<b>four</b></code>](#)<Bullet />[\`String\`](/scalars/string) <Badge class="secondary" text="scalar"/>
         > 
         > 
 
@@ -102,6 +122,9 @@ describe("object", () => {
         "type TestName implements TestInterfaceName {
           one: String
           two: Boolean @deprecated
+          three(
+            four: String
+          ): String
         }"
       `);
     });
@@ -114,6 +137,9 @@ describe("object", () => {
       expect(code).toMatchInlineSnapshot(`
         "type TestName implements TestInterfaceName {
           one: String
+          three(
+            four: String
+          ): String
         }"
       `);
     });

--- a/packages/printer-legacy/tests/unit/graphql/operation.test.js
+++ b/packages/printer-legacy/tests/unit/graphql/operation.test.js
@@ -6,7 +6,10 @@ const {
   DEFAULT_OPTIONS,
   OPTION_DEPRECATED,
 } = require("../../../src/const/options");
-const { printOperationMetadata } = require("../../../src/graphql/operation");
+const {
+  printOperationMetadata,
+  printCodeOperation,
+} = require("../../../src/graphql/operation");
 
 describe("operation", () => {
   describe("printOperationMetadata()", () => {
@@ -142,6 +145,32 @@ describe("operation", () => {
         > 
         > 
 
+        "
+      `);
+    });
+  });
+
+  describe("printCodeOperation()", () => {
+    test("returns an operation with its fields", () => {
+      expect.hasAssertions();
+
+      const operation = {
+        name: "TestQuery",
+        type: GraphQLID,
+        args: [
+          {
+            name: "ArgFooBar",
+            type: GraphQLString,
+          },
+        ],
+      };
+
+      const code = printCodeOperation(operation);
+
+      expect(code).toMatchInlineSnapshot(`
+        "TestQuery(
+          ArgFooBar: String
+        ): ID
         "
       `);
     });


### PR DESCRIPTION
# Description

Use new argument to print code fields and arguments with indentation (white spaces). This would cover some edge cases described in #850 .

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
