### PR TITLE
:bookmark:  release 1.20.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -164,8 +164,9 @@
     },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
+      "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -200,19 +201,20 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.22.5",
+      "version": "7.22.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.9.tgz",
+      "integrity": "sha512-Pwyi89uO4YrGKxL/eNJ8lfEH55DnRloGPOseaA8NFNL6jAUnn+KccaISiFazCj5IolPPDjGSdzQzXVzODVRqUQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-member-expression-to-functions": "^7.22.5",
         "@babel/helper-optimise-call-expression": "^7.22.5",
-        "@babel/helper-replace-supers": "^7.22.5",
+        "@babel/helper-replace-supers": "^7.22.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.5",
-        "semver": "^6.3.0"
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -222,9 +224,10 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
-      "version": "6.3.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -262,8 +265,9 @@
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.22.5.tgz",
+      "integrity": "sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -302,8 +306,9 @@
     },
     "node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz",
+      "integrity": "sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -320,19 +325,20 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.22.5",
+      "version": "7.22.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.9.tgz",
+      "integrity": "sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-member-expression-to-functions": "^7.22.5",
-        "@babel/helper-optimise-call-expression": "^7.22.5",
-        "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/helper-optimise-call-expression": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
@@ -348,8 +354,9 @@
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
+      "integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -358,9 +365,10 @@
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.5",
+      "version": "7.22.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -482,8 +490,9 @@
     },
     "node_modules/@babel/plugin-proposal-class-properties": {
       "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
+      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -496,15 +505,16 @@
       }
     },
     "node_modules/@babel/plugin-proposal-decorators": {
-      "version": "7.22.3",
+      "version": "7.22.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.22.7.tgz",
+      "integrity": "sha512-omXqPF7Onq4Bb7wHxXjM3jSMSJvUUbvDvmmds7KI5n9Cq6Ln5I05I1W2nRlRof1rGdiUxJrxwe285WF96XlBXQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.22.1",
-        "@babel/helper-plugin-utils": "^7.21.5",
-        "@babel/helper-replace-supers": "^7.22.1",
-        "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/plugin-syntax-decorators": "^7.22.3"
+        "@babel/helper-create-class-features-plugin": "^7.22.6",
+        "@babel/helper-plugin-utils": "^7.22.5",
+        "@babel/helper-replace-supers": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/plugin-syntax-decorators": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -515,8 +525,9 @@
     },
     "node_modules/@babel/plugin-proposal-private-methods": {
       "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
+      "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -565,11 +576,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-decorators": {
-      "version": "7.22.3",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.22.5.tgz",
+      "integrity": "sha512-avpUOBS7IU6al8MmF1XpAyj9QYeLPuSDJI5D4pVMSMdL7xQokKqJPYQC67RCT0aCTashUXPiGwMJ0DEXXCEmMA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.21.5"
+        "@babel/helper-plugin-utils": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -719,8 +731,9 @@
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.22.5.tgz",
+      "integrity": "sha512-B4pzOXj+ONRmuaQTg05b3y/4DuFz3WcCNAXPLb2Q0GT0TrGKGxNKV4jwsXts+StaM0LQczZbOpj8o1DLPDJIiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.22.5",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -734,12 +747,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.22.5",
+      "version": "7.22.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.22.9.tgz",
+      "integrity": "sha512-BnVR1CpKiuD0iobHPaM1iLvcwPYN2uVFAqoLVSpEDKWuOikoCv5HbKLxclhKYUXlWkX86DoZGtqI4XhbOsyrMg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-create-class-features-plugin": "^7.22.5",
+        "@babel/helper-create-class-features-plugin": "^7.22.9",
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/plugin-syntax-typescript": "^7.22.5"
       },
@@ -752,8 +766,9 @@
     },
     "node_modules/@babel/preset-typescript": {
       "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.22.5.tgz",
+      "integrity": "sha512-YbPaal9LxztSGhmndR46FmAbkJ/1fAsw293tSU+I5E5h+cnJ3d4GTwyUgGYmOXJYdGA+uNePle4qbaRzj2NISQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
         "@babel/helper-validator-option": "^7.22.5",
@@ -1191,13 +1206,12 @@
       }
     },
     "node_modules/@graphql-inspector/core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@graphql-inspector/core/-/core-5.0.1.tgz",
-      "integrity": "sha512-1CWfFYucnRdULGiN1NDSinlNlpucBT+0x4i4AIthKe5n5jD9RIVyJtkA8zBbujUFrP++YE3l+TQifwbN1yTQsw==",
+      "version": "5.0.0",
+      "license": "MIT",
       "dependencies": {
         "dependency-graph": "0.11.0",
         "object-inspect": "1.12.3",
-        "tslib": "2.6.0"
+        "tslib": "2.5.3"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -2456,6 +2470,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@stryker-mutator/api/node_modules/tslib": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "dev": true
+    },
     "node_modules/@stryker-mutator/core": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-7.1.1.tgz",
