### PR TITLE
:sparkles:  support schema options in graphql-config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -121,4 +121,3 @@ Note that **`schema` is not part of the extension configuration**, but part of t
 
 * single schema only, no schema stitching
 * `include`, `exclude`, `documents` and glob pattern are not supported
-* schema options (eg headers) are not supported, instead use [loaders options](/docs/advanced/schema-loading)

--- a/packages/core/src/graphql-config.js
+++ b/packages/core/src/graphql-config.js
@@ -35,12 +35,27 @@ const loadConfiguration = (
         projectConfig.schema = schema;
       } else {
         projectConfig.schema = Object.keys(schema)[0];
+        projectConfig.loaders = setLoaderOptions(
+          projectConfig.loaders,
+          Object.values(schema)[0],
+        );
       }
     }
     return projectConfig;
   } catch (error) {
     return undefined;
   }
+};
+
+const setLoaderOptions = (loaders, options) => {
+  for (const loader in loaders) {
+    if (typeof loaders[loader] === "string") {
+      loaders[loader] = { module: loaders[loader], options };
+    } else {
+      loaders[loader].options = { ...options, ...loaders[loader].options };
+    }
+  }
+  return loaders;
 };
 
 module.exports = { loadConfiguration, EXTENSION_NAME };

--- a/packages/core/tests/unit/graphql-config.test.js
+++ b/packages/core/tests/unit/graphql-config.test.js
@@ -74,6 +74,7 @@ describe("graphql-config", () => {
         documents: undefined,
         exclude: undefined,
         include: undefined,
+        loaders: undefined,
         schema: "http://localhost:4000/graphql",
       });
     });
@@ -92,6 +93,14 @@ describe("graphql-config", () => {
         extensions: {
           "graphql-markdown": {
             baseURL: "default",
+            loaders: {
+              UrlLoader: {
+                module: "@graphql-tools/url-loader",
+                options: {
+                  method: "POST",
+                },
+              },
+            },
           },
         },
       };
@@ -111,6 +120,17 @@ describe("graphql-config", () => {
         documents: undefined,
         exclude: undefined,
         include: undefined,
+        loaders: {
+          UrlLoader: {
+            module: "@graphql-tools/url-loader",
+            options: {
+              method: "POST",
+              headers: {
+                Authorization: true,
+              },
+            },
+          },
+        },
         schema: "http://localhost:4000/graphql",
       });
     });
@@ -131,6 +151,7 @@ describe("graphql-config", () => {
             extensions: {
               "graphql-markdown": {
                 baseURL: "foo",
+                loaders: { UrlLoader: "@graphql-tools/url-loader" },
               },
             },
           },
@@ -153,6 +174,16 @@ describe("graphql-config", () => {
         documents: undefined,
         exclude: undefined,
         include: undefined,
+        loaders: {
+          UrlLoader: {
+            module: "@graphql-tools/url-loader",
+            options: {
+              headers: {
+                Authorization: true,
+              },
+            },
+          },
+        },
         schema: "http://localhost:4000/graphql",
       });
     });


### PR DESCRIPTION
# Description

Add support of schema options when defined at `schema` level in GraphQL Config. 
The options are pushed to each loaders.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
