### PR TITLE
:sparkles:  add support for graphql-config (#828)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
     "edno",
     "foobaz",
     "GraphQLID",
+    "graphqlrc",
     "Grégory",
     "groupbydirective",
     "Heitz",

--- a/Earthfile
+++ b/Earthfile
@@ -65,6 +65,7 @@ smoke-init:
   COPY ./packages/docusaurus/scripts/config-plugin.js ./config-plugin.js
   COPY ./website/src/css/custom.css ./src/css/custom.css
   COPY --dir ./packages/docusaurus/tests/__data__ ./data
+  COPY ./packages/docusaurus/tests/__data__/.graphqlrc ./.graphqlrc
   COPY ./website/static/img ./static/img
   RUN node config-plugin.js
 
@@ -72,7 +73,8 @@ smoke-test:
   FROM +smoke-init
   WORKDIR /docusaurus2
   RUN npm config set update-notifier false
-  RUN npm install -g fs-extra jest
+  RUN npm install -g fs-extra jest 
+  RUN npm install graphql-config
   COPY --dir ./packages/docusaurus/tests/e2e/specs ./__tests__/e2e/specs
   COPY --dir ./packages/docusaurus/tests/helpers ./__tests__/helpers
   COPY ./packages/docusaurus/tests/e2e/jest.config.js ./jest.config.js

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,6 +80,13 @@ For more details about `navbar`, please refer to Docusaurus [documentation](http
 
 Instead of defining the configuration alongside the Docusaurus config file, you can use a [GraphQL Config](https://the-guild.dev/graphql/config/docs/user/usage) file (multiple formats supported).
 
+You need to install the package `graphql-config`.
+
+```bash
+npm install graphql-config
+```
+
+
 ```js title="docusaurus.config.js"
 module.exports = {
   // ...

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 You can define some or all of the plugin settings directly at the plugin level in the Docusaurus configuration file `docusaurus.config.js`:
 
-```js
+```js title="docusaurus.config.js"
 module.exports = {
   // ...
   plugins: [
@@ -29,14 +29,14 @@ module.exports = {
 All settings are described in the page [settings](/docs/settings).
 
 :::tip
-If you want to use several GraphQL schemas, read our page for [additional schema](/docs/advanced/additional-schema).
+If you want to use several GraphQL schemas, read our guide for **[additional schema](/docs/advanced/additional-schema)**.
 :::
 
 ## Sidebar
 
 A sidebar file `sidebar-schema.js` will be generated for the documentation, and you need to add a reference to `sidebar-schema.js` into the default `sidebar.js`.
 
-```js
+```js title="sidebar.js"
 module.exports = {
   docsSidebar: [
     // ... your site's sidebar
@@ -59,7 +59,7 @@ See [docs multi-instance](/docs/advanced/docs-multi-instance) for sidebar settin
 
 You will also need to add a link to your documentation on your site. One way to do it is to add it to your site's `navbar` in `docusaurus.config.js`:
 
-```js
+```js title="docusaurus.config.js"
 module.exports = {
   // ...
   navbar: {
@@ -75,3 +75,49 @@ module.exports = {
 ```
 
 For more details about `navbar`, please refer to Docusaurus [documentation](https://docusaurus.io/docs/api/themes/configuration#navbar).
+
+## GraphQL Config
+
+Instead of defining the configuration alongside the Docusaurus config file, you can use a [GraphQL Config](https://the-guild.dev/graphql/config/docs/user/usage) file (multiple formats supported).
+
+```js title="docusaurus.config.js"
+module.exports = {
+  // ...
+  plugins: [
+    [
+      "@graphql-markdown/docusaurus",
+    ],
+  ],
+};
+```
+
+```yaml title=".graphqlrc"
+schema: "https://graphql.anilist.co/"
+extensions:
+  graphql-markdown:
+    linkRoot: "/examples/default"
+    baseURL: "."
+    homepage: "data/anilist.md"
+    loaders:
+      UrlLoader:
+        module: "@graphql-tools/url-loader"
+        options: 
+          method: "POST"
+    printTypeOptions:
+      deprecated: "group"
+    docOptions:
+      pagination: false,
+      toc: false
+```
+
+:::caution
+Note that **`schema` is not part of the extension configuration**, but part of the default graphql-config configuration.
+:::
+
+**Current limitations:**
+
+* single schema only, no schema stitching
+* projects are not supported, only default
+* `include`, `exclude`, `documents` and glob pattern are not supported
+* schema options (eg headers) are not supported, instead use [loaders options](/docs/advanced/schema-loading)
+* not compatible with [multiple schemas](/docs/advanced/additional-schema)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -15,3 +15,4 @@ The `@graphql-markdown/docusaurus` package extends the Docusaurus CLI with comma
 - MDX generated are fully compatible with `plugin-content-docs`
 - Use any schema loader compatible with `@graphql-tools/load`
 - Group types into categories using directives
+- Support of GraphQL config (beta)

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,8 +63,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz",
       "integrity": "sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "node-fetch": "^2.6.1"
       },
@@ -76,7 +75,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
       "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.22.5"
       },
@@ -395,7 +394,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
       "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -427,7 +426,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
       "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
@@ -441,7 +440,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -453,7 +452,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -467,7 +466,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -476,7 +475,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -485,7 +484,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -1271,8 +1270,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.0.tgz",
       "integrity": "sha512-lT9/1XmPSYzBcEybXPLsuA6C5E0t8438PVUELABcqdvwHgZ3VOOx29MLBEqhr2oewOlDChH6PXNkfxoOoAuzRg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "dataloader": "^2.2.2",
@@ -1290,8 +1288,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.0.0.tgz",
       "integrity": "sha512-ZW5/7Q0JqUM+guwn8/cM/1Hz16Zvj6WR6r3gnOwoPO7a9bCbe8QTCk4itT/EO+RiGT8RLUPYaunWR9jxfNqqOA==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@graphql-tools/batch-execute": "^9.0.0",
         "@graphql-tools/executor": "^1.0.0",
@@ -1312,8 +1309,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.1.0.tgz",
       "integrity": "sha512-+1wmnaUHETSYxiK/ELsT60x584Rw3QKBB7F/7fJ83HKPnLifmE2Dm/K9Eyt6L0Ppekf1jNUbWBpmBGb8P5hAeg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "@graphql-typed-document-node/core": "3.2.0",
@@ -1332,8 +1328,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-1.0.1.tgz",
       "integrity": "sha512-mcOEYr+p+Mex03cGtQ+QG4ofh83BxLlVAegkBoNIzb06KH3c7FgmlkRysiEaDtr8L4FjKzNo8LVfzgqaYRRylg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "@repeaterjs/repeater": "3.0.4",
@@ -1354,8 +1349,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.0.0.tgz",
       "integrity": "sha512-7R9IWRN1Iszyayd4qgguITLLTmRUZ3wSS5umK0xwShB8mFQ5cSsVx6rewPhGIwGEenN6e9ahwcGX9ytuLlw55g==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "@repeaterjs/repeater": "^3.0.4",
@@ -1377,8 +1371,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.0.1.tgz",
       "integrity": "sha512-PQrTJ+ncHMEQspBARc2lhwiQFfRAX/z/CsOdZTFjIljOHgRWGAA1DAx7pEN0j6PflbLCfZ3NensNq2jCBwF46w==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "@types/ws": "^8.0.0",
@@ -1431,7 +1424,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.0.tgz",
       "integrity": "sha512-ki6EF/mobBWJjAAC84xNrFMhNfnUFD6Y0rQMGXekrUgY0NdeYXHU0ZUgHzC9O5+55FslqUmAUHABePDHTyZsLg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "globby": "^11.0.3",
@@ -1498,8 +1491,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.0.tgz",
       "integrity": "sha512-rPc9oDzMnycvz+X+wrN3PLrhMBQkG4+sd8EzaFN6dypcssiefgWKToXtRKI8HHK68n2xEq1PyrOpkjHFJB+GwA==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@ardatan/sync-fetch": "^0.0.1",
         "@graphql-tools/delegate": "^10.0.0",
@@ -1541,8 +1533,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.0.tgz",
       "integrity": "sha512-HDOeUUh6UhpiH0WPJUQl44ODt1x5pnMUbOJZ7GjTdGQ7LK0AgVt3ftaAQ9duxLkiAtYJmu5YkULirfZGj4HzDg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@graphql-tools/delegate": "^10.0.0",
         "@graphql-tools/schema": "^10.0.0",
@@ -2420,8 +2411,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
       "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.24",
@@ -2665,7 +2655,7 @@
     },
     "node_modules/@types/node": {
       "version": "18.15.9",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -2692,8 +2682,7 @@
       "version": "8.5.5",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
       "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2830,8 +2819,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
       "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=16.0.0"
       }
@@ -2840,8 +2828,7 @@
       "version": "0.9.7",
       "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.7.tgz",
       "integrity": "sha512-heClS5ctTmoEvVbFd+6ztX0SyQduI3/Q+77vtNApDU/+Mwajy6ugxaoDGgSzJUoQ37McSV09kcGCt1Jcc6z9lQ==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@whatwg-node/node-fetch": "^0.4.6",
         "urlpattern-polyfill": "^9.0.0"
@@ -2854,8 +2841,7 @@
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.6.tgz",
       "integrity": "sha512-9oLD57yW0WWfu4ZtEmybBrx1JfkO4TzDpD2zXlp2Ue3UJplifQRap+MbE0PxRlVWtR4KWsIRamhn7J44DkwoyA==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@whatwg-node/events": "^0.1.0",
         "busboy": "^1.6.0",
@@ -2977,7 +2963,7 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -3203,7 +3189,7 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -3329,8 +3315,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
       "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "streamsearch": "^1.1.0"
       },
@@ -3360,7 +3345,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3591,7 +3576,7 @@
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -3599,7 +3584,7 @@
     },
     "node_modules/color-name": {
       "version": "1.1.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -3828,7 +3813,7 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/conventional-commit-types": {
@@ -3843,8 +3828,8 @@
     },
     "node_modules/cosmiconfig": {
       "version": "8.1.3",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -3998,8 +3983,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
       "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/date-format": {
       "version": "4.0.14",
@@ -4146,8 +4130,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
       "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -4182,7 +4165,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -4893,8 +4876,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
       "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": "^12.20 || >= 14.13"
       },
@@ -4906,8 +4888,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
       "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4958,8 +4939,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
       "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
       }
@@ -4968,8 +4948,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
       "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "punycode": "^1.3.2"
       }