@@ -2499,6 +2519,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@stryker-mutator/core/node_modules/tslib": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "dev": true
+    },
     "node_modules/@stryker-mutator/instrumenter": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-7.1.1.tgz",
@@ -2538,6 +2564,12 @@
       "peerDependencies": {
         "@stryker-mutator/core": "~7.1.0"
       }
+    },
+    "node_modules/@stryker-mutator/jest-runner/node_modules/tslib": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
+      "dev": true
     },
     "node_modules/@stryker-mutator/util": {
       "version": "7.1.1",
@@ -2901,8 +2933,9 @@
     },
     "node_modules/angular-html-parser": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-4.0.1.tgz",
+      "integrity": "sha512-x9SLf2jNNh3nG+haVIwKX/GVW8PcvSRmkeT9WqTDYSAVuwT9IzwEyVm09FCZpOo/dtFRxE9vaNXqcAf/MIxphg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -4716,9 +4749,8 @@
     },
     "node_modules/eslint/node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4732,9 +4764,8 @@
     },
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4747,9 +4778,8 @@
     },
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4757,9 +4787,8 @@
     },
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4773,9 +4802,8 @@
     },
     "node_modules/eslint/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4785,15 +4813,13 @@
     },
     "node_modules/eslint/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/globals": {
       "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -4806,15 +4832,13 @@
     },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4824,9 +4848,8 @@
     },
     "node_modules/eslint/node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -5298,20 +5321,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -10581,9 +10590,8 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+      "version": "2.5.3",
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -10849,9 +10857,10 @@
       }
     },
     "node_modules/weapon-regex": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "Apache-2.0"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/weapon-regex/-/weapon-regex-1.1.1.tgz",
+      "integrity": "sha512-b0RmqduiSUKyKFamrpU+UK78Jm65/6CgKq1zoWFaS9PM7vwNK4RWrjmX1jREs3pLmG7botsgMLVOltxDR7RGRw==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -11156,7 +11165,7 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/utils": "^1.5.1"
@@ -11166,7 +11175,7 @@
       },
       "peerDependencies": {
         "@graphql-markdown/diff": "^1.0.14",
-        "@graphql-markdown/printer-legacy": "^1.4.2",
+        "@graphql-markdown/printer-legacy": "^1.4.3",
         "graphql-config": "^5.0.2"
       },
       "peerDependenciesMeta": {
@@ -11197,11 +11206,11 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.20.2",
+      "version": "1.20.3",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.6.2",
-        "@graphql-markdown/printer-legacy": "^1.4.2"
+        "@graphql-markdown/core": "^1.6.3",
+        "@graphql-markdown/printer-legacy": "^1.4.3"
       },
       "engines": {
         "node": ">=16.14"
@@ -11212,7 +11221,7 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/utils": "^1.5.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.6.2",
+  "version": "1.6.3",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "@graphql-markdown/diff": "^1.0.14",
-    "@graphql-markdown/printer-legacy": "^1.4.2",
+    "@graphql-markdown/printer-legacy": "^1.4.3",
     "graphql-config": "^5.0.2"
   },
   "peerDependenciesMeta": {

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.20.2",
+  "version": "1.20.3",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {
@@ -31,8 +31,8 @@
     "stryker": "stryker run"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.6.2",
-    "@graphql-markdown/printer-legacy": "^1.4.2"
+    "@graphql-markdown/core": "^1.6.3",
+    "@graphql-markdown/printer-legacy": "^1.4.3"
   },
   "peerDependencies": {
     "@docusaurus/logger": "*"

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.4.2",
+  "version": "1.4.3",
   "license": "MIT",
   "main": "src/index.js",
   "repository": {


### PR DESCRIPTION
# Description

:bug: Fix the CSS issue for type badges in *related type* sections (see option [`printTypeOptions.relatedTypeSection`](https://graphql-markdown.github.io/docs/settings#printtypeoptions)).

* **Before fix**
  ![Screenshot 2023-07-19 at 14-22-28 Deleted GraphQL-Markdown](https://github.com/graphql-markdown/graphql-markdown/assets/324670/185015cc-a811-47ba-9564-69b65049d11f)

* **After fix**
  ![Screenshot 2023-07-19 at 14-30-46 Deleted GraphQL-Markdown](https://github.com/graphql-markdown/graphql-markdown/assets/324670/05a2d2ac-a6f4-4a8b-8bfd-15a0e19aab4e)

## What's Changed

### @graphql-markdown/docusaurus@1.20.3
* :package: bump dependency @graphql-markdown/core to 1.6.3
 * :package: bump dependency @graphql-markdown/printer-legacy to 1.4.3

### @graphql-markdown/core@1.6.3
* :package: bump peerDependency @graphql-markdown/printer-legacy to 1.4.3

### @graphql-markdown/printer-legacy@1.4.3
* :bug: fix badge css for relation of type sections by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/908

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
