### PR TITLE
:bookmark:  release 1.20.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-prettier": "5.0.0-alpha.2",
         "graphql": "16.7.1",
+        "graphql-config": "^5.0.2",
         "husky": "8.0.3",
         "jest": "29.6.0",
         "lodash.filter": "4.6.0",
@@ -72,7 +73,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz",
       "integrity": "sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "node-fetch": "^2.6.1"
       },
@@ -84,7 +85,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
       "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/highlight": "^7.22.5"
       },
@@ -403,7 +404,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
       "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -435,7 +436,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
       "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
@@ -449,7 +450,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -461,7 +462,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -475,7 +476,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -484,7 +485,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4"
       }
@@ -493,7 +494,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -1292,7 +1293,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.0.tgz",
       "integrity": "sha512-lT9/1XmPSYzBcEybXPLsuA6C5E0t8438PVUELABcqdvwHgZ3VOOx29MLBEqhr2oewOlDChH6PXNkfxoOoAuzRg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "dataloader": "^2.2.2",
@@ -1310,7 +1311,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.0.0.tgz",
       "integrity": "sha512-ZW5/7Q0JqUM+guwn8/cM/1Hz16Zvj6WR6r3gnOwoPO7a9bCbe8QTCk4itT/EO+RiGT8RLUPYaunWR9jxfNqqOA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@graphql-tools/batch-execute": "^9.0.0",
         "@graphql-tools/executor": "^1.0.0",
@@ -1331,7 +1332,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.1.0.tgz",
       "integrity": "sha512-+1wmnaUHETSYxiK/ELsT60x584Rw3QKBB7F/7fJ83HKPnLifmE2Dm/K9Eyt6L0Ppekf1jNUbWBpmBGb8P5hAeg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "@graphql-typed-document-node/core": "3.2.0",
@@ -1350,7 +1351,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-1.0.1.tgz",
       "integrity": "sha512-mcOEYr+p+Mex03cGtQ+QG4ofh83BxLlVAegkBoNIzb06KH3c7FgmlkRysiEaDtr8L4FjKzNo8LVfzgqaYRRylg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "@repeaterjs/repeater": "3.0.4",
@@ -1371,7 +1372,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.0.0.tgz",
       "integrity": "sha512-7R9IWRN1Iszyayd4qgguITLLTmRUZ3wSS5umK0xwShB8mFQ5cSsVx6rewPhGIwGEenN6e9ahwcGX9ytuLlw55g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "@repeaterjs/repeater": "^3.0.4",
@@ -1393,7 +1394,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.0.1.tgz",
       "integrity": "sha512-PQrTJ+ncHMEQspBARc2lhwiQFfRAX/z/CsOdZTFjIljOHgRWGAA1DAx7pEN0j6PflbLCfZ3NensNq2jCBwF46w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "@types/ws": "^8.0.0",
@@ -1446,7 +1447,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.0.tgz",
       "integrity": "sha512-ki6EF/mobBWJjAAC84xNrFMhNfnUFD6Y0rQMGXekrUgY0NdeYXHU0ZUgHzC9O5+55FslqUmAUHABePDHTyZsLg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@graphql-tools/utils": "^10.0.0",
         "globby": "^11.0.3",
@@ -1513,7 +1514,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.0.tgz",
       "integrity": "sha512-rPc9oDzMnycvz+X+wrN3PLrhMBQkG4+sd8EzaFN6dypcssiefgWKToXtRKI8HHK68n2xEq1PyrOpkjHFJB+GwA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@ardatan/sync-fetch": "^0.0.1",
         "@graphql-tools/delegate": "^10.0.0",
@@ -1555,7 +1556,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.0.tgz",
       "integrity": "sha512-HDOeUUh6UhpiH0WPJUQl44ODt1x5pnMUbOJZ7GjTdGQ7LK0AgVt3ftaAQ9duxLkiAtYJmu5YkULirfZGj4HzDg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@graphql-tools/delegate": "^10.0.0",
         "@graphql-tools/schema": "^10.0.0",
@@ -2492,7 +2493,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
       "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -2744,7 +2745,7 @@
     },
     "node_modules/@types/node": {
       "version": "18.15.9",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
@@ -2773,7 +2774,7 @@
       "version": "8.5.5",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
       "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2910,7 +2911,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@whatwg-node/events/-/events-0.1.1.tgz",
       "integrity": "sha512-AyQEn5hIPV7Ze+xFoXVU3QTHXVbWPrzaOkxtENMPMuNL6VVHrp4hHfDt9nrQpjO7BgvuM95dMtkycX5M/DZR3w==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=16.0.0"
       }