@@ -4978,8 +4957,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -5501,8 +5479,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.0.2.tgz",
       "integrity": "sha512-7TPxOrlbiG0JplSZYCyxn2XQtqVhXomEjXUmWJVSS5ET1nPhOJSsIb/WTwqWhcYX6G0RlHXSj9PLtGTKmxLNGg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "@graphql-tools/graphql-file-loader": "^8.0.0",
         "@graphql-tools/json-file-loader": "^8.0.0",
@@ -5533,8 +5510,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5544,8 +5520,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.3.tgz",
       "integrity": "sha512-lIUdtK5hdofgCTu3aT0sOaHsYR37viUuIc0rwnnDXImbwFRcumyLMeZaM0t0I/fgxS6s6JMfu0rLD1Wz9pv1ng==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5557,8 +5532,7 @@
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz",
       "integrity": "sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -5736,7 +5710,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -5751,7 +5725,7 @@
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
       "version": "4.0.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6349,7 +6323,7 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-bigint": {
@@ -6624,8 +6598,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
       "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "peerDependencies": {
         "ws": "*"
       }
@@ -8049,8 +8022,7 @@
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
       "integrity": "sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8059,11 +8031,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8121,7 +8093,7 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -8186,7 +8158,7 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -8466,8 +8438,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/meros/-/meros-1.3.0.tgz",
       "integrity": "sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=13"
       },
@@ -8578,8 +8549,7 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
       "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -8884,7 +8854,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -8895,7 +8865,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -9786,8 +9756,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -9805,8 +9774,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
       "integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -10118,8 +10086,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -10416,8 +10383,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
       "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -10487,15 +10453,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -10689,8 +10653,7 @@
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "optional": true,
-      "peer": true,
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10799,7 +10762,8 @@
         "@graphql-markdown/utils": "^1.5.0"
       },
       "devDependencies": {
-        "@graphql-markdown/printer-legacy": "^1.1.3"
+        "@graphql-markdown/printer-legacy": "^1.1.3",
+        "graphql-config": "^5.0.2"
       },
       "engines": {
         "node": ">=16.14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,8 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz",
       "integrity": "sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "node-fetch": "^2.6.1"
       },
@@ -74,6 +76,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
       "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "devOptional": true,
       "dependencies": {
         "@babel/highlight": "^7.22.5"
       },
@@ -392,6 +395,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
       "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+      "devOptional": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -423,6 +427,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
       "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+      "devOptional": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
@@ -436,6 +441,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "devOptional": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -447,6 +453,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -460,6 +467,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "devOptional": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -468,6 +476,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "devOptional": true,
       "engines": {
         "node": ">=4"
       }
@@ -476,6 +485,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "devOptional": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -1199,6 +1209,8 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.0.tgz",
       "integrity": "sha512-lT9/1XmPSYzBcEybXPLsuA6C5E0t8438PVUELABcqdvwHgZ3VOOx29MLBEqhr2oewOlDChH6PXNkfxoOoAuzRg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "dataloader": "^2.2.2",
@@ -1216,6 +1228,8 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.0.0.tgz",
       "integrity": "sha512-ZW5/7Q0JqUM+guwn8/cM/1Hz16Zvj6WR6r3gnOwoPO7a9bCbe8QTCk4itT/EO+RiGT8RLUPYaunWR9jxfNqqOA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@graphql-tools/batch-execute": "^9.0.0",
         "@graphql-tools/executor": "^1.0.0",
@@ -1236,6 +1250,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.1.0.tgz",
       "integrity": "sha512-+1wmnaUHETSYxiK/ELsT60x584Rw3QKBB7F/7fJ83HKPnLifmE2Dm/K9Eyt6L0Ppekf1jNUbWBpmBGb8P5hAeg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "@graphql-typed-document-node/core": "3.2.0",
@@ -1254,6 +1270,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-1.0.1.tgz",
       "integrity": "sha512-mcOEYr+p+Mex03cGtQ+QG4ofh83BxLlVAegkBoNIzb06KH3c7FgmlkRysiEaDtr8L4FjKzNo8LVfzgqaYRRylg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "@repeaterjs/repeater": "3.0.4",
@@ -1274,6 +1292,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.0.0.tgz",
       "integrity": "sha512-7R9IWRN1Iszyayd4qgguITLLTmRUZ3wSS5umK0xwShB8mFQ5cSsVx6rewPhGIwGEenN6e9ahwcGX9ytuLlw55g==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "@repeaterjs/repeater": "^3.0.4",
@@ -1295,6 +1315,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.0.1.tgz",
       "integrity": "sha512-PQrTJ+ncHMEQspBARc2lhwiQFfRAX/z/CsOdZTFjIljOHgRWGAA1DAx7pEN0j6PflbLCfZ3NensNq2jCBwF46w==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "@types/ws": "^8.0.0",
