### PR TITLE
:bookmark:  release 1.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -148,8 +148,9 @@
     },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
+      "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -344,8 +345,9 @@
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz",
+      "integrity": "sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.0"
       },
@@ -383,8 +385,9 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.21.0.tgz",
+      "integrity": "sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -481,8 +484,9 @@
     },
     "node_modules/@babel/plugin-proposal-class-properties": {
       "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
+      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -515,8 +519,9 @@
     },
     "node_modules/@babel/plugin-proposal-private-methods": {
       "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
+      "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -599,11 +604,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.18.6",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.21.4.tgz",
+      "integrity": "sha512-5hewiLct5OKyh6PLKEYaFclcqtIgCb6bmELouxjF6up5q3Sov7rOayW4RwhbaBL0dit8rA80GNfY+UuDp2mBbQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.18.6"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -693,11 +699,29 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.20.0",
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.21.4.tgz",
+      "integrity": "sha512-xz0D39NvhQn4t4RNsHmDnnsaQizIlUkdtYvLs8La1BlfjQ6JEwxkJGeqJMW2tAXx+q6H+WFuUTXNdYVpEya0YA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.19.0"
+        "@babel/helper-plugin-utils": "^7.20.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.5.tgz",
+      "integrity": "sha512-OVryBEgKUbtqMoB7eG2rs6UFexJi6Zj6FDXx+esBLPTCxCNxAY9o+8Di7IsUGJ+AVhp5ncK0fxWUBd0/1gPhrQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.21.5",
+        "@babel/helper-plugin-utils": "^7.21.5",
+        "@babel/helper-simple-access": "^7.21.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -707,14 +731,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.21.3",
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.22.3.tgz",
+      "integrity": "sha512-pyjnCIniO5PNaEuGxT28h0HbMru3qCVrMqVgVOz/krComdIrY9W6FCLBq9NWHY8HDGaUlan+UhmZElDENIfCcw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-create-class-features-plugin": "^7.21.0",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-typescript": "^7.20.0"
+        "@babel/helper-create-class-features-plugin": "^7.22.1",
+        "@babel/helper-plugin-utils": "^7.21.5",
+        "@babel/plugin-syntax-typescript": "^7.21.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -724,13 +749,16 @@
       }
     },
     "node_modules/@babel/preset-typescript": {
-      "version": "7.21.0",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.21.5.tgz",
+      "integrity": "sha512-iqe3sETat5EOrORXiQ6rWfoOg2y68Cs75B9wNxdPW4kixJxh7aXQE1KPdWLDniC24T/6dSnguF33W9j/ZZQcmA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-plugin-utils": "^7.21.5",
         "@babel/helper-validator-option": "^7.21.0",
-        "@babel/plugin-transform-typescript": "^7.21.0"
+        "@babel/plugin-syntax-jsx": "^7.21.4",
+        "@babel/plugin-transform-modules-commonjs": "^7.21.5",
+        "@babel/plugin-transform-typescript": "^7.21.3"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2203,52 +2231,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@stryker-mutator/core/node_modules/glob": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.6.tgz",
-      "integrity": "sha512-U/rnDpXJGF414QQQZv5uVsabTVxMSwzS5CH0p3DRCIV6ownl4f7PzGnkGmvlum2wB+9RlJWJZ6ACU1INnBqiPA==",
-      "dev": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.0.3",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2",
-        "path-scurry": "^1.7.0"
-      },
-      "bin": {
-        "glob": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/minimatch": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
-      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@stryker-mutator/core/node_modules/minipass": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/@stryker-mutator/core/node_modules/tslib": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
@@ -2603,8 +2585,9 @@
     },
     "node_modules/angular-html-parser": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-4.0.1.tgz",
+      "integrity": "sha512-x9SLf2jNNh3nG+haVIwKX/GVW8PcvSRmkeT9WqTDYSAVuwT9IzwEyVm09FCZpOo/dtFRxE9vaNXqcAf/MIxphg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -2928,8 +2911,9 @@
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3071,8 +3055,9 @@
     },
     "node_modules/chalk": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -3149,8 +3134,9 @@
     },
     "node_modules/cli-width": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.0.0.tgz",