@@ -2919,7 +2920,7 @@
       "version": "0.9.7",
       "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.7.tgz",
       "integrity": "sha512-heClS5ctTmoEvVbFd+6ztX0SyQduI3/Q+77vtNApDU/+Mwajy6ugxaoDGgSzJUoQ37McSV09kcGCt1Jcc6z9lQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@whatwg-node/node-fetch": "^0.4.6",
         "urlpattern-polyfill": "^9.0.0"
@@ -2932,7 +2933,7 @@
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.6.tgz",
       "integrity": "sha512-9oLD57yW0WWfu4ZtEmybBrx1JfkO4TzDpD2zXlp2Ue3UJplifQRap+MbE0PxRlVWtR4KWsIRamhn7J44DkwoyA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@whatwg-node/events": "^0.1.0",
         "busboy": "^1.6.0",
@@ -3057,7 +3058,7 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -3292,7 +3293,7 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -3456,7 +3457,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
       "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "streamsearch": "^1.1.0"
       },
@@ -3486,7 +3487,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3722,7 +3723,7 @@
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
@@ -3730,7 +3731,7 @@
     },
     "node_modules/color-name": {
       "version": "1.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -3959,7 +3960,7 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/conventional-commit-types": {
@@ -3974,7 +3975,7 @@
     },
     "node_modules/cosmiconfig": {
       "version": "8.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "import-fresh": "^3.2.1",
@@ -4129,7 +4130,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.2.2.tgz",
       "integrity": "sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/date-format": {
       "version": "4.0.14",
@@ -4325,7 +4326,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
       "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4"
       }
@@ -4361,7 +4362,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -5084,7 +5085,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
       "integrity": "sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": "^12.20 || >= 14.13"
       },
@@ -5096,7 +5097,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
       "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5147,7 +5148,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
       "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
       }
@@ -5156,7 +5157,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
       "integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "punycode": "^1.3.2"
       }
@@ -5165,7 +5166,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/fastq": {
       "version": "1.15.0",
@@ -5416,20 +5417,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -5703,7 +5690,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.0.2.tgz",
       "integrity": "sha512-7TPxOrlbiG0JplSZYCyxn2XQtqVhXomEjXUmWJVSS5ET1nPhOJSsIb/WTwqWhcYX6G0RlHXSj9PLtGTKmxLNGg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@graphql-tools/graphql-file-loader": "^8.0.0",
         "@graphql-tools/json-file-loader": "^8.0.0",
@@ -5734,7 +5721,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -5744,7 +5731,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-4.2.3.tgz",
       "integrity": "sha512-lIUdtK5hdofgCTu3aT0sOaHsYR37viUuIc0rwnnDXImbwFRcumyLMeZaM0t0I/fgxS6s6JMfu0rLD1Wz9pv1ng==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5756,7 +5743,7 @@
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz",
       "integrity": "sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10"
       },
@@ -5935,7 +5922,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -5950,7 +5937,7 @@
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -6548,7 +6535,7 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-bigint": {
@@ -6884,7 +6871,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
       "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "ws": "*"
       }
@@ -8430,7 +8417,7 @@
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
       "integrity": "sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8439,11 +8426,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8501,7 +8488,7 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -8567,7 +8554,7 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -8850,7 +8837,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/meros/-/meros-1.3.0.tgz",
       "integrity": "sha512-2BNGOimxEz5hmjUG2FwoxCt5HN7BXdaWyFqEwxPTrJzVdABtrL4TiHTcsWSFAxPQ/tOnEaQEJh3qWq71QRMY+w==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=13"
       },