@@ -1347,6 +1369,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.0.tgz",
       "integrity": "sha512-ki6EF/mobBWJjAAC84xNrFMhNfnUFD6Y0rQMGXekrUgY0NdeYXHU0ZUgHzC9O5+55FslqUmAUHABePDHTyZsLg==",
+      "devOptional": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "globby": "^11.0.3",
@@ -1413,6 +1436,8 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.0.tgz",
       "integrity": "sha512-rPc9oDzMnycvz+X+wrN3PLrhMBQkG4+sd8EzaFN6dypcssiefgWKToXtRKI8HHK68n2xEq1PyrOpkjHFJB+GwA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@ardatan/sync-fetch": "^0.0.1",
         "@graphql-tools/delegate": "^10.0.0",
@@ -1454,6 +1479,8 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.0.tgz",
       "integrity": "sha512-HDOeUUh6UhpiH0WPJUQl44ODt1x5pnMUbOJZ7GjTdGQ7LK0AgVt3ftaAQ9duxLkiAtYJmu5YkULirfZGj4HzDg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@graphql-tools/delegate": "^10.0.0",
         "@graphql-tools/schema": "^10.0.0",
@@ -2330,7 +2357,9 @@
     "node_modules/@repeaterjs/repeater": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
-      "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA=="
+      "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.24",
@@ -2574,6 +2603,7 @@
     },
     "node_modules/@types/node": {
       "version": "18.15.9",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -2600,6 +2630,8 @@
       "version": "8.5.5",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
       "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2736,6 +2768,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
       "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=16.0.0"
       }
@@ -2744,6 +2778,8 @@
       "version": "0.9.7",
       "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.7.tgz",
       "integrity": "sha512-heClS5ctTmoEvVbFd+6ztX0SyQduI3/Q+77vtNApDU/+Mwajy6ugxaoDGgSzJUoQ37McSV09kcGCt1Jcc6z9lQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@whatwg-node/node-fetch": "^0.4.6",
         "urlpattern-polyfill": "^9.0.0"
@@ -2756,6 +2792,8 @@
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.6.tgz",
       "integrity": "sha512-9oLD57yW0WWfu4ZtEmybBrx1JfkO4TzDpD2zXlp2Ue3UJplifQRap+MbE0PxRlVWtR4KWsIRamhn7J44DkwoyA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@whatwg-node/events": "^0.1.0",
         "busboy": "^1.6.0",
@@ -2877,6 +2915,7 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "devOptional": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -3102,6 +3141,7 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -3227,6 +3267,8 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
       "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "streamsearch": "^1.1.0"
       },
@@ -3256,6 +3298,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3486,6 +3529,7 @@
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -3493,6 +3537,7 @@
     },
     "node_modules/color-name": {
       "version": "1.1.3",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -3721,6 +3766,7 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/conventional-commit-types": {
@@ -3736,6 +3782,7 @@
     "node_modules/cosmiconfig": {
       "version": "8.1.3",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -3888,7 +3935,9 @@
     "node_modules/dataloader": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
-      "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g=="
+      "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/date-format": {
       "version": "4.0.14",
@@ -4035,6 +4084,8 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
       "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -4069,6 +4120,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -4779,6 +4831,8 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
       "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20 || >= 14.13"
       },
@@ -4789,7 +4843,9 @@
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4840,6 +4896,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
       "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
       }
@@ -4848,6 +4906,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
       "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "punycode": "^1.3.2"
       }
@@ -4855,7 +4915,9 @@
     "node_modules/fast-url-parser/node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -5377,6 +5439,8 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.0.2.tgz",
       "integrity": "sha512-7TPxOrlbiG0JplSZYCyxn2XQtqVhXomEjXUmWJVSS5ET1nPhOJSsIb/WTwqWhcYX6G0RlHXSj9PLtGTKmxLNGg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@graphql-tools/graphql-file-loader": "^8.0.0",
         "@graphql-tools/json-file-loader": "^8.0.0",
@@ -5407,6 +5471,8 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5416,6 +5482,8 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.3.tgz",
       "integrity": "sha512-lIUdtK5hdofgCTu3aT0sOaHsYR37viUuIc0rwnnDXImbwFRcumyLMeZaM0t0I/fgxS6s6JMfu0rLD1Wz9pv1ng==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5427,6 +5495,8 @@
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz",
       "integrity": "sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5605,6 +5675,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -5619,6 +5690,7 @@
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
       "version": "4.0.0",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6216,6 +6288,7 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-bigint": {
@@ -6490,6 +6563,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
       "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "optional": true,
+      "peer": true,
       "peerDependencies": {
         "ws": "*"
       }
@@ -7913,6 +7988,8 @@
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
       "integrity": "sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==",
+      "optional": true,
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7920,10 +7997,12 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "devOptional": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7981,6 +8060,7 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -8045,6 +8125,7 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -8324,6 +8405,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/meros/-/meros-1.3.0.tgz",
       "integrity": "sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=13"
       },
@@ -8434,6 +8517,8 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
       "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -8738,6 +8823,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -8748,6 +8834,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -9638,6 +9725,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -9654,7 +9743,9 @@
     "node_modules/string-env-interpolation": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
-      "integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg=="
+      "integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -9966,7 +10057,9 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -10262,7 +10355,9 @@
     "node_modules/urlpattern-polyfill": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g=="
+      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -10331,12 +10426,16 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -10530,6 +10629,8 @@
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10635,8 +10736,7 @@
       "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.5.0",
-        "graphql-config": "^5.0.2"
+        "@graphql-markdown/utils": "^1.5.0"
       },
       "devDependencies": {
         "@graphql-markdown/printer-legacy": "^1.1.3"
@@ -10647,6 +10747,7 @@
       "peerDependencies": {
         "@graphql-markdown/diff": "^1.0.12",
         "@graphql-markdown/printer-legacy": "^1.4.0",
+        "graphql-config": "^5.0.2",
         "prettier": "^2.8"
       },
       "peerDependenciesMeta": {
@@ -10654,6 +10755,9 @@
           "optional": true
         },
         "@graphql-markdown/printer-legacy": {
+          "optional": true
+        },
+        "graphql-config": {
           "optional": true
         },
         "prettier": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,7 @@
         "@graphql-markdown/docusaurus": "file:packages/docusaurus",
         "@graphql-markdown/printer-legacy": "file:packages/printer-legacy",
         "@graphql-markdown/tools-config": "file:config",
-        "@graphql-markdown/utils": "file:packages/utils",
-        "chalk": "^5.3.0"
+        "@graphql-markdown/utils": "file:packages/utils"
       },
       "devDependencies": {
         "@graphql-tools/graphql-file-loader": "8.0.0",
@@ -60,11 +59,21 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@ardatan/sync-fetch": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz",
+      "integrity": "sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==",
+      "dependencies": {
+        "node-fetch": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
       "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.22.5"
       },
@@ -383,7 +392,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
       "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -415,7 +423,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
       "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
@@ -429,7 +436,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -441,7 +447,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -455,7 +460,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -464,7 +468,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -473,7 +476,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -1193,6 +1195,120 @@
       "resolved": "packages/utils",
       "link": true
     },
