### PR TITLE
:bug: fix badge css for relation of type sections

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
     "arrowParens",
     "autobuild",
     "automerge",
+    "barfoo",
     "Battlestation",
     "changefreq",
     "classname",

--- a/packages/printer-legacy/src/badge.js
+++ b/packages/printer-legacy/src/badge.js
@@ -63,6 +63,7 @@ function printBadge({ text, classname }) {
 }
 
 module.exports = {
+  DEFAULT_CSS_CLASSNAME,
   getTypeBadges,
   printBadge,
   printBadges,

--- a/packages/printer-legacy/src/link.js
+++ b/packages/printer-legacy/src/link.js
@@ -112,8 +112,7 @@ class Link {
     if (typeof category === "undefined") {
       return "";
     }
-    const link = Link.toLink(type, type.name, category, options);
-    return `[\`${link.text}\`](${link.url})  <Badge class="secondary" text="${category.singular}"/>`;
+    return Link.toLink(type, type.name, category, options);
   };
 
   static printParentLink = (type, options) => {

--- a/packages/printer-legacy/src/link.js
+++ b/packages/printer-legacy/src/link.js
@@ -110,7 +110,7 @@ class Link {
 
   static getRelationLink = (category, type, options) => {
     if (typeof category === "undefined") {
-      return "";
+      return undefined;
     }
     return Link.toLink(type, type.name, category, options);
   };

--- a/packages/printer-legacy/src/link.js
+++ b/packages/printer-legacy/src/link.js
@@ -22,28 +22,28 @@ const {
 } = require("@graphql-markdown/utils");
 
 const { getGroup } = require("./group");
-const { ROOT_TYPE_LOCALE, DEPRECATED } = require("./const/strings");
+const { DEPRECATED, ROOT_TYPE_LOCALE } = require("./const/strings");
 const { OPTION_DEPRECATED } = require("./const/options");
 
 class Link {
   static getLinkCategory = (graphLQLNamedType) => {
     switch (true) {
+      case isDirectiveType(graphLQLNamedType):
+        return ROOT_TYPE_LOCALE.DIRECTIVE;
       case isEnumType(graphLQLNamedType):
         return ROOT_TYPE_LOCALE.ENUM;
-      case isUnionType(graphLQLNamedType):
-        return ROOT_TYPE_LOCALE.UNION;
+      case isInputType(graphLQLNamedType):
+        return ROOT_TYPE_LOCALE.INPUT;
       case isInterfaceType(graphLQLNamedType):
         return ROOT_TYPE_LOCALE.INTERFACE;
       case isObjectType(graphLQLNamedType):
         return ROOT_TYPE_LOCALE.TYPE;
-      case isInputType(graphLQLNamedType):
-        return ROOT_TYPE_LOCALE.INPUT;
-      case isScalarType(graphLQLNamedType):
-        return ROOT_TYPE_LOCALE.SCALAR;
-      case isDirectiveType(graphLQLNamedType):
-        return ROOT_TYPE_LOCALE.DIRECTIVE;
       case isOperation(graphLQLNamedType):
         return ROOT_TYPE_LOCALE.OPERATION;
+      case isScalarType(graphLQLNamedType):
+        return ROOT_TYPE_LOCALE.SCALAR;
+      case isUnionType(graphLQLNamedType):
+        return ROOT_TYPE_LOCALE.UNION;
     }
     return undefined;
   };

--- a/packages/printer-legacy/src/relation.js
+++ b/packages/printer-legacy/src/relation.js
@@ -1,18 +1,18 @@
 const {
   graphql: {
-    isOperation,
-    getRelationOfReturn,
     getRelationOfField,
     getRelationOfImplementation,
+    getRelationOfReturn,
+    isOperation,
   },
 } = require("@graphql-markdown/utils");
 
 const { getRelationLink } = require("./link");
-const { printBadge, DEFAULT_CSS_CLASSNAME } = require("./badge");
+const { DEFAULT_CSS_CLASSNAME, printBadge } = require("./badge");
 const {
-  ROOT_TYPE_LOCALE,
   HEADER_SECTION_LEVEL,
   MARKDOWN_EOP,
+  ROOT_TYPE_LOCALE,
 } = require("./const/strings");
 
 const getRootTypeLocaleFromString = (text) => {

--- a/packages/printer-legacy/src/relation.js
+++ b/packages/printer-legacy/src/relation.js
@@ -8,6 +8,7 @@ const {
 } = require("@graphql-markdown/utils");
 
 const { getRelationLink } = require("./link");
+const { printBadge, DEFAULT_CSS_CLASSNAME } = require("./badge");
 const {
   ROOT_TYPE_LOCALE,
   HEADER_SECTION_LEVEL,
@@ -46,7 +47,16 @@ const printRelationOf = (type, section, getRelation, options) => {
     }
 
     const category = getRootTypeLocaleFromString(relation);
-    data = data.concat(types.map((t) => getRelationLink(category, t, options)));
+    const badge = printBadge({
+      text: category.singular,
+      classname: DEFAULT_CSS_CLASSNAME,
+    });
+    data = data.concat(
+      types.map((t) => {
+        const link = getRelationLink(category, t, options);
+        return `[\`${link.text}\`](${link.url})  ${badge}`;
+      }),
+    );
   }
 
   if (data.length === 0) {

--- a/packages/printer-legacy/src/relation.js
+++ b/packages/printer-legacy/src/relation.js
@@ -54,7 +54,7 @@ const printRelationOf = (type, section, getRelation, options) => {
     data = data.concat(
       types.map((t) => {
         const link = getRelationLink(category, t, options);
-        return `[\`${link.text}\`](${link.url})  ${badge}`;
+        return link ? `[\`${link.text}\`](${link.url})  ${badge}` : "";
       }),
     );
   }

--- a/packages/printer-legacy/tests/unit/link.test.js
+++ b/packages/printer-legacy/tests/unit/link.test.js
@@ -1,4 +1,9 @@
-const { GraphQLList, GraphQLDirective, GraphQLObjectType } = require("graphql");
+const {
+  GraphQLList,
+  GraphQLDirective,
+  GraphQLObjectType,
+  GraphQLScalarType,
+} = require("graphql");
 
 jest.mock("@graphql-markdown/utils", () => {
   return {
@@ -463,6 +468,53 @@ describe("link", () => {
       jest.spyOn(Utils.object, "hasProperty").mockReturnValueOnce(false);
 
       expect(Link.printParentLink({})).toBe("");
+    });
+  });
+
+  describe("getRelationLink()", () => {
+    test("returns a link object from a relation type", () => {
+      expect.hasAssertions();
+
+      const entityName = "TestScalar";
+      const slug = "test-scalar";
+      const type = new GraphQLScalarType({
+        name: entityName,
+      });
+
+      jest.spyOn(Utils.graphql, "getNamedType").mockReturnValue(entityName);
+      jest.spyOn(Utils.graphql, "isScalarType").mockReturnValue(true);
+      jest.spyOn(Utils.string, "toSlug").mockReturnValueOnce(slug);
+
+      const link = Link.getRelationLink("foo", type, {
+        ...DEFAULT_OPTIONS,
+        basePath,
+      });
+
+      expect(link).toStrictEqual({
+        text: "TestScalar",
+        url: "docs/graphql/scalars/test-scalar",
+      });
+    });
+
+    test("returns undefined if category not defined", () => {
+      expect.hasAssertions();
+
+      const entityName = "TestScalar";
+      const slug = "test-scalar";
+      const type = new GraphQLScalarType({
+        name: entityName,
+      });
+
+      jest.spyOn(Utils.graphql, "getNamedType").mockReturnValue(entityName);
+      jest.spyOn(Utils.graphql, "isScalarType").mockReturnValue(true);
+      jest.spyOn(Utils.string, "toSlug").mockReturnValueOnce(slug);
+
+      const link = Link.getRelationLink(undefined, type, {
+        ...DEFAULT_OPTIONS,
+        basePath,
+      });
+
+      expect(link).toBeUndefined();
     });
   });
 });

--- a/packages/printer-legacy/tests/unit/relation.test.js
+++ b/packages/printer-legacy/tests/unit/relation.test.js
@@ -2,7 +2,7 @@ const { GraphQLScalarType } = require("graphql");
 
 jest.mock("@graphql-markdown/utils", () => {
   return {
-    string: { toSlug: jest.fn() },
+    string: { toSlug: jest.fn(), escapeMDX: jest.fn((s) => s) },
     url: { pathUrl: jest.fn() },
     object: { hasProperty: jest.fn() },
     graphql: {
@@ -62,7 +62,7 @@ describe("relation", () => {
       expect(relation).toMatchInlineSnapshot(`
             "### RelationOf
 
-            [\`Bar\`](#)  <Badge class="secondary" text="interface"/><Bullet />[\`Baz\`](#)  <Badge class="secondary" text="subscription"/><Bullet />[\`Foo\`](#)  <Badge class="secondary" text="query"/>
+            [\`Bar\`](#)  <Badge class="badge badge--secondary" text="interface"/><Bullet />[\`Baz\`](#)  <Badge class="badge badge--secondary" text="subscription"/><Bullet />[\`Foo\`](#)  <Badge class="badge badge--secondary" text="query"/>
 
             "
           `);

--- a/packages/printer-legacy/tests/unit/relation.test.js
+++ b/packages/printer-legacy/tests/unit/relation.test.js
@@ -2,21 +2,24 @@ const { GraphQLScalarType } = require("graphql");
 
 jest.mock("@graphql-markdown/utils", () => {
   return {
-    string: { toSlug: jest.fn(), escapeMDX: jest.fn((s) => s) },
-    url: { pathUrl: jest.fn() },
-    object: { hasProperty: jest.fn() },
     graphql: {
-      getRelationOfReturn: jest.fn(),
       getNamedType: jest.fn(),
-      isOperation: jest.fn(),
+      getRelationOfReturn: jest.fn(),
+      isDirectiveType: jest.fn(),
       isEnumType: jest.fn(),
-      isUnionType: jest.fn(),
+      isInputType: jest.fn(),
       isInterfaceType: jest.fn(),
       isObjectType: jest.fn(),
-      isInputType: jest.fn(),
+      isOperation: jest.fn(),
       isScalarType: jest.fn(),
-      isDirectiveType: jest.fn(),
+      isUnionType: jest.fn(),
     },
+    object: { hasProperty: jest.fn() },
+    string: {
+      escapeMDX: jest.fn((s) => s),
+      toSlug: jest.fn(),
+    },
+    url: { pathUrl: jest.fn() },
   };
 });
 const Utils = require("@graphql-markdown/utils");


### PR DESCRIPTION
# Description

Fix issue where "relation of" sections do not have correct CSS classname.

This was a regression after refactoring badge handling.

**Bug**

![Screenshot 2023-07-19 at 14-22-28 Deleted GraphQL-Markdown](https://github.com/graphql-markdown/graphql-markdown/assets/324670/185015cc-a811-47ba-9564-69b65049d11f)

**Fix**

![Screenshot 2023-07-19 at 14-30-46 Deleted GraphQL-Markdown](https://github.com/graphql-markdown/graphql-markdown/assets/324670/05a2d2ac-a6f4-4a8b-8bfd-15a0e19aab4e)

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
