### PR TITLE
:bookmark: release 1.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9774,7 +9774,7 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/utils": "^1.4.0"
@@ -9787,7 +9787,7 @@
       },
       "peerDependencies": {
         "@graphql-markdown/diff": "^1.0.10",
-        "@graphql-markdown/printer-legacy": "^1.3.0",
+        "@graphql-markdown/printer-legacy": "^1.3.1",
         "prettier": "^2.8"
       },
       "peerDependenciesMeta": {
@@ -9818,11 +9818,11 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.18.0",
+      "version": "1.18.1",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.4.0",
-        "@graphql-markdown/printer-legacy": "^1.3.0"
+        "@graphql-markdown/core": "^1.4.1",
+        "@graphql-markdown/printer-legacy": "^1.3.1"
       },
       "engines": {
         "node": ">=16.14"
@@ -9830,7 +9830,7 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/utils": "^1.4.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -32,7 +32,7 @@
     "@graphql-markdown/utils": "^1.4.0"
   },
   "peerDependencies": {
-    "@graphql-markdown/printer-legacy": "^1.3.0",
+    "@graphql-markdown/printer-legacy": "^1.3.1",
     "@graphql-markdown/diff": "^1.0.10",
     "prettier": "^2.8"
   },

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.18.0",
+  "version": "1.18.1",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -31,8 +31,8 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.4.0",
-    "@graphql-markdown/printer-legacy": "^1.3.0"
+    "@graphql-markdown/core": "^1.4.1",
+    "@graphql-markdown/printer-legacy": "^1.3.1"
   },
   "directories": {
     "test": "tests"

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
# Description

Release fix #851 and closes #850. 

---
:bug: Fix the code indentation for fields being incorrect in some cases (#850) by @ljiang-ti in #851.
## What's Changed

### @graphql-markdown/docusaurus@1.18.1
* :package: bump dependency @graphql-markdown/core from 1.4.0 to 1.4.1
* :package: bump dependency @graphql-markdown/printer-legacy from 1.3.0 to 1.3.1

### @graphql-markdown/core@1.4.1
* :package: bump peerDependency @graphql-markdown/printer-legacy from 1.3.0 to 1.3.1

### @graphql-markdown/printer-legacy@1.3.1
* :bug: Fix indentation level in code section by @ljiang-ti in https://github.com/graphql-markdown/graphql-markdown/pull/851

---

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] ~I have made corresponding changes to the documentation.~
- [ ] ~I have added tests that prove my fix is effective or that my changes work.~
- [x] New and existing unit tests pass locally with my changes.