+    "node_modules/@graphql-tools/batch-execute": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.0.tgz",
+      "integrity": "sha512-lT9/1XmPSYzBcEybXPLsuA6C5E0t8438PVUELABcqdvwHgZ3VOOx29MLBEqhr2oewOlDChH6PXNkfxoOoAuzRg==",
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.0",
+        "dataloader": "^2.2.2",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/delegate": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.0.0.tgz",
+      "integrity": "sha512-ZW5/7Q0JqUM+guwn8/cM/1Hz16Zvj6WR6r3gnOwoPO7a9bCbe8QTCk4itT/EO+RiGT8RLUPYaunWR9jxfNqqOA==",
+      "dependencies": {
+        "@graphql-tools/batch-execute": "^9.0.0",
+        "@graphql-tools/executor": "^1.0.0",
+        "@graphql-tools/schema": "^10.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "dataloader": "^2.2.2",
+        "tslib": "^2.5.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/executor": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.1.0.tgz",
+      "integrity": "sha512-+1wmnaUHETSYxiK/ELsT60x584Rw3QKBB7F/7fJ83HKPnLifmE2Dm/K9Eyt6L0Ppekf1jNUbWBpmBGb8P5hAeg==",
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.0",
+        "@graphql-typed-document-node/core": "3.2.0",
+        "@repeaterjs/repeater": "^3.0.4",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/executor-graphql-ws": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-1.0.1.tgz",
+      "integrity": "sha512-mcOEYr+p+Mex03cGtQ+QG4ofh83BxLlVAegkBoNIzb06KH3c7FgmlkRysiEaDtr8L4FjKzNo8LVfzgqaYRRylg==",
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.0",
+        "@repeaterjs/repeater": "3.0.4",
+        "@types/ws": "^8.0.0",
+        "graphql-ws": "5.14.0",
+        "isomorphic-ws": "5.0.0",
+        "tslib": "^2.4.0",
+        "ws": "8.13.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/executor-http": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.0.0.tgz",
+      "integrity": "sha512-7R9IWRN1Iszyayd4qgguITLLTmRUZ3wSS5umK0xwShB8mFQ5cSsVx6rewPhGIwGEenN6e9ahwcGX9ytuLlw55g==",
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.0",
+        "@repeaterjs/repeater": "^3.0.4",
+        "@whatwg-node/fetch": "^0.9.0",
+        "dset": "^3.1.2",
+        "extract-files": "^11.0.0",
+        "meros": "^1.2.1",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/executor-legacy-ws": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.0.1.tgz",
+      "integrity": "sha512-PQrTJ+ncHMEQspBARc2lhwiQFfRAX/z/CsOdZTFjIljOHgRWGAA1DAx7pEN0j6PflbLCfZ3NensNq2jCBwF46w==",
+      "dependencies": {
+        "@graphql-tools/utils": "^10.0.0",
+        "@types/ws": "^8.0.0",
+        "isomorphic-ws": "5.0.0",
+        "tslib": "^2.4.0",
+        "ws": "8.13.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@graphql-tools/graphql-file-loader": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.0.tgz",
@@ -1231,7 +1347,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.0.tgz",
       "integrity": "sha512-ki6EF/mobBWJjAAC84xNrFMhNfnUFD6Y0rQMGXekrUgY0NdeYXHU0ZUgHzC9O5+55FslqUmAUHABePDHTyZsLg==",
-      "dev": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "globby": "^11.0.3",
@@ -1294,6 +1409,32 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@graphql-tools/url-loader": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.0.tgz",
+      "integrity": "sha512-rPc9oDzMnycvz+X+wrN3PLrhMBQkG4+sd8EzaFN6dypcssiefgWKToXtRKI8HHK68n2xEq1PyrOpkjHFJB+GwA==",
+      "dependencies": {
+        "@ardatan/sync-fetch": "^0.0.1",
+        "@graphql-tools/delegate": "^10.0.0",
+        "@graphql-tools/executor-graphql-ws": "^1.0.0",
+        "@graphql-tools/executor-http": "^1.0.0",
+        "@graphql-tools/executor-legacy-ws": "^1.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "@graphql-tools/wrap": "^10.0.0",
+        "@types/ws": "^8.0.0",
+        "@whatwg-node/fetch": "^0.9.0",
+        "isomorphic-ws": "^5.0.0",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.11",
+        "ws": "^8.12.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@graphql-tools/utils": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.0.tgz",
@@ -1301,6 +1442,24 @@
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/wrap": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.0.tgz",
+      "integrity": "sha512-HDOeUUh6UhpiH0WPJUQl44ODt1x5pnMUbOJZ7GjTdGQ7LK0AgVt3ftaAQ9duxLkiAtYJmu5YkULirfZGj4HzDg==",
+      "dependencies": {
+        "@graphql-tools/delegate": "^10.0.0",
+        "@graphql-tools/schema": "^10.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "tslib": "^2.4.0",
+        "value-or-promise": "^1.0.12"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -2168,6 +2327,11 @@
         "node": ">=14"
       }
     },
+    "node_modules/@repeaterjs/repeater": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
+      "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA=="
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.24",
       "dev": true,
@@ -2410,7 +2574,6 @@
     },
     "node_modules/@types/node": {
       "version": "18.15.9",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -2432,6 +2595,14 @@
       "version": "2.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
+      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.23",
@@ -2561,6 +2732,41 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@whatwg-node/events": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
+      "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/fetch": {
+      "version": "0.9.7",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.7.tgz",
+      "integrity": "sha512-heClS5ctTmoEvVbFd+6ztX0SyQduI3/Q+77vtNApDU/+Mwajy6ugxaoDGgSzJUoQ37McSV09kcGCt1Jcc6z9lQ==",
+      "dependencies": {
+        "@whatwg-node/node-fetch": "^0.4.6",
+        "urlpattern-polyfill": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/node-fetch": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.6.tgz",
+      "integrity": "sha512-9oLD57yW0WWfu4ZtEmybBrx1JfkO4TzDpD2zXlp2Ue3UJplifQRap+MbE0PxRlVWtR4KWsIRamhn7J44DkwoyA==",
+      "dependencies": {
+        "@whatwg-node/events": "^0.1.0",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "fast-url-parser": "^1.1.3",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.8.2",
       "dev": true,
@@ -2671,7 +2877,6 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -2897,7 +3102,6 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -3019,6 +3223,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/cachedir": {
       "version": "2.3.0",
       "dev": true,
@@ -3041,7 +3256,6 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3079,6 +3293,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
       "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -3271,7 +3486,6 @@
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -3279,7 +3493,6 @@
     },
     "node_modules/color-name": {
       "version": "1.1.3",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -3508,7 +3721,6 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/conventional-commit-types": {
@@ -3523,9 +3735,7 @@
     },
     "node_modules/cosmiconfig": {
       "version": "8.1.3",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -3675,6 +3885,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/dataloader": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
+      "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g=="
+    },
     "node_modules/date-format": {
       "version": "4.0.14",
       "dev": true,
@@ -3816,6 +4031,14 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dset": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
+      "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3846,7 +4069,6 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -4553,6 +4775,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/extract-files": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
+      "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
+      }
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
@@ -4597,6 +4835,27 @@
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
+      "dependencies": {
+        "punycode": "^1.3.2"
+      }
+    },
+    "node_modules/fast-url-parser/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -5114,6 +5373,67 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/graphql-config": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.0.2.tgz",
+      "integrity": "sha512-7TPxOrlbiG0JplSZYCyxn2XQtqVhXomEjXUmWJVSS5ET1nPhOJSsIb/WTwqWhcYX6G0RlHXSj9PLtGTKmxLNGg==",
+      "dependencies": {
+        "@graphql-tools/graphql-file-loader": "^8.0.0",
+        "@graphql-tools/json-file-loader": "^8.0.0",
+        "@graphql-tools/load": "^8.0.0",
+        "@graphql-tools/merge": "^9.0.0",
+        "@graphql-tools/url-loader": "^8.0.0",
+        "@graphql-tools/utils": "^10.0.0",
+        "cosmiconfig": "^8.1.0",
+        "jiti": "^1.18.2",
+        "minimatch": "^4.2.3",
+        "string-env-interpolation": "^1.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "cosmiconfig-toml-loader": "^1.0.0",
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      },
+      "peerDependenciesMeta": {
+        "cosmiconfig-toml-loader": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/graphql-config/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/graphql-config/node_modules/minimatch": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.3.tgz",
+      "integrity": "sha512-lIUdtK5hdofgCTu3aT0sOaHsYR37viUuIc0rwnnDXImbwFRcumyLMeZaM0t0I/fgxS6s6JMfu0rLD1Wz9pv1ng==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz",
+      "integrity": "sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "dev": true,
@@ -5285,7 +5605,6 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -5300,7 +5619,6 @@
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -5898,7 +6216,6 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-bigint": {
@@ -6168,6 +6485,14 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -7584,15 +7909,21 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jiti": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
+      "integrity": "sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7650,7 +7981,6 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -7715,7 +8045,6 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -7991,6 +8320,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/meros": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/meros/-/meros-1.3.0.tgz",
+      "integrity": "sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==",
+      "engines": {
+        "node": ">=13"
+      },
+      "peerDependencies": {
+        "@types/node": ">=13"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "license": "MIT",
@@ -8084,6 +8429,25 @@
       "version": "1.4.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -8374,7 +8738,6 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -8385,7 +8748,6 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -9272,6 +9634,14 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -9280,6 +9650,11 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/string-env-interpolation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
+      "integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg=="
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -9588,6 +9963,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "dev": true,
@@ -9879,6 +10259,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/urlpattern-polyfill": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
+      "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g=="
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9942,6 +10327,20 @@
       "resolved": "https://registry.npmjs.org/weapon-regex/-/weapon-regex-1.1.0.tgz",
       "integrity": "sha512-DxCiBA0U7+5DSWs900rbkCScvLIyJgkYNrj1XRSLOq46mIHuIAMlwCilC1bVuAE+XBYq1+rjABSE/PfizKafxQ==",
       "dev": true
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -10127,6 +10526,26 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "dev": true,
@@ -10216,7 +10635,8 @@
       "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.5.0"
+        "@graphql-markdown/utils": "^1.5.0",
+        "graphql-config": "^5.0.2"
       },
       "devDependencies": {
         "@graphql-markdown/printer-legacy": "^1.1.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,12 +29,12 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.5.0",
-    "graphql-config": "^5.0.2"
+    "@graphql-markdown/utils": "^1.5.0"
   },
   "peerDependencies": {
     "@graphql-markdown/diff": "^1.0.12",
     "@graphql-markdown/printer-legacy": "^1.4.0",
+    "graphql-config": "^5.0.2",
     "prettier": "^2.8"
   },
   "peerDependenciesMeta": {
@@ -42,6 +42,9 @@
       "optional": true
     },
     "@graphql-markdown/diff": {
+      "optional": true
+    },
+    "graphql-config": {
       "optional": true
     },
     "prettier": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,8 @@
     }
   },
   "devDependencies": {
-    "@graphql-markdown/printer-legacy": "^1.1.3"
+    "@graphql-markdown/printer-legacy": "^1.1.3",
+    "graphql-config": "^5.0.2"
   },
   "directories": {
     "test": "tests"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,11 +29,12 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.5.0"
+    "@graphql-markdown/utils": "^1.5.0",
+    "graphql-config": "^5.0.2"
   },
   "peerDependencies": {
-    "@graphql-markdown/printer-legacy": "^1.4.0",
     "@graphql-markdown/diff": "^1.0.12",
+    "@graphql-markdown/printer-legacy": "^1.4.0",
     "prettier": "^2.8"
   },
   "peerDependenciesMeta": {

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -38,49 +38,36 @@ const DEFAULT_OPTIONS = {
 };
 
 function buildConfig(configFileOpts, cliOpts) {
-  let config = DEFAULT_OPTIONS;
-
-  if (typeof configFileOpts !== "undefined" && configFileOpts != null) {
-    config = { ...DEFAULT_OPTIONS, ...configFileOpts };
-  }
-
-  if (typeof cliOpts === "undefined" || cliOpts == null) {
+  if (typeof cliOpts === "undefined" || cliOpts === null) {
     cliOpts = {};
   }
 
   const graphqlConfig = loadConfiguration();
-  const mergedConfig = { ...graphqlConfig, ...config };
+  const config = { ...DEFAULT_OPTIONS, ...graphqlConfig, ...configFileOpts };
 
-  const baseURL = cliOpts.base ?? mergedConfig.baseURL;
-  const skipDocDirective = getSkipDocDirectives(cliOpts, mergedConfig);
+  const baseURL = cliOpts.base ?? config.baseURL;
+  const skipDocDirective = getSkipDocDirectives(cliOpts, config);
 
   return {
     baseURL,
     customDirective: getCustomDirectives(
-      mergedConfig.customDirective,
+      config.customDirective,
       skipDocDirective,
     ),
-    diffMethod: getDiffMethod(
-      cliOpts.diff ?? mergedConfig.diffMethod,
-      cliOpts.force,
-    ),
-    docOptions: getDocOptions(cliOpts, mergedConfig.docOptions),
+    diffMethod: getDiffMethod(cliOpts.diff ?? config.diffMethod, cliOpts.force),
+    docOptions: getDocOptions(cliOpts, config.docOptions),
     groupByDirective:
-      parseGroupByOption(cliOpts.groupByDirective) ||
-      mergedConfig.groupByDirective,
-    homepageLocation: cliOpts.homepage ?? mergedConfig.homepage,
-    linkRoot: cliOpts.link ?? mergedConfig.linkRoot,
-    loaders: mergedConfig.loaders,
-    outputDir: join(cliOpts.root ?? mergedConfig.rootPath, baseURL),
-    prettify: cliOpts.pretty ?? mergedConfig.pretty,
-    printer: mergedConfig.printer,
-    printTypeOptions: gePrintTypeOptions(
-      cliOpts,
-      mergedConfig.printTypeOptions,
-    ),
-    schemaLocation: cliOpts.schema ?? mergedConfig.schema,
+      parseGroupByOption(cliOpts.groupByDirective) || config.groupByDirective,
+    homepageLocation: cliOpts.homepage ?? config.homepage,
+    linkRoot: cliOpts.link ?? config.linkRoot,
+    loaders: config.loaders,
+    outputDir: join(cliOpts.root ?? config.rootPath, baseURL),
+    prettify: cliOpts.pretty ?? config.pretty,
+    printer: config.printer,
+    printTypeOptions: gePrintTypeOptions(cliOpts, config.printTypeOptions),
+    schemaLocation: cliOpts.schema ?? config.schema,
     skipDocDirective,
-    tmpDir: cliOpts.tmp ?? mergedConfig.tmpDir,
+    tmpDir: cliOpts.tmp ?? config.tmpDir,
   };
 }
 

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -5,6 +5,8 @@ const {
   object: { hasProperty },
 } = require("@graphql-markdown/utils");
 
+const { loadConfiguration } = require("./graphql-config");
+
 const PACKAGE_NAME = "@graphql-markdown/docusaurus";
 const ASSETS_LOCATION = join(__dirname, "../assets/");
 
@@ -49,7 +51,7 @@ function buildConfig(configFileOpts, cliOpts) {
   const baseURL = cliOpts.base ?? config.baseURL;
   const skipDocDirective = getSkipDocDirectives(cliOpts, config);
 
-  return {
+  const mergedConfig = {
     baseURL,
     customDirective: getCustomDirectives(
       config.customDirective,
@@ -70,6 +72,10 @@ function buildConfig(configFileOpts, cliOpts) {
     skipDocDirective,
     tmpDir: cliOpts.tmp ?? config.tmpDir,
   };
+
+  const graphqlConfig = loadConfiguration();
+
+  return { ...graphqlConfig, ...mergedConfig };
 }
 
 function getCustomDirectives(customDirectiveOptions, skipDocDirective = []) {

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -48,34 +48,40 @@ function buildConfig(configFileOpts, cliOpts) {
     cliOpts = {};
   }
 
-  const baseURL = cliOpts.base ?? config.baseURL;
-  const skipDocDirective = getSkipDocDirectives(cliOpts, config);
+  const graphqlConfig = loadConfiguration();
+  const mergedConfig = { ...graphqlConfig, ...config };
 
-  const mergedConfig = {
+  const baseURL = cliOpts.base ?? mergedConfig.baseURL;
+  const skipDocDirective = getSkipDocDirectives(cliOpts, mergedConfig);
+
+  return {
     baseURL,
     customDirective: getCustomDirectives(
-      config.customDirective,
+      mergedConfig.customDirective,
       skipDocDirective,
     ),
-    diffMethod: getDiffMethod(cliOpts.diff ?? config.diffMethod, cliOpts.force),
-    docOptions: getDocOptions(cliOpts, config.docOptions),
+    diffMethod: getDiffMethod(
+      cliOpts.diff ?? mergedConfig.diffMethod,
+      cliOpts.force,
+    ),
+    docOptions: getDocOptions(cliOpts, mergedConfig.docOptions),
     groupByDirective:
-      parseGroupByOption(cliOpts.groupByDirective) || config.groupByDirective,
-    homepageLocation: cliOpts.homepage ?? config.homepage,
-    linkRoot: cliOpts.link ?? config.linkRoot,
-    loaders: config.loaders,
-    outputDir: join(cliOpts.root ?? config.rootPath, baseURL),
-    prettify: cliOpts.pretty ?? config.pretty,
-    printer: config.printer,
-    printTypeOptions: gePrintTypeOptions(cliOpts, config.printTypeOptions),
-    schemaLocation: cliOpts.schema ?? config.schema,
+      parseGroupByOption(cliOpts.groupByDirective) ||
+      mergedConfig.groupByDirective,
+    homepageLocation: cliOpts.homepage ?? mergedConfig.homepage,
+    linkRoot: cliOpts.link ?? mergedConfig.linkRoot,
+    loaders: mergedConfig.loaders,
+    outputDir: join(cliOpts.root ?? mergedConfig.rootPath, baseURL),
+    prettify: cliOpts.pretty ?? mergedConfig.pretty,
+    printer: mergedConfig.printer,
+    printTypeOptions: gePrintTypeOptions(
+      cliOpts,
+      mergedConfig.printTypeOptions,
+    ),
+    schemaLocation: cliOpts.schema ?? mergedConfig.schema,
     skipDocDirective,
-    tmpDir: cliOpts.tmp ?? config.tmpDir,
+    tmpDir: cliOpts.tmp ?? mergedConfig.tmpDir,
   };
-
-  const graphqlConfig = loadConfiguration();
-
-  return { ...graphqlConfig, ...mergedConfig };
 }
 
 function getCustomDirectives(customDirectiveOptions, skipDocDirective = []) {

--- a/packages/core/src/graphql-config.js
+++ b/packages/core/src/graphql-config.js
@@ -32,7 +32,18 @@ const loadConfiguration = (
     return undefined;
   }
 
-  return config.getDefault().extension(EXTENSION_NAME);
+  const defaultConfig = config.getDefault().extension(EXTENSION_NAME);
+
+  if (typeof defaultConfig?.schema !== "string") {
+    const schema = defaultConfig?.schema[0];
+    if (typeof schema === "string") {
+      defaultConfig.schema = schema;
+    } else {
+      defaultConfig.schema = Object.keys(schema)[0];
+    }
+  }
+
+  return defaultConfig;
 };
 
 module.exports = { loadConfiguration, EXTENSION_NAME };

--- a/packages/core/src/graphql-config.js
+++ b/packages/core/src/graphql-config.js
@@ -11,9 +11,10 @@ const loadConfiguration = (
 ) => {
   let GraphQLConfig;
   try {
+    // eslint-disable-next-line node/no-missing-require
     GraphQLConfig = require("graphql-config");
   } catch (error) {
-    logger.info("Cannot find module 'graphql-config'");
+    logger.log("Cannot find module 'graphql-config'!");
     return undefined;
   }
 

--- a/packages/core/src/graphql-config.js
+++ b/packages/core/src/graphql-config.js
@@ -1,4 +1,4 @@
-const { loadConfigSync } = require("graphql-config");
+const logger = require("@graphql-markdown/utils").logger.getInstance();
 
 const EXTENSION_NAME = "graphql-markdown";
 
@@ -9,7 +9,15 @@ const loadConfiguration = (
     throwOnEmpty: false,
   },
 ) => {
-  const config = loadConfigSync({
+  let GraphQLConfig;
+  try {
+    GraphQLConfig = require("graphql-config");
+  } catch (error) {
+    logger.warn(error.message);
+    return undefined;
+  }
+
+  const config = GraphQLConfig.loadConfigSync({
     ...options,
     extensions: [() => ({ name: EXTENSION_NAME })],
     throwOnMissing: throwOnMissing || false,

--- a/packages/core/src/graphql-config.js
+++ b/packages/core/src/graphql-config.js
@@ -1,0 +1,29 @@
+const { loadConfigSync } = require("graphql-config");
+
+const EXTENSION_NAME = "graphql-markdown";
+
+const loadConfiguration = (
+  options = undefined,
+  { throwOnMissing, throwOnEmpty } = {
+    throwOnMissing: false,
+    throwOnEmpty: false,
+  },
+) => {
+  const config = loadConfigSync({
+    ...options,
+    extensions: [() => ({ name: EXTENSION_NAME })],
+    throwOnMissing: throwOnMissing || false,
+    throwOnEmpty: throwOnEmpty || false,
+  });
+
+  if (
+    typeof config === "undefined" ||
+    typeof config.getDefault() === "undefined"
+  ) {
+    return undefined;
+  }
+
+  return config.getDefault().extension(EXTENSION_NAME);
+};
+
+module.exports = { loadConfiguration, EXTENSION_NAME };

--- a/packages/core/src/graphql-config.js
+++ b/packages/core/src/graphql-config.js
@@ -13,7 +13,7 @@ const loadConfiguration = (
   try {
     GraphQLConfig = require("graphql-config");
   } catch (error) {
-    logger.info(error.message);
+    logger.info("Cannot find module 'graphql-config'");
     return undefined;
   }
 

--- a/packages/core/src/graphql-config.js
+++ b/packages/core/src/graphql-config.js
@@ -13,7 +13,7 @@ const loadConfiguration = (
   try {
     GraphQLConfig = require("graphql-config");
   } catch (error) {
-    logger.warn(error.message);
+    logger.info(error.message);
     return undefined;
   }
 

--- a/packages/core/tests/unit/config.test.js
+++ b/packages/core/tests/unit/config.test.js
@@ -373,7 +373,7 @@ describe("config", () => {
     test("returns custom directive maps", () => {
       expect.hasAssertions();
 
-      const descriptor = (directiveType, constDirectiveType) =>
+      const descriptor = (_, constDirectiveType) =>
         `Test${constDirectiveType.name.value}`;
       const options = {
         testA: { descriptor },

--- a/packages/core/tests/unit/graphql-config.test.js
+++ b/packages/core/tests/unit/graphql-config.test.js
@@ -61,25 +61,17 @@ describe("graphql-config", () => {
         }
       `);
     });
-
-    test("return undefined with a warning log if graphql-config package missing", () => {
-      expect.hasAssertions();
-
-      jest.mock("graphql-config", () => {
-        throw new Error("Package not found");
-      });
-
-      const logSpy = jest.spyOn(global.logger, "warn");
-
-      expect(loadConfiguration()).toBeUndefined();
-      expect(logSpy).toHaveBeenCalled();
-    });
   });
 });
 
 describe("config", () => {
   describe("buildConfig()", () => {
-    test("returns .graphqlrc options set", () => {
+    afterEach(() => {
+      vol.reset();
+      jest.restoreAllMocks();
+    });
+
+    test("returns config with .graphqlrc options set", () => {
       expect.hasAssertions();
 
       const graphqlConfig = {

--- a/packages/core/tests/unit/graphql-config.test.js
+++ b/packages/core/tests/unit/graphql-config.test.js
@@ -1,0 +1,64 @@
+const { vol } = require("memfs");
+jest.mock("fs");
+
+const path = require("path");
+
+const { loadConfiguration } = require("../../src/graphql-config");
+
+describe("graphql-config", () => {
+  describe("loadConfiguration()", () => {
+    afterEach(() => {
+      vol.reset();
+      jest.restoreAllMocks();
+    });
+
+    test("return undefined if not graphql-config found", () => {
+      expect.hasAssertions();
+
+      expect(loadConfiguration()).toBeUndefined();
+    });
+
+    test("return undefined if graphql-config empty", () => {
+      expect.hasAssertions();
+
+      vol.fromJSON({
+        "/.graphqlrc": "",
+      });
+
+      expect(loadConfiguration()).toBeUndefined();
+    });
+
+    test("return config if graphql-config valid", () => {
+      expect.hasAssertions();
+
+      const graphqlConfig = {
+        schema: "assets/my-schema.graphql",
+        extensions: {
+          "graphql-markdown": {
+            baseURL: "test",
+          },
+        },
+      };
+
+      const filePath = path.join(process.cwd(), ".graphqlrc");
+      vol.fromJSON({
+        [filePath]: JSON.stringify(graphqlConfig),
+      });
+
+      expect(
+        loadConfiguration(undefined, {
+          throwOnMissing: true,
+          throwOnEmpty: true,
+        }),
+      ).toMatchInlineSnapshot(`
+        {
+          "baseURL": "test",
+          "documents": undefined,
+          "exclude": undefined,
+          "include": undefined,
+          "schema": "assets/my-schema.graphql",
+        }
+      `);
+    });
+  });
+});

--- a/packages/core/tests/unit/graphql-config.test.js
+++ b/packages/core/tests/unit/graphql-config.test.js
@@ -60,5 +60,22 @@ describe("graphql-config", () => {
         }
       `);
     });
+
+    test("return undefined with a warning log if graphql-config package missing", () => {
+      expect.hasAssertions();
+
+      jest.mock("graphql-config", () => {
+        throw new Error("Package not found");
+      });
+
+      const logSpy = jest.spyOn(global.logger, "warn");
+
+      vol.fromJSON({
+        "/.graphqlrc": "",
+      });
+
+      expect(loadConfiguration()).toBeUndefined();
+      expect(logSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/core/tests/unit/graphql-config.test.js
+++ b/packages/core/tests/unit/graphql-config.test.js
@@ -29,11 +29,29 @@ describe("graphql-config", () => {
       expect(loadConfiguration()).toBeUndefined();
     });
 
-    test("return config if graphql-config valid", () => {
+    test.each([
+      ["http://localhost:4000/graphql"],
+      [
+        [
+          {
+            "http://localhost:4000/graphql": {
+              headers: { Authorization: true },
+            },
+          },
+        ],
+      ],
+      [["http://localhost:4000/graphql"]],
+    ])("return config if graphql-config valid", () => {
       expect.hasAssertions();
 
       const graphqlConfig = {
-        schema: "assets/my-schema.graphql",
+        schema: [
+          {
+            "http://localhost:4000/graphql": {
+              headers: { Authorization: true },
+            },
+          },
+        ],
         extensions: {
           "graphql-markdown": {
             baseURL: "test",
@@ -51,15 +69,13 @@ describe("graphql-config", () => {
           throwOnMissing: true,
           throwOnEmpty: true,
         }),
-      ).toMatchInlineSnapshot(`
-        {
-          "baseURL": "test",
-          "documents": undefined,
-          "exclude": undefined,
-          "include": undefined,
-          "schema": "assets/my-schema.graphql",
-        }
-      `);
+      ).toStrictEqual({
+        baseURL: "test",
+        documents: undefined,
+        exclude: undefined,
+        include: undefined,
+        schema: "http://localhost:4000/graphql",
+      });
     });
   });
 });

--- a/packages/docusaurus/scripts/config-plugin.js
+++ b/packages/docusaurus/scripts/config-plugin.js
@@ -123,13 +123,6 @@ if (existsSync(groupBySidebarFile)) {
   sidebar = { ...sidebar, group: schemaSidebar };
 }
 
-const groupSchema = require(path.resolve(__dirname, "data/${pluginGraphqlrcConfigFilename}"));
-const groupBySidebarFile = path.resolve(__dirname, groupSchema.rootPath, groupSchema.baseURL, "sidebar-schema.js");
-if (existsSync(groupBySidebarFile)) {
-  const { schemaSidebar } = require(groupBySidebarFile);
-  sidebar = { ...sidebar, group: schemaSidebar };
-}
-
 module.exports = sidebar;
 \n`;
 

--- a/packages/docusaurus/scripts/config-plugin.js
+++ b/packages/docusaurus/scripts/config-plugin.js
@@ -3,6 +3,8 @@ const fs = require("fs");
 const pluginConfigFilename = "docusaurus2-graphql-doc-generator.config.js";
 const pluginGroupConfigFilename =
   "docusaurus2-graphql-doc-generator-groups.config.js";
+const pluginGraphqlrcConfigFilename =
+  "docusaurus2-graphql-doc-generator-tweets.graphqlrc.js";
 
 // eslint-disable-next-line node/no-missing-require
 const docusaurusConfigFilepath = require.resolve("./docusaurus.config.js");
@@ -70,6 +72,7 @@ const config = {
   plugins: [
     ["@graphql-markdown/docusaurus", "@config1@"],
     ["@graphql-markdown/docusaurus", "@config2@"],
+    ["@graphql-markdown/docusaurus", "@config3@"],
   ],
 };
 
@@ -84,6 +87,10 @@ module.exports = ${JSON.stringify(config)};\n`
   .replace(
     `"@config2@"`,
     `require(path.resolve(__dirname, "data/${pluginGroupConfigFilename}"))`,
+  )
+  .replace(
+    `"@config3@"`,
+    `require(path.resolve(__dirname, "data/${pluginGraphqlrcConfigFilename}"))`,
   );
 
 fs.writeFile(docusaurusConfigFilepath, configExportString, (err) => {
@@ -110,6 +117,13 @@ if (existsSync(basicSidebarFile)) {
 }
 
 const groupSchema = require(path.resolve(__dirname, "data/${pluginGroupConfigFilename}"));
+const groupBySidebarFile = path.resolve(__dirname, groupSchema.rootPath, groupSchema.baseURL, "sidebar-schema.js");
+if (existsSync(groupBySidebarFile)) {
+  const { schemaSidebar } = require(groupBySidebarFile);
+  sidebar = { ...sidebar, group: schemaSidebar };
+}
+
+const groupSchema = require(path.resolve(__dirname, "data/${pluginGraphqlrcConfigFilename}"));
 const groupBySidebarFile = path.resolve(__dirname, groupSchema.rootPath, groupSchema.baseURL, "sidebar-schema.js");
 if (existsSync(groupBySidebarFile)) {
   const { schemaSidebar } = require(groupBySidebarFile);

--- a/packages/docusaurus/tests/__data__/.graphqlrc
+++ b/packages/docusaurus/tests/__data__/.graphqlrc
@@ -1,0 +1,17 @@
+schema: data/tweet.graphql
+extensions:
+  graphql-markdown:
+    baseURL: "."
+    linkRoot: "/examples/tweet"
+    homepage: data/groups.md
+    loaders:
+      GraphQLFileLoader: "@graphql-tools/graphql-file-loader"
+    docOptions:
+      index: true
+    printTypeOptions:
+      parentTypePrefix: false
+      relatedTypeSection: false
+      typeBadges: true
+      deprecated: group
+    skipDocDirective:
+      - "@noDoc"

--- a/packages/docusaurus/tests/__data__/anilist.md
+++ b/packages/docusaurus/tests/__data__/anilist.md
@@ -9,7 +9,13 @@ pagination_prev: null
 sidebar_class_name: navbar__toggle
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 This documentation has been automatically generated using [AniList APIv2](https://anilist.gitbook.io/anilist-apiv2-docs/) endpoint with following plugin configuration:
+
+<Tabs groupId="config">
+<TabItem value="docusaurus" label="Docusaurus (JSON)">
 
 ```json
 {
@@ -32,5 +38,43 @@ This documentation has been automatically generated using [AniList APIv2](https:
   }
 }
 ```
+
+</TabItem>
+<TabItem value="graphql-config" label="GraphQL Config (YAML)">
+
+```yaml
+schema: https://graphql.anilist.co/
+extensions:
+  graphql-markdown:
+    linkRoot: "/examples/default"
+    baseURL: "."
+    homepage: data/anilist.md
+    loaders:
+      UrlLoader:
+        module: "@graphql-tools/url-loader"
+        options:
+          method: POST
+    printTypeOptions:
+      deprecated: group
+    docOptions:
+      pagination: false
+      toc: false
+```
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+```bash
+npx docusaurus graphql-to-doc \
+    --homepage data/anilist.md \
+    --schema https://graphql.anilist.co/ \
+    --base . \
+    --link /examples/default \
+    --noPagination \
+    --deprecated group
+```
+
+</TabItem>
+</Tabs>
 
 <small><i>Generated on ##generated-date-time##.</i></small>

--- a/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator-multi-instance.config.js
+++ b/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator-multi-instance.config.js
@@ -1,4 +1,5 @@
 module.exports = [
   require("./docusaurus2-graphql-doc-generator.config.js"),
   require("./docusaurus2-graphql-doc-generator-groups.config.js"),
+  require("./docusaurus2-graphql-doc-generator-tweets.graphqlrc.js"),
 ];

--- a/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator-tweets.graphqlrc.js
+++ b/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator-tweets.graphqlrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  id: "schema_tweets",
+  // this config uses .graphqlrc
+};

--- a/packages/docusaurus/tests/__data__/groups.md
+++ b/packages/docusaurus/tests/__data__/groups.md
@@ -9,7 +9,13 @@ pagination_prev: null
 sidebar_class_name: navbar__toggle
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 This is an example of documentation grouping with GraphQL directive using the `groupByDirective` option (see [documentation](/docs/advanced/group-by-directive)):
+
+<Tabs groupId="config">
+<TabItem value="docusaurus" label="Docusaurus (JS/TS)">
 
 ```js
 {
@@ -53,5 +59,75 @@ This is an example of documentation grouping with GraphQL directive using the `g
   },
 }
 ```
+
+</TabItem>
+<TabItem value="graphql-config" label="GraphQL Config (JS/TS)">
+
+```js
+{
+  schema: "data/schema_with_grouping.graphql",
+  extensions: {
+    "graphql-markdown": {
+      baseURL: ".",
+      linkRoot: "/examples/group-by",
+      homepage: "data/groups.md",
+      groupByDirective: {
+        directive: "doc",
+        field: "category",
+        fallback: "Common"
+      },
+      docOptions: {
+        index: true
+      },
+      printTypeOptions: {
+        parentTypePrefix: false,
+        relatedTypeSection: false,
+        typeBadges: true,
+        deprecated: "group"
+      },
+      skipDocDirective: ["@noDoc"],
+      customDirective: {
+        auth: {
+          descriptor: (directive, type) =>
+            directiveDescriptor(
+              directive,
+              type,
+              "This requires the current user to be in `${requires}` role.",
+            ),
+        },
+        complexity: {
+          descriptor: (directive, type) => {
+            const { value, multipliers } = getTypeDirectiveValues(directive, type);
+            const multiplierDescription = multipliers
+              ? ` per ${multipliers.map((v) => `\`${v}\``).join(", ")}`
+              : "";
+            return `This has an additional cost of \`${value}\` points${multiplierDescription}.`;
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+```bash
+npx docusaurus graphql-to-doc \
+    --homepage data/groups.md \
+    --schema data/schema_with_grouping.graphql \
+    --groupByDirective @doc(category|=Common) \
+    --base . \
+    --link /examples/group-by \
+    --skip @noDoc \
+    --index \
+    --noParentType \
+    --noRelatedType \
+    --deprecated group
+```
+
+</TabItem>
+</Tabs>
 
 <small><i>Generated on ##generated-date-time##.</i></small>

--- a/packages/docusaurus/tests/e2e/specs/cli.spec.js
+++ b/packages/docusaurus/tests/e2e/specs/cli.spec.js
@@ -11,6 +11,10 @@ const docsDirs = [];
 const messagesGenerated = [];
 
 for (const pluginConfig of pluginConfigs) {
+  if (!pluginConfig.schema) {
+    // if schema not test then assume .graphqlrc
+    continue;
+  }
   docsDirs.push(
     path.resolve(rootDir, pluginConfig.rootPath, pluginConfig.baseURL),
   );
@@ -86,6 +90,11 @@ describe("graphql-to-doc", () => {
 
   test("should return 0 with generated message when completed with force flag (multi-instance)", async () => {
     for (const [index, pluginConfig] of pluginConfigs.entries()) {
+      if (!pluginConfig.schema) {
+        // if schema not test then assume .graphqlrc
+        continue;
+      }
+
       const generateOutput = await cli({
         commandID: pluginConfig.id,
         args: ["--force"],
@@ -107,5 +116,19 @@ describe("graphql-to-doc", () => {
         expect(stdout).toMatch(message),
       );
     }
+  }, 60000);
+
+  test("should return 0 when using .graphqlrc config", async () => {
+    const generateOutput = await cli({ commandID: "schema_tweets" });
+    expect(generateOutput).toMatchObject({
+      code: 0,
+      error: null,
+      stderr: "",
+      stdout: expect.any(String),
+    });
+    const stdout = generateOutput.stdout.replace(/\d+\.?\d*/g, "{Any<Number>}");
+    expect(stdout).toMatch(
+      `{Any<Number>} pages generated in {Any<Number>}s from schema "data/tweet.graphql".`,
+    );
   }, 60000);
 });


### PR DESCRIPTION
# Description

A `graphql-config` support with limitations:
 - loaders are managed by `@graphql-markdown/utils/graphql`
 - projects are not supported
 - `include`, `exclude` and glob pattern are not supported
 - schema options (eg headers) are not supported

Example `.graphqlrc` (root folder):

```yaml
schema: "https://graphql.anilist.co/"
extensions:
  graphql-markdown:
    linkRoot: "/examples/default"
    baseURL: "."
    homepage: "data/anilist.md"
    loaders:
      UrlLoader:
        module: "@graphql-tools/url-loader"
        options: 
          method: "POST"
    printTypeOptions:
      deprecated: "group"
    docOptions:
      pagination: false,
      toc: false
```

:warning: **Note that `schema` is not part of the extension configuration, but part of the default `graphql-config` configuration.**

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
