### PR TITLE
:bug: fix generateDocFromSchema generator.js

### DIFF
--- a/packages/core/src/generator.js
+++ b/packages/core/src/generator.js
@@ -44,7 +44,7 @@ const generateDocFromSchema = async ({
 
   const rootTypes = getSchemaMap(schema);
   const customDirectives = getCustomDirectives(rootTypes, customDirective);
-  const groups = new getGroups(rootTypes, groupByDirective);
+  const groups = getGroups(rootTypes, groupByDirective);
   const printer = getPrinter(
     // module mandatory
     printerModule,


### PR DESCRIPTION
# Description

Fix typo introduced in https://github.com/graphql-markdown/graphql-markdown/blame/ba1002f82f1072fe4afe4c4decf39e8e2dfef99d/packages/core/src/generator.js#L47

However, this typo does not seem to impact the behavior :man_shrugging: 

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
