### PR TITLE
:bug: remove circular declaration of getCustomTags

### DIFF
--- a/packages/printer-legacy/src/badge.js
+++ b/packages/printer-legacy/src/badge.js
@@ -6,7 +6,6 @@ const {
 
 const { getLinkCategory } = require("./link");
 const { getGroup } = require("./group");
-const { getCustomTags } = require("./directive");
 
 const DEFAULT_CSS_CLASSNAME = "badge--secondary";
 
@@ -65,7 +64,6 @@ function printBadge({ text, classname }) {
 
 module.exports = {
   getTypeBadges,
-  getCustomTags,
   printBadge,
   printBadges,
 };


### PR DESCRIPTION
# Description

Remove circular declaration of `getCustomTags`

```
(node:24) Warning: Accessing non-existent property 'getCustomTags' of module exports inside circular dependency
     +build-examples | (Use `node --trace-warnings ...` to show where the warning was created)
```

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
