### PR TITLE
:bookmark:  release 1.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10767,7 +10767,7 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/utils": "^1.5.0"
@@ -10780,7 +10780,7 @@
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@graphql-markdown/diff": "^1.0.12",
+        "@graphql-markdown/diff": "^1.0.13",
         "@graphql-markdown/printer-legacy": "^1.4.0",
         "graphql-config": "^5.0.2",
         "prettier": "^2.8"
@@ -10802,7 +10802,7 @@
     },
     "packages/diff": {
       "name": "@graphql-markdown/diff",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "MIT",
       "dependencies": {
         "@graphql-inspector/core": "^5.0.0",
@@ -10816,10 +10816,10 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.19.0",
+      "version": "1.20.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.5.0",
+        "@graphql-markdown/core": "^1.6.0",
         "@graphql-markdown/printer-legacy": "^1.4.0"
       },
       "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -32,7 +32,7 @@
     "@graphql-markdown/utils": "^1.5.0"
   },
   "peerDependencies": {
-    "@graphql-markdown/diff": "^1.0.12",
+    "@graphql-markdown/diff": "^1.0.13",
     "@graphql-markdown/printer-legacy": "^1.4.0",
     "graphql-config": "^5.0.2",
     "prettier": "^2.8"

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.12",
+  "version": "1.0.13",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.19.0",
+  "version": "1.20.0",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -31,7 +31,7 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.5.0",
+    "@graphql-markdown/core": "^1.6.0",
     "@graphql-markdown/printer-legacy": "^1.4.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
# Description

:sparkles: [GraphQL Config](https://the-guild.dev/graphql/config) is now supported, see the [documentation](https://graphql-markdown.github.io/docs/configuration#graphql-config) for more information and limitations :rocket: 

First install the package `graphql-config`, then you are ready to go.

```bash
npm install graphql-config
```

Example `.graphqlrc`:

```yaml
schema: "https://graphql.anilist.co/"
extensions:
  graphql-markdown:
    linkRoot: "/examples/default"
    baseURL: "."
    homepage: "data/anilist.md"
    loaders:
      UrlLoader:
        module: "@graphql-tools/url-loader"
        options: 
          method: "POST"
    printTypeOptions:
      deprecated: "group"
    docOptions:
      pagination: false,
      toc: false
```

## What's Changed

### @graphql-markdown/docusaurus@1.20.0
* :technologist:  force loading  @docusaurus/logger on module init by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/886
* :sparkles:  add support for graphql-config (#828) by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/885
* :sparkles:  add graphql-config projects support by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/888
* :package:  bump dependency @graphql-markdown/core to 1.6.0

### @graphql-markdown/core@1.6.0
* :sparkles:  add support for graphql-config (#828) by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/885
* :sparkles:  add graphql-config projects support by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/888
* :sparkles:  support schema options in graphql-config by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/889
*  :package:  bump peerDependency @graphql-markdown/diff to 1.0.13

### @graphql-markdown/diff@1.0.13

* :package: fix(deps): update dependency @graphql-inspector/core to v4.2.2 by @renovate in https://github.com/graphql-markdown/graphql-markdown/pull/880
* :package: fix(deps): update dependency @graphql-inspector/core to v5 by @renovate in https://github.com/graphql-markdown/graphql-markdown/pull/881


# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
