### PR TITLE
:recycle:  code clean up and doc refresh

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -16,7 +16,7 @@ The base URL to be used by Docusaurus. It will also be used as folder name under
 
 ## `customDirective`
 
-Use these options to render custom directive information for types (see [custom directive](/docs/advanced/custom-directive)).
+Use this option to render directive information for types (see [custom directive](/docs/advanced/custom-directive)).
 
 | Setting           | CLI flag        | Default     |
 | ----------------- | --------------- | ----------- |
@@ -91,9 +91,9 @@ plugins: [
 
 Use a GraphQL directive for creating documentation categories (see [documentation categories](/docs/advanced/group-by-directive)).
 
-| Setting            | CLI flag                                                                 | Default |
-| ------------------ | ------------------------------------------------------------------------ | ------- |
-| `groupByDirective` | <code>-gdb, --groupByDirective <@directive(field&#124;=fallback)></code> | -       |
+| Setting            | CLI flag                                                                 | Default     |
+| ------------------ | ------------------------------------------------------------------------ | ----------- |
+| `groupByDirective` | <code>-gdb, --groupByDirective <@directive(field&#124;=fallback)></code> | `undefined` |
 
 ## `homepage`
 
@@ -215,7 +215,7 @@ The option supports multiple values separated by a space character, eg `--skipDo
 
 | Setting            | CLI flag                 | Default |
 | ------------------ | ------------------------ | ------- |
-| `skipDocDirective` | `--skip <@directive...>` | -       |
+| `skipDocDirective` | `--skip <@directive...>` | `[]`    |
 
 <br/>
 

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -9,29 +9,30 @@ const PACKAGE_NAME = "@graphql-markdown/docusaurus";
 const ASSETS_LOCATION = join(__dirname, "../assets/");
 
 const DEFAULT_OPTIONS = {
-  schema: "./schema.graphql",
-  rootPath: "./docs",
   baseURL: "schema",
-  linkRoot: "/",
-  homepage: join(ASSETS_LOCATION, "generated.md"),
+  customDirective: undefined,
   diffMethod: undefined,
-  tmpDir: join(tmpdir(), PACKAGE_NAME),
+  docOptions: {
+    index: false,
+    pagination: true,
+    toc: true,
+  },
+  groupByDirective: undefined,
+  homepage: join(ASSETS_LOCATION, "generated.md"),
+  linkRoot: "/",
   loaders: {},
   pretty: false,
   printer: "@graphql-markdown/printer-legacy",
-  docOptions: {
-    pagination: true,
-    toc: true,
-    index: false,
-  },
   printTypeOptions: {
+    deprecated: "default",
     parentTypePrefix: true,
     relatedTypeSection: true,
     typeBadges: true,
-    deprecated: "default",
   },
+  rootPath: "./docs",
+  schema: "./schema.graphql",
+  tmpDir: join(tmpdir(), PACKAGE_NAME),
   skipDocDirective: [],
-  customDirective: undefined,
 };
 
 function buildConfig(configFileOpts, cliOpts) {
@@ -50,24 +51,24 @@ function buildConfig(configFileOpts, cliOpts) {
 
   return {
     baseURL,
-    schemaLocation: cliOpts.schema ?? config.schema,
-    outputDir: join(cliOpts.root ?? config.rootPath, baseURL),
-    linkRoot: cliOpts.link ?? config.linkRoot,
-    homepageLocation: cliOpts.homepage ?? config.homepage,
-    diffMethod: getDiffMethod(cliOpts.diff ?? config.diffMethod, cliOpts.force),
-    tmpDir: cliOpts.tmp ?? config.tmpDir,
-    loaders: config.loaders,
-    groupByDirective:
-      parseGroupByOption(cliOpts.groupByDirective) || config.groupByDirective,
-    prettify: cliOpts.pretty ?? config.pretty,
-    docOptions: getDocOptions(cliOpts, config.docOptions),
-    printTypeOptions: gePrintTypeOptions(cliOpts, config.printTypeOptions),
-    printer: config.printer,
-    skipDocDirective,
     customDirective: getCustomDirectives(
       config.customDirective,
       skipDocDirective,
     ),
+    diffMethod: getDiffMethod(cliOpts.diff ?? config.diffMethod, cliOpts.force),
+    docOptions: getDocOptions(cliOpts, config.docOptions),
+    groupByDirective:
+      parseGroupByOption(cliOpts.groupByDirective) || config.groupByDirective,
+    homepageLocation: cliOpts.homepage ?? config.homepage,
+    linkRoot: cliOpts.link ?? config.linkRoot,
+    loaders: config.loaders,
+    outputDir: join(cliOpts.root ?? config.rootPath, baseURL),
+    prettify: cliOpts.pretty ?? config.pretty,
+    printer: config.printer,
+    printTypeOptions: gePrintTypeOptions(cliOpts, config.printTypeOptions),
+    schemaLocation: cliOpts.schema ?? config.schema,
+    skipDocDirective,
+    tmpDir: cliOpts.tmp ?? config.tmpDir,
   };
 }
 
@@ -181,11 +182,11 @@ function parseGroupByOption(groupOptions) {
 }
 
 module.exports = {
-  buildConfig,
-  getSkipDocDirectives,
-  getSkipDocDirective,
-  parseGroupByOption,
-  getCustomDirectives,
-  DEFAULT_OPTIONS,
   ASSETS_LOCATION,
+  buildConfig,
+  DEFAULT_OPTIONS,
+  getCustomDirectives,
+  getSkipDocDirective,
+  getSkipDocDirectives,
+  parseGroupByOption,
 };


### PR DESCRIPTION
# Description

Quick doc refresh for settings to ensure that default values match code, and clean up of the `settings.js` in core package.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
