### PR TITLE
895 add print option to hide code blocks

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -41,7 +41,7 @@ The possible values are:
 
 :::info
 The package `@graphql-markdown/diff` is required for using `diffMethod`.
-If the package is missing, then the change detection will be skipped.
+If the package is missing, then the change detection is always skipped.
 
 ```shell
 npm install @graphql-markdown/diff
@@ -65,7 +65,7 @@ Use these options to tweak some of the Docusaurus documentation features:
 
 <br/>
 
-```js {9-13}
+```js title="docusaurus.config.js"
 plugins: [
     [
       "@graphql-markdown/docusaurus",
@@ -74,11 +74,13 @@ plugins: [
         rootPath: "./docs",
         baseURL: "swapi",
         homepage: "./docs/swapi.md",
+        // highlight-start
         docOptions: {
           pagination: false, // disable buttons previous and next, same as CLI flag --noPagination
           toc: false, // disable page table of content, same as CLI flag --noToc
           index: true, // enable generated index pages, same as CLI flag --index
         },
+        // highlight-end
         loaders: {
           GraphQLFileLoader: "@graphql-tools/graphql-file-loader" // local file schema
         },
@@ -131,6 +133,7 @@ GraphQL schema loaders to use (see [schema loading](/docs/advanced/schema-loadin
 
 Use these options to toggle type information rendered on pages:
 
+- `codeSection`: display type code section
 - `parentTypePrefix`: prefix field names with parent type name
 - `relatedTypeSection`: display related type sections
 - `typeBadges`: add field type attributes badges
@@ -141,6 +144,7 @@ Use these options to toggle type information rendered on pages:
 
 | Setting                               | CLI flag                | Default   |
 | ------------------------------------- | ----------------------- | --------- |
+| `printTypeOptions.codeSection`        | `--noCode`              | `true`    |
 | `printTypeOptions.parentTypePrefix`   | `--noParentType`        | `true`    |
 | `printTypeOptions.relatedTypeSection` | `--noRelatedType`       | `true`    |
 | `printTypeOptions.typeBadges`         | `--noTypeBadges`        | `true`    |
@@ -148,7 +152,7 @@ Use these options to toggle type information rendered on pages:
 
 <br/>
 
-```js {9-14}
+```js title="docusaurus.config.js"
 plugins: [
     [
       "@graphql-markdown/docusaurus",
@@ -157,12 +161,15 @@ plugins: [
         rootPath: "./docs",
         baseURL: "swapi",
         homepage: "./docs/swapi.md",
+        // highlight-start
         printTypeOptions: {
+          codeSection: false, // disable code section, same as CLI flag --noCode
           parentTypePrefix: false, // disable parent prefix, same as CLI flag --noParentType
           relatedTypeSection: false, // disable related type sections, same as CLI flag --noRelatedType
           typeBadges: false, // disable type attribute badges, same as CLI flag --noTypeBadges
           deprecated: "group", // group deprecated entities, same as CLI flag --deprecated group
         },
+        // highlight-end
         loaders: {
           GraphQLFileLoader: "@graphql-tools/graphql-file-loader" // local file schema
         }
@@ -174,7 +181,7 @@ plugins: [
 <br/>
 
 :::info
-See [customize deprecated sections](/docs/advanced/custom-deprecated-section) to customize the rendering of `printTypeOptions.deprecated: "group"`.
+See **[customize deprecated sections](/docs/advanced/custom-deprecated-section)** to customize the rendering of `printTypeOptions.deprecated: "group"`.
 :::
 
 ## `pretty`
@@ -193,7 +200,8 @@ The `prettier` package has to be installed separately. If the package is not pre
 
 ## `rootPath`
 
-The output root path for the generated documentation, relative to the current workspace. The final path will be `rootPath/baseURL`.
+The output root path for the generated documentation, relative to the current workspace. 
+It works in relation with [`baseURL`](#baseurl), and the final path will be `rootPath/baseURL`.
 
 | Setting    | CLI flag                | Default  |
 | ---------- | ----------------------- | -------- |
@@ -211,7 +219,7 @@ The GraphQL schema location.
 
 The schema directive/s used for skipping types from documentation.
 
-The option supports multiple values separated by a space character, eg `--skipDocDirective @noDoc @deprecated`.
+The CLI flag supports multiple values separated by a space character, eg `--skip @noDoc @deprecated`.
 
 | Setting            | CLI flag                 | Default |
 | ------------------ | ------------------------ | ------- |
@@ -220,7 +228,7 @@ The option supports multiple values separated by a space character, eg `--skipDo
 <br/>
 
 :::info