+      "integrity": "sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">= 12"
       }
@@ -4604,8 +4590,9 @@
     },
     "node_modules/figures": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^5.0.0",
         "is-unicode-supported": "^1.2.0"
@@ -4619,8 +4606,9 @@
     },
     "node_modules/figures/node_modules/escape-string-regexp": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -4943,6 +4931,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.2.6.tgz",
+      "integrity": "sha512-U/rnDpXJGF414QQQZv5uVsabTVxMSwzS5CH0p3DRCIV6ownl4f7PzGnkGmvlum2wB+9RlJWJZ6ACU1INnBqiPA==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.0.3",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2",
+        "path-scurry": "^1.7.0"
+      },
+      "bin": {
+        "glob": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -6083,8 +6093,9 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -7906,12 +7917,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.7",
       "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
+      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -7942,8 +7977,9 @@
     },
     "node_modules/mute-stream": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -8328,15 +8364,6 @@
       "dev": true,
       "engines": {
         "node": "14 || >=16.14"
-      }
-    },
-    "node_modules/path-scurry/node_modules/minipass": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-6.0.2.tgz",
-      "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-type": {
@@ -10060,10 +10087,10 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.4.1"
+        "@graphql-markdown/utils": "^1.5.0"
       },
       "devDependencies": {
         "@graphql-markdown/printer-legacy": "^1.1.3"
@@ -10072,8 +10099,8 @@
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@graphql-markdown/diff": "^1.0.11",
-        "@graphql-markdown/printer-legacy": "^1.3.2",
+        "@graphql-markdown/diff": "^1.0.12",
+        "@graphql-markdown/printer-legacy": "^1.4.0",
         "prettier": "^2.8"
       },
       "peerDependenciesMeta": {
@@ -10090,11 +10117,11 @@
     },
     "packages/diff": {
       "name": "@graphql-markdown/diff",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
         "@graphql-inspector/core": "^4.2.1",
-        "@graphql-markdown/utils": "^1.4.1",
+        "@graphql-markdown/utils": "^1.5.0",
         "@graphql-tools/graphql-file-loader": "^8.0.0",
         "@graphql-tools/load": "^8.0.0"
       },
@@ -10104,11 +10131,11 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.18.2",
+      "version": "1.19.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.4.2",
-        "@graphql-markdown/printer-legacy": "^1.3.2"
+        "@graphql-markdown/core": "^1.5.0",
+        "@graphql-markdown/printer-legacy": "^1.4.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -10116,10 +10143,10 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.4.1"
+        "@graphql-markdown/utils": "^1.5.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -10127,7 +10154,7 @@
     },
     "packages/utils": {
       "name": "@graphql-markdown/utils",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/load": "^8.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.4.2",
+  "version": "1.5.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -29,11 +29,11 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.4.1"
+    "@graphql-markdown/utils": "^1.5.0"
   },
   "peerDependencies": {
-    "@graphql-markdown/printer-legacy": "^1.3.2",
-    "@graphql-markdown/diff": "^1.0.11",
+    "@graphql-markdown/printer-legacy": "^1.4.0",
+    "@graphql-markdown/diff": "^1.0.12",
     "prettier": "^2.8"
   },
   "peerDependenciesMeta": {

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.11",
+  "version": "1.0.12",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@graphql-inspector/core": "^4.2.1",
-    "@graphql-markdown/utils": "^1.4.1",
+    "@graphql-markdown/utils": "^1.5.0",
     "@graphql-tools/graphql-file-loader": "^8.0.0",
     "@graphql-tools/load": "^8.0.0"
   },

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.18.2",
+  "version": "1.19.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -31,8 +31,8 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.4.2",
-    "@graphql-markdown/printer-legacy": "^1.3.2"
+    "@graphql-markdown/core": "^1.5.0",
+    "@graphql-markdown/printer-legacy": "^1.4.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.3.2",
+  "version": "1.4.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -22,7 +22,7 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.4.1"
+    "@graphql-markdown/utils": "^1.5.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.4.1",
+  "version": "1.5.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
# Description

