### PR TITLE
:sparkles:  add graphql-config projects support

### DIFF
--- a/docs/advanced/additional-schema.md
+++ b/docs/advanced/additional-schema.md
@@ -9,39 +9,82 @@ If you need to support multiple schemas, then you can set multiple instances of 
 
 Assign a unique `id` attribute to each plugin instance (if not set, then `id` value is `default`).
 
-```js {15 }
+```js title="docusaurus.config.js"
 plugins: [
-    [
-      "@graphql-markdown/docusaurus",
-       {
-        // id: 'swapi', // omitted => default instance
-        schema: "./schema/swapi.graphql",
-        rootPath: "./docs", // docs will be generated under './docs/swapi' (rootPath/baseURL)
-        baseURL: "swapi",
-        homepage: "./docs/swapi.md",
-        loaders: {
-          GraphQLFileLoader: "@graphql-tools/graphql-file-loader" // local file schema
-        }
-      },
-    ],
-    [
-      "@graphql-markdown/docusaurus",
-      {
-        id: "admin",
-        schema: "./schema/admin.graphql",
-        rootPath: "./docs", // docs will be generated under './docs/admin' (rootPath/baseURL)
-        baseURL: "admin",
-        homepage: "./docs/admin.md",
-        loaders: {
-          GraphQLFileLoader: "@graphql-tools/graphql-file-loader" // local file schema
-        }
-      },
-    ],
+  [
+    "@graphql-markdown/docusaurus",
+    {
+      // highlight-next-line
+      // id: 'default', // omitted => default instance
+      schema: "./schema/swapi.graphql",
+      rootPath: "./docs", // docs will be generated under './docs/swapi' (rootPath/baseURL)
+      baseURL: "swapi",
+      homepage: "./docs/swapi.md",
+      loaders: {
+        GraphQLFileLoader: "@graphql-tools/graphql-file-loader" // local file schema
+      }
+    },
   ],
+  [
+    "@graphql-markdown/docusaurus",
+    {
+      // highlight-next-line
+      id: "admin",
+      schema: "./schema/admin.graphql",
+      rootPath: "./docs", // docs will be generated under './docs/admin' (rootPath/baseURL)
+      baseURL: "admin",
+      homepage: "./docs/admin.md",
+      loaders: {
+        GraphQLFileLoader: "@graphql-tools/graphql-file-loader" // local file schema
+      }
+    },
+  ],
+],
 ```
 
 Instance with an `id` will have their own command line:
 
 ```shell
 npm run docusaurus graphql-to-doc:admin