-Types with `@deprecated` directive can also be skipped by setting [`printTypeOptions.deprecated`](#printtypeoptions) to `skip`.
+Types with `@deprecated` directive can also be skipped using the setting **[`printTypeOptions.deprecated: "skip"`](#printtypeoptions)** or the flag `--deprecated skip`.
 :::
 
 ## `tmpDir`

--- a/packages/core/src/config.js
+++ b/packages/core/src/config.js
@@ -26,6 +26,7 @@ const DEFAULT_OPTIONS = {
   pretty: false,
   printer: "@graphql-markdown/printer-legacy",
   printTypeOptions: {
+    codeSection: true,
     deprecated: "default",
     parentTypePrefix: true,
     relatedTypeSection: true,
@@ -113,14 +114,15 @@ function getDocOptions(cliOpts, configOptions) {
 
 function gePrintTypeOptions(cliOpts, configOptions) {
   return {
-    parentTypePrefix: !cliOpts.noParentType && configOptions.parentTypePrefix,
-    relatedTypeSection:
-      !cliOpts.noRelatedType && configOptions.relatedTypeSection,
-    typeBadges: !cliOpts.noTypeBadges && configOptions.typeBadges,
+    codeSection: !cliOpts.noCode && configOptions.codeSection,
     deprecated:
       cliOpts.deprecated ??
       configOptions.deprecated ??
       DEFAULT_OPTIONS.printTypeOptions.deprecated,
+    parentTypePrefix: !cliOpts.noParentType && configOptions.parentTypePrefix,
+    relatedTypeSection:
+      !cliOpts.noRelatedType && configOptions.relatedTypeSection,
+    typeBadges: !cliOpts.noTypeBadges && configOptions.typeBadges,
   };
 }
 

--- a/packages/core/tests/unit/config.test.js
+++ b/packages/core/tests/unit/config.test.js
@@ -114,20 +114,21 @@ describe("config", () => {
         },
         groupByDirective: {
           directive: "doc",
-          field: "category",
           fallback: "Common",
+          field: "category",
         },
         pretty: true,
         docOptions: {
+          index: false,
           pagination: false,
           toc: false,
-          index: false,
         },
         printTypeOptions: {
+          codeSection: false,
+          deprecated: "group",
           parentTypePrefix: false,
           relatedTypeSection: false,
           typeBadges: false,
-          deprecated: "group",
         },
         skipDocDirective: ["@noDoc"],
         customDirective: {
@@ -187,19 +188,20 @@ describe("config", () => {
 
       const cliOpts = {
         base: "cli/schema",
-        schema: "cli/my-schema.graphql",
-        root: "cli",
-        link: "/cli",
-        homepage: "cli/my-homepage.md",
-        diff: "CLI",
-        tmp: "./cli",
-        groupByDirective: "@group(name|=misc)",
-        pretty: true,
-        noToc: true,
-        noPagination: true,
-        index: true,
-        skip: "@noDoc",
         deprecated: "group",
+        diff: "CLI",
+        groupByDirective: "@group(name|=misc)",
+        homepage: "cli/my-homepage.md",
+        index: true,
+        link: "/cli",
+        noCode: true,
+        noPagination: true,
+        noToc: true,
+        pretty: true,
+        root: "cli",
+        schema: "cli/my-schema.graphql",
+        skip: "@noDoc",
+        tmp: "./cli",
       };
 
       const config = buildConfig(configFileOpts, cliOpts);
@@ -226,6 +228,7 @@ describe("config", () => {
         },
         printTypeOptions: {
           ...DEFAULT_OPTIONS.printTypeOptions,
+          codeSection: false,
           deprecated: "group",
         },
         printer: DEFAULT_OPTIONS.printer,

--- a/packages/docusaurus/src/index.js
+++ b/packages/docusaurus/src/index.js
@@ -34,6 +34,7 @@ module.exports = function pluginGraphQLDocGenerator(_, configOptions) {
           "-h, --homepage <homepage>",
           "File location for doc landing page",
         )
+        .option("--noCode", "Disable code section for types")
         .option("--noPagination", "Disable page navigation buttons")
         .option("--noParentType", "Disable parent type name as field prefix")
         .option("--noRelatedType", "Disable related types sections")

--- a/packages/printer-legacy/src/const/options.js
+++ b/packages/printer-legacy/src/const/options.js
@@ -4,19 +4,25 @@ const OPTION_DEPRECATED = {
   SKIP: "skip",
 };
 
-const DEFAULT_OPTIONS = {
-  schema: undefined,
-  basePath: "/",
-  groups: {},
+const PRINT_TYPE_DEFAULT_OPTIONS = {
   parentTypePrefix: true,
+  printDeprecated: OPTION_DEPRECATED.DEFAULT,
+  codeSection: true,
   relatedTypeSection: true,
   typeBadges: true,
-  skipDocDirective: undefined,
-  printDeprecated: OPTION_DEPRECATED.DEFAULT,
+};
+
+const DEFAULT_OPTIONS = {
+  ...PRINT_TYPE_DEFAULT_OPTIONS,
+  basePath: "/",
   customDirectives: {},
+  groups: {},
+  schema: undefined,
+  skipDocDirective: undefined,
 };
 
 module.exports = {
-  OPTION_DEPRECATED,
   DEFAULT_OPTIONS,
+  OPTION_DEPRECATED,
+  PRINT_TYPE_DEFAULT_OPTIONS,
 };

--- a/packages/printer-legacy/tests/unit/printer.test.js
+++ b/packages/printer-legacy/tests/unit/printer.test.js
@@ -125,6 +125,7 @@ describe("Printer", () => {
       expect(Printer.options).toMatchInlineSnapshot(`
         {
           "basePath": undefined,
+          "codeSection": true,
           "customDirectives": undefined,
           "groups": undefined,
           "parentTypePrefix": true,
@@ -155,6 +156,7 @@ describe("Printer", () => {
       Printer.init({}, "test", "/", {
         groups: {},
         printTypeOptions: {
+          codeSection: false,
           parentTypePrefix: false,
           relatedTypeSection: false,
           typeBadges: false,
@@ -165,6 +167,7 @@ describe("Printer", () => {
       expect(Printer.options).toMatchInlineSnapshot(`
         {
           "basePath": undefined,
+          "codeSection": false,
           "customDirectives": undefined,
           "groups": {},
           "parentTypePrefix": false,
@@ -267,6 +270,19 @@ describe("Printer", () => {
       const code = Printer.printCode(type, DEFAULT_OPTIONS);
 
       expect(code).toMatchSnapshot();
+    });
+
+    test("returns an empty string if printTypeOptions.code is false", () => {
+      expect.hasAssertions();
+
+      const type = "TestFooBarType";
+
+      const code = Printer.printCode(type, {
+        ...DEFAULT_OPTIONS,
+        codeSection: false,
+      });
+
+      expect(code).toBe("");
     });
   });
 


### PR DESCRIPTION
# Description

Implements #895 by adding a new option `printTypeOptions.codeSection` and CLI flag `--noCode`.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