> :warning: *This release introduces minor breaking changes, see section breaking changes.*

---

:label: Building upon `customDirective` released in 1.18.0, we added to it a new option `tag` that allows one to display custom badges (tags) in the documentation pages. 

The feature is an extension of the `customDirective` by using the already available directive processing. It works the same way as `descriptor`, and also come with an helper `directiveTag`... more details in the [documentation](https://graphql-markdown.github.io/docs/advanced/custom-directive).

```js
  customDirective: {
    beta: {
      tag: (directive) => ({
        text: directive?.name.toUpperCase(),
        classname: "badge--danger",
      }),
    },
```


![Screenshot from 2023-06-03 11-27-49](https://github.com/graphql-markdown/graphql-markdown/assets/324670/985f3868-ac9f-4fdf-8069-43a68c344718)

![Screenshot from 2023-06-03 11-28-21](https://github.com/graphql-markdown/graphql-markdown/assets/324670/c245d30c-e1d8-403f-bcaa-fa1323e6f565)

## Breaking changes

* Since tags have now a dedicated handler, the directive declared in `customDirective` for `descriptor` won't display a badge. **This is a breaking change**, but a helper `directiveTag` is provided for backward compatibility. 
Users who want to keep the previous behavior just need to declare `tag: directiveTag` for each directive declared.

  ```js
  auth: {
        descriptor: (directive, type) =>
          directiveDescriptor(
            directive,
            type,
            "This requires the current user to be in `${requires}` role.",
          ),
        tag: directiveTag,
      },
  ```

* The badge functions have been refactored to support custom CSS className. 
While refactoring, I realized some redundancy regarding `deprecated` displayed both as a badge and as a warning badge at description level. This is was not great UX, and the **deprecated "warning badge" has been changed into an admonition**, clearer UI.

  ![Screenshot from 2023-06-03 08-22-06](https://github.com/graphql-markdown/graphql-markdown/assets/324670/13f62166-8765-4816-8e79-000615035e6f)

* Last change is the **change of position of the custom directive descriptions** that are now *after* the type description instead of before.

  ![Screenshot from 2023-06-03 11-25-14](https://github.com/graphql-markdown/graphql-markdown/assets/324670/d30059b5-3a57-4f99-9d44-185591afedf1)

## What's Changed

### @graphql-markdown/docusaurus@1.19.0
* :package: bump dependency @graphql-markdown/core from 1.4.2 to 1.5.0
* :package: bump dependency @graphql-markdown/printer-legacy from 1.3.1 to 1.3.2
* :sparkles:  add custom logger support by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/869

### @graphql-markdown/core@1.5.0
* :package: bump dependency @graphql-markdown/utils from 1.4.1 to 1.5.0
* :package: bump peerDependency @graphql-markdown/printer-legacy from 1.3.2 to 1.4.0
* :package: bump peerDependency @graphql-markdown/diff from 1.0.11 to 1.0.12
* :sparkles: custom tags for types by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/863
* :sparkles:  add custom logger support by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/869

### @graphql-markdown/printer-legacy@1.4.0
* :package: bump dependency @graphql-markdown/utils from 1.4.1 to 1.5.0
* :sparkles: custom tags for types by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/863

### @graphql-markdown/diff@1.0.12
* :package: bump dependency @graphql-markdown/utils from 1.4.0 to 1.4.1

### @graphql-markdown/utils@1.5.0
* :package: fix(deps): update graphql-tools monorepo to v8 (major) by @renovate in https://github.com/graphql-markdown/graphql-markdown/pull/854
* :sparkles: custom tags for types by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/863
* :sparkles:  add custom logger support by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/869


---

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