@@ -8961,7 +8948,7 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
       "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -9287,7 +9274,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -9298,7 +9285,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -10304,7 +10291,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -10322,7 +10309,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-env-interpolation/-/string-env-interpolation-1.0.1.tgz",
       "integrity": "sha512-78lwMoCcn0nNu8LszbP1UA7g55OeE4v7rCeWnM5B453rnNr4aq+5it3FEYtZrSEiMvHZOZ9Jlqb0OD0M2VInqg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -10668,7 +10655,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -10975,7 +10962,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
       "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -11047,13 +11034,13 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -11248,7 +11235,7 @@
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -11351,21 +11338,17 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.5.0"
-      },
-      "devDependencies": {
-        "@graphql-markdown/printer-legacy": "^1.1.3",
-        "graphql-config": "^5.0.2"
+        "@graphql-markdown/utils": "^1.5.1"
       },
       "engines": {
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@graphql-markdown/diff": "^1.0.13",
-        "@graphql-markdown/printer-legacy": "^1.4.0",
+        "@graphql-markdown/diff": "^1.0.14",
+        "@graphql-markdown/printer-legacy": "^1.4.1",
         "graphql-config": "^5.0.2"
       },
       "peerDependenciesMeta": {
@@ -11382,11 +11365,11 @@
     },
     "packages/diff": {
       "name": "@graphql-markdown/diff",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "MIT",
       "dependencies": {
         "@graphql-inspector/core": "^5.0.0",
-        "@graphql-markdown/utils": "^1.5.0",
+        "@graphql-markdown/utils": "^1.5.1",
         "@graphql-tools/graphql-file-loader": "^8.0.0",
         "@graphql-tools/load": "^8.0.0"
       },
@@ -11396,11 +11379,11 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.20.0",
+      "version": "1.20.1",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.6.0",
-        "@graphql-markdown/printer-legacy": "^1.4.0"
+        "@graphql-markdown/core": "^1.6.1",
+        "@graphql-markdown/printer-legacy": "^1.4.1"
       },
       "engines": {
         "node": ">=16.14"
@@ -11411,10 +11394,10 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.5.0"
+        "@graphql-markdown/utils": "^1.5.1"
       },
       "engines": {
         "node": ">=16.14"
@@ -11422,7 +11405,7 @@
     },
     "packages/utils": {
       "name": "@graphql-markdown/utils",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/load": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "5.0.0-alpha.2",
     "graphql": "16.7.1",
+    "graphql-config": "^5.0.2",
     "husky": "8.0.3",
     "jest": "29.6.0",
     "lodash.filter": "4.6.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -29,11 +29,11 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.5.0"
+    "@graphql-markdown/utils": "^1.5.1"
   },
   "peerDependencies": {
-    "@graphql-markdown/diff": "^1.0.13",
-    "@graphql-markdown/printer-legacy": "^1.4.0",
+    "@graphql-markdown/diff": "^1.0.14",
+    "@graphql-markdown/printer-legacy": "^1.4.1",
     "graphql-config": "^5.0.2"
   },
   "peerDependenciesMeta": {
@@ -46,10 +46,6 @@
     "graphql-config": {
       "optional": true
     }
-  },
-  "devDependencies": {
-    "@graphql-markdown/printer-legacy": "^1.1.3",
-    "graphql-config": "^5.0.2"
   },
   "directories": {
     "test": "tests"

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.13",
+  "version": "1.0.14",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@graphql-inspector/core": "^5.0.0",
-    "@graphql-markdown/utils": "^1.5.0",
+    "@graphql-markdown/utils": "^1.5.1",
     "@graphql-tools/graphql-file-loader": "^8.0.0",
     "@graphql-tools/load": "^8.0.0"
   },

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.20.0",
+  "version": "1.20.1",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -31,8 +31,8 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.6.0",
-    "@graphql-markdown/printer-legacy": "^1.4.0"
+    "@graphql-markdown/core": "^1.6.1",
+    "@graphql-markdown/printer-legacy": "^1.4.1"
   },
   "peerDependencies": {
     "@docusaurus/logger": "*"

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -22,7 +22,7 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.5.0"
+    "@graphql-markdown/utils": "^1.5.1"
   },
   "directories": {
     "test": "tests"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.5.0",
+  "version": "1.5.1",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
# Description

## What's Changed

:package: Update compatibility with `prettier` 3.0.0 when using [`pretty`](https://graphql-markdown.github.io/docs/settings#pretty) setting. :magic_wand: 

### @graphql-markdown/docusaurus@1.20.1
* :package: bump dependency @graphql-markdown/core to 1.6.1
* :package: bump dependency @graphql-markdown/printer-legacy to 1.4.1

### @graphql-markdown/core@1.6.1
* :package: chore(deps): update dependency prettier to v3 by @renovate in https://github.com/graphql-markdown/graphql-markdown/pull/892
* :package: bump dependency @graphql-markdown/utils to 1.5.1
* :package: bump peerDependency @graphql-markdown/diff to 1.0.14
* :package: bump peerDependency @graphql-markdown/printer-legacy to 1.4.1

### @graphql-markdown/utils@1.5.1
* :package: chore(deps): update dependency prettier to v3 by @renovate in https://github.com/graphql-markdown/graphql-markdown/pull/892

### @graphql-markdown/printer-legacy@1.4.1
* :package: bump dependency @graphql-markdown/utils to 1.5.1

### @graphql-markdown/diff@1.0.14
* :package: bump dependency @graphql-markdown/utils to 1.5.1


# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