+```
+
+## GraphQL Config
+
+If you use [GraphQL config](/docs/configuration#graphql-config), then you need to define `projects` with the same `id` (including `default`).
+
+```js title="docusaurus.config.js"
+plugins: [
+  "@graphql-markdown/docusaurus", // default instance
+  [
+    "@graphql-markdown/docusaurus",
+    {
+      // highlight-next-line
+      id: "admin",
+    },
+  ],
+],
+```
+
+```yaml title=".graphqlrc"
+projects:
+  # highlight-next-line
+  default:
+    schema: "./schema/swapi.graphql"
+    extensions:
+      graphql-markdown:
+        linkRoot: "./docs"
+        baseURL: "swapi"
+        homepage: "./docs/swapi.md"
+        loaders:
+          GraphQLFileLoader: "@graphql-tools/graphql-file-loader"
+  # highlight-next-line
+  admin:
+    schema: "./schema/admin.graphql"
+    extensions:
+      graphql-markdown:
+        linkRoot: "./docs"
+        baseURL: "admin"
+        homepage: "./docs/admin.md"
+        loaders:
+          GraphQLFileLoader: "@graphql-tools/graphql-file-loader"
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ module.exports = {
 };
 ```
 
-All settings are described in the page [settings](/docs/settings).
+All settings are described in the page **[settings](/docs/settings)**.
 
 :::tip
 If you want to use several GraphQL schemas, read our guide for **[additional schema](/docs/advanced/additional-schema)**.
@@ -52,7 +52,7 @@ For example, if your `sidebars.js` is located under `./src` folder, then you nee
 :::
 
 :::tip
-See [docs multi-instance](/docs/advanced/docs-multi-instance) for sidebar settings when using multiple sets of documentation.
+See **[docs multi-instance](/docs/advanced/docs-multi-instance)** for sidebar settings when using multiple sets of documentation.
 :::
 
 ## Site Settings
@@ -90,11 +90,7 @@ npm install graphql-config
 ```js title="docusaurus.config.js"
 module.exports = {
   // ...
-  plugins: [
-    [
-      "@graphql-markdown/docusaurus",
-    ],
-  ],
+  plugins: ["@graphql-markdown/docusaurus"],
 };
 ```
 
@@ -124,7 +120,5 @@ Note that **`schema` is not part of the extension configuration**, but part of t
 **Current limitations:**
 
 * single schema only, no schema stitching
-* projects are not supported, only default
 * `include`, `exclude`, `documents` and glob pattern are not supported
 * schema options (eg headers) are not supported, instead use [loaders options](/docs/advanced/schema-loading)
-* not compatible with [multiple schemas](/docs/advanced/additional-schema)

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -37,12 +37,12 @@ const DEFAULT_OPTIONS = {
   skipDocDirective: [],
 };
 
-function buildConfig(configFileOpts, cliOpts) {
+function buildConfig(configFileOpts, cliOpts, id = undefined) {
   if (typeof cliOpts === "undefined" || cliOpts === null) {
     cliOpts = {};
   }
 
-  const graphqlConfig = loadConfiguration();
+  const graphqlConfig = loadConfiguration(id);
   const config = { ...DEFAULT_OPTIONS, ...graphqlConfig, ...configFileOpts };
 
   const baseURL = cliOpts.base ?? config.baseURL;

--- a/packages/core/src/graphql-config.js
+++ b/packages/core/src/graphql-config.js
@@ -26,25 +26,28 @@ const loadConfiguration = (
     throwOnEmpty: throwOnEmpty || false,
   });
 
-  if (
-    typeof config === "undefined" ||
-    typeof config.getProject(id) === "undefined"
-  ) {
+  try {
+    if (
+      typeof config === "undefined" ||
+      typeof config.getProject(id) === "undefined"
+    ) {
+      return undefined;
+    }
+
+    const projectConfig = config.getProject(id).extension(EXTENSION_NAME);
+
+    if (typeof projectConfig?.schema !== "string") {
+      const schema = projectConfig?.schema[0];
+      if (typeof schema === "string") {
+        projectConfig.schema = schema;
+      } else {
+        projectConfig.schema = Object.keys(schema)[0];
+      }
+    }
+    return projectConfig;
+  } catch (error) {
     return undefined;
   }
-
-  const projectConfig = config.getProject(id).extension(EXTENSION_NAME);
-
-  if (typeof projectConfig?.schema !== "string") {
-    const schema = projectConfig?.schema[0];
-    if (typeof schema === "string") {
-      projectConfig.schema = schema;
-    } else {
-      projectConfig.schema = Object.keys(schema)[0];
-    }
-  }
-
-  return projectConfig;
 };
 
 module.exports = { loadConfiguration, EXTENSION_NAME };

--- a/packages/core/src/graphql-config.js
+++ b/packages/core/src/graphql-config.js
@@ -3,6 +3,7 @@ const logger = require("@graphql-markdown/utils").logger.getInstance();
 const EXTENSION_NAME = "graphql-markdown";
 
 const loadConfiguration = (
+  id = undefined,
   options = undefined,
   { throwOnMissing, throwOnEmpty } = {
     throwOnMissing: false,
@@ -27,23 +28,23 @@ const loadConfiguration = (
 
   if (
     typeof config === "undefined" ||
-    typeof config.getDefault() === "undefined"
+    typeof config.getProject(id) === "undefined"
   ) {
     return undefined;
   }
 
-  const defaultConfig = config.getDefault().extension(EXTENSION_NAME);
+  const projectConfig = config.getProject(id).extension(EXTENSION_NAME);
 
-  if (typeof defaultConfig?.schema !== "string") {
-    const schema = defaultConfig?.schema[0];
+  if (typeof projectConfig?.schema !== "string") {
+    const schema = projectConfig?.schema[0];
     if (typeof schema === "string") {
-      defaultConfig.schema = schema;
+      projectConfig.schema = schema;
     } else {
-      defaultConfig.schema = Object.keys(schema)[0];
+      projectConfig.schema = Object.keys(schema)[0];
     }
   }
 
-  return defaultConfig;
+  return projectConfig;
 };
 
 module.exports = { loadConfiguration, EXTENSION_NAME };

--- a/packages/core/src/graphql-config.js
+++ b/packages/core/src/graphql-config.js
@@ -22,18 +22,11 @@ const loadConfiguration = (
   const config = GraphQLConfig.loadConfigSync({
     ...options,
     extensions: [() => ({ name: EXTENSION_NAME })],
-    throwOnMissing: throwOnMissing || false,
-    throwOnEmpty: throwOnEmpty || false,
+    throwOnMissing,
+    throwOnEmpty,
   });
 
   try {
-    if (
-      typeof config === "undefined" ||
-      typeof config.getProject(id) === "undefined"
-    ) {
-      return undefined;
-    }
-
     const projectConfig = config.getProject(id).extension(EXTENSION_NAME);
 
     if (typeof projectConfig?.schema !== "string") {

--- a/packages/core/tests/unit/graphql-config.test.js
+++ b/packages/core/tests/unit/graphql-config.test.js
@@ -40,7 +40,7 @@ describe("graphql-config", () => {
           },
         ],
       ],
-      [["http://localhost:4000/graphql"]],
+      [["http://localhost:4000/graphql", "./packages/bar/schema.graphql"]],
     ])("returns config if graphql-config valid", () => {
       expect.hasAssertions();
 
@@ -185,7 +185,7 @@ describe("graphql-config", () => {
         [filePath]: JSON.stringify(graphqlConfig),
       });
 
-      expect(loadConfiguration("baz", undefined)).toBeUndefined();
+      expect(loadConfiguration("baz")).toBeUndefined();
     });
   });
 });

--- a/packages/core/tests/unit/graphql-config.test.js
+++ b/packages/core/tests/unit/graphql-config.test.js
@@ -157,7 +157,7 @@ describe("graphql-config", () => {
       });
     });
 
-    test("throw an error if project id does not exist", () => {
+    test("returns undefined if project id does not exist", () => {
       expect.hasAssertions();
 
       const graphqlConfig = {
@@ -185,12 +185,7 @@ describe("graphql-config", () => {
         [filePath]: JSON.stringify(graphqlConfig),
       });
 
-      expect(() => {
-        loadConfiguration("baz", undefined, {
-          throwOnMissing: true,
-          throwOnEmpty: true,
-        });
-      }).toThrow("Project 'baz' not found");
+      expect(loadConfiguration("baz", undefined)).toBeUndefined();
     });
   });
 });

--- a/packages/core/tests/unit/graphql-config.test.js
+++ b/packages/core/tests/unit/graphql-config.test.js
@@ -13,13 +13,13 @@ describe("graphql-config", () => {
       jest.restoreAllMocks();
     });
 
-    test("return undefined if not graphql-config found", () => {
+    test("returns undefined if not graphql-config found", () => {
       expect.hasAssertions();
 
       expect(loadConfiguration()).toBeUndefined();
     });
 
-    test("return undefined if graphql-config empty", () => {
+    test("returns undefined if graphql-config empty", () => {
       expect.hasAssertions();
 
       vol.fromJSON({
@@ -41,7 +41,7 @@ describe("graphql-config", () => {
         ],
       ],
       [["http://localhost:4000/graphql"]],
-    ])("return config if graphql-config valid", () => {
+    ])("returns config if graphql-config valid", () => {
       expect.hasAssertions();
 
       const graphqlConfig = {
@@ -65,7 +65,7 @@ describe("graphql-config", () => {
       });
 
       expect(
-        loadConfiguration(undefined, {
+        loadConfiguration(undefined, undefined, {
           throwOnMissing: true,
           throwOnEmpty: true,
         }),
@@ -76,6 +76,121 @@ describe("graphql-config", () => {
         include: undefined,
         schema: "http://localhost:4000/graphql",
       });
+    });
+
+    test("returns default config", () => {
+      expect.hasAssertions();
+
+      const graphqlConfig = {
+        schema: [
+          {
+            "http://localhost:4000/graphql": {
+              headers: { Authorization: true },
+            },
+          },
+        ],
+        extensions: {
+          "graphql-markdown": {
+            baseURL: "default",
+          },
+        },
+      };
+
+      const filePath = join(process.cwd(), ".graphqlrc");
+      vol.fromJSON({
+        [filePath]: JSON.stringify(graphqlConfig),
+      });
+
+      expect(
+        loadConfiguration("default", undefined, {
+          throwOnMissing: true,
+          throwOnEmpty: true,
+        }),
+      ).toStrictEqual({
+        baseURL: "default",
+        documents: undefined,
+        exclude: undefined,
+        include: undefined,
+        schema: "http://localhost:4000/graphql",
+      });
+    });
+
+    test("returns project config", () => {
+      expect.hasAssertions();
+
+      const graphqlConfig = {
+        projects: {
+          foo: {
+            schema: [
+              {
+                "http://localhost:4000/graphql": {
+                  headers: { Authorization: true },
+                },
+              },
+            ],
+            extensions: {
+              "graphql-markdown": {
+                baseURL: "foo",
+              },
+            },
+          },
+          bar: { schema: "./packages/bar/schema.graphql" },
+        },
+      };
+
+      const filePath = join(process.cwd(), ".graphqlrc");
+      vol.fromJSON({
+        [filePath]: JSON.stringify(graphqlConfig),
+      });
+
+      expect(
+        loadConfiguration("foo", undefined, {
+          throwOnMissing: true,
+          throwOnEmpty: true,
+        }),
+      ).toStrictEqual({
+        baseURL: "foo",
+        documents: undefined,
+        exclude: undefined,
+        include: undefined,
+        schema: "http://localhost:4000/graphql",
+      });
+    });
+
+    test("throw an error if project id does not exist", () => {
+      expect.hasAssertions();
+
+      const graphqlConfig = {
+        projects: {
+          foo: {
+            schema: [
+              {
+                "http://localhost:4000/graphql": {
+                  headers: { Authorization: true },
+                },
+              },
+            ],
+            extensions: {
+              "graphql-markdown": {
+                baseURL: "test",
+              },
+            },
+          },
+          bar: { schema: "./packages/bar/schema.graphql" },
+        },
+      };
+
+      const filePath = join(process.cwd(), ".graphqlrc");
+      vol.fromJSON({
+        [filePath]: JSON.stringify(graphqlConfig),
+      });
+
+      expect(() => {
+        loadConfiguration("baz", undefined, {
+          throwOnMissing: true,
+          throwOnEmpty: true,
+        });
+      }).toThrow("Project 'baz' not found");
     });
   });
 });

--- a/packages/docusaurus/src/index.js
+++ b/packages/docusaurus/src/index.js
@@ -54,7 +54,11 @@ module.exports = function pluginGraphQLDocGenerator(_, configOptions) {
         )
         .option("--pretty", "Prettify generated files")
         .action(async (cliOptions) => {
-          const options = config.buildConfig(configOptions, cliOptions);
+          const options = config.buildConfig(
+            configOptions,
+            cliOptions,
+            configOptions.id,
+          );
           await generateDocFromSchema({
             ...options,
             loggerModule: LOGGER_MODULE,

--- a/packages/docusaurus/tests/__data__/.graphqlrc
+++ b/packages/docusaurus/tests/__data__/.graphqlrc
@@ -1,17 +1,19 @@
-schema: data/tweet.graphql
-extensions:
-  graphql-markdown:
-    baseURL: "."
-    linkRoot: "/examples/tweet"
-    homepage: data/groups.md
-    loaders:
-      GraphQLFileLoader: "@graphql-tools/graphql-file-loader"
-    docOptions:
-      index: true
-    printTypeOptions:
-      parentTypePrefix: false
-      relatedTypeSection: false
-      typeBadges: true
-      deprecated: group
-    skipDocDirective:
-      - "@noDoc"
+projects:
+  schema_tweets:
+    schema: data/tweet.graphql
+    extensions:
+      graphql-markdown:
+        baseURL: "."
+        linkRoot: "/examples/tweet"
+        homepage: data/groups.md
+        loaders:
+          GraphQLFileLoader: "@graphql-tools/graphql-file-loader"
+        docOptions:
+          index: true
+        printTypeOptions:
+          parentTypePrefix: false
+          relatedTypeSection: false
+          typeBadges: true
+          deprecated: group
+        skipDocDirective:
+          - "@noDoc"


### PR DESCRIPTION
# Description

This enable projects support for GraphQL config, removing the limitation on multi schema (see documentation).

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
