### PR TITLE
:bookmark:  pre-release 1.21.0-next.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15402,23 +15402,23 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.6.4",
+      "version": "1.7.0-next.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/graphql": "^1.0.0",
-        "@graphql-markdown/logger": "^1.0.0",
-        "@graphql-markdown/utils": "^1.5.1"
+        "@graphql-markdown/graphql": "^1.0.0-next.0",
+        "@graphql-markdown/logger": "^1.0.0-next.0",
+        "@graphql-markdown/utils": "^1.6.0-next.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0"
+        "@graphql-markdown/types": "^1.0.0-next.0"
       },
       "engines": {
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@graphql-markdown/diff": "^1.0.14",
-        "@graphql-markdown/helpers": "^1.0.0",
-        "@graphql-markdown/printer-legacy": "^1.4.3",
+        "@graphql-markdown/diff": "^1.1.0-next.0",
+        "@graphql-markdown/helpers": "^1.0.0-next.0",
+        "@graphql-markdown/printer-legacy": "^1.5.0-next.0",
         "graphql-config": "^5.0.2"
       },
       "peerDependenciesMeta": {
@@ -15438,17 +15438,17 @@
     },
     "packages/diff": {
       "name": "@graphql-markdown/diff",
-      "version": "1.0.14",
+      "version": "1.1.0-next.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-inspector/core": "^5.0.0",
-        "@graphql-markdown/graphql": "^1.0.0",
-        "@graphql-markdown/utils": "^1.5.1",
+        "@graphql-markdown/graphql": "^1.0.0-next.0",
+        "@graphql-markdown/utils": "^1.6.0-next.0",
         "@graphql-tools/graphql-file-loader": "^8.0.0",
         "@graphql-tools/load": "^8.0.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0"
+        "@graphql-markdown/types": "^1.0.0-next.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15456,16 +15456,16 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.20.4",
+      "version": "1.21.0-next.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.6.4",
-        "@graphql-markdown/logger": "^1.0.0",
-        "@graphql-markdown/printer-legacy": "^1.4.3"
+        "@graphql-markdown/core": "^1.7.0-next.0",
+        "@graphql-markdown/logger": "^1.0.0-next.0",
+        "@graphql-markdown/printer-legacy": "^1.5.0-next.0"
       },
       "devDependencies": {
         "@docusaurus/types": "^2.4.1",
-        "@graphql-markdown/types": "^1.0.0"
+        "@graphql-markdown/types": "^1.0.0-next.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15476,13 +15476,13 @@
     },
     "packages/graphql": {
       "name": "@graphql-markdown/graphql",
-      "version": "1.0.0",
+      "version": "1.0.0-next.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.5.1"
+        "@graphql-markdown/utils": "^1.6.0-next.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0"
+        "@graphql-markdown/types": "^1.0.0-next.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15490,13 +15490,13 @@
     },
     "packages/helpers": {
       "name": "@graphql-markdown/helpers",
-      "version": "1.0.0",
+      "version": "1.0.0-next.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/graphql": "^1.0.0"
+        "@graphql-markdown/graphql": "^1.0.0-next.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0"
+        "@graphql-markdown/types": "^1.0.0-next.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15504,10 +15504,10 @@
     },
     "packages/logger": {
       "name": "@graphql-markdown/logger",
-      "version": "1.0.0",
+      "version": "1.0.0-next.0",
       "license": "MIT",
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0"
+        "@graphql-markdown/types": "^1.0.0-next.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15515,14 +15515,14 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.4.3",
+      "version": "1.5.0-next.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/graphql": "^1.0.0",
-        "@graphql-markdown/utils": "^1.5.1"
+        "@graphql-markdown/graphql": "^1.0.0-next.0",
+        "@graphql-markdown/utils": "^1.6.0-next.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0"
+        "@graphql-markdown/types": "^1.0.0-next.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15530,18 +15530,18 @@
     },
     "packages/types": {
       "name": "@graphql-markdown/types",
-      "version": "1.0.0",
+      "version": "1.0.0-next.0",
       "license": "MIT"
     },
     "packages/utils": {
       "name": "@graphql-markdown/utils",
-      "version": "1.5.1",
+      "version": "1.6.0-next.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/load": "^8.0.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0"
+        "@graphql-markdown/types": "^1.0.0-next.0"
       },
       "engines": {
         "node": ">=16.14"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.6.4",
+  "version": "1.7.0-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -62,18 +62,18 @@
     "clean": "rm -rf ./dist"
   },
   "dependencies": {
-    "@graphql-markdown/graphql": "^1.0.0",
-    "@graphql-markdown/logger": "^1.0.0",
-    "@graphql-markdown/utils": "^1.5.1"
+    "@graphql-markdown/graphql": "^1.0.0-next.0",
+    "@graphql-markdown/logger": "^1.0.0-next.0",
+    "@graphql-markdown/utils": "^1.6.0-next.0"
   },
   "peerDependencies": {
-    "@graphql-markdown/diff": "^1.0.14",
-    "@graphql-markdown/helpers": "^1.0.0",
-    "@graphql-markdown/printer-legacy": "^1.4.3",
+    "@graphql-markdown/diff": "^1.1.0-next.0",
+    "@graphql-markdown/helpers": "^1.0.0-next.0",
+    "@graphql-markdown/printer-legacy": "^1.5.0-next.0",
     "graphql-config": "^5.0.2"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0"
+    "@graphql-markdown/types": "^1.0.0-next.0"
   },
   "peerDependenciesMeta": {
     "@graphql-markdown/printer-legacy": {

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.14",
+  "version": "1.1.0-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,13 +56,13 @@
   },
   "dependencies": {
     "@graphql-inspector/core": "^5.0.0",
-    "@graphql-markdown/graphql": "^1.0.0",
-    "@graphql-markdown/utils": "^1.5.1",
+    "@graphql-markdown/graphql": "^1.0.0-next.0",
+    "@graphql-markdown/utils": "^1.6.0-next.0",
     "@graphql-tools/graphql-file-loader": "^8.0.0",
     "@graphql-tools/load": "^8.0.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0"
+    "@graphql-markdown/types": "^1.0.0-next.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.20.4",
+  "version": "1.21.0-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -50,13 +50,13 @@
     "clean": "rm -rf ./dist"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.6.4",
-    "@graphql-markdown/logger": "^1.0.0",
-    "@graphql-markdown/printer-legacy": "^1.4.3"
+    "@graphql-markdown/core": "^1.7.0-next.0",
+    "@graphql-markdown/logger": "^1.0.0-next.0",
+    "@graphql-markdown/printer-legacy": "^1.5.0-next.0"
   },
   "devDependencies": {
     "@docusaurus/types": "^2.4.1",
-    "@graphql-markdown/types": "^1.0.0"
+    "@graphql-markdown/types": "^1.0.0-next.0"
   },
   "peerDependencies": {
     "@docusaurus/logger": "*"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.0",
+  "version": "1.0.0-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,10 +56,10 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.5.1"
+    "@graphql-markdown/utils": "^1.6.0-next.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0"
+    "@graphql-markdown/types": "^1.0.0-next.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.0",
+  "version": "1.0.0-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,10 +56,10 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/graphql": "^1.0.0"
+    "@graphql-markdown/graphql": "^1.0.0-next.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0"
+    "@graphql-markdown/types": "^1.0.0-next.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.0",
+  "version": "1.0.0-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -42,7 +42,7 @@
     "docs": "typedoc"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0"
+    "@graphql-markdown/types": "^1.0.0-next.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.4.3",
+  "version": "1.5.0-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -55,11 +55,11 @@
     "clean": "rm -rf ./dist"
   },
   "dependencies": {
-    "@graphql-markdown/graphql": "^1.0.0",
-    "@graphql-markdown/utils": "^1.5.1"
+    "@graphql-markdown/graphql": "^1.0.0-next.0",
+    "@graphql-markdown/utils": "^1.6.0-next.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0"
+    "@graphql-markdown/types": "^1.0.0-next.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-markdown/types",
-  "version": "1.0.0",
+  "version": "1.0.0-next.0",
   "description": "Common types for @graphql-markdown packages",
   "repository": {
     "type": "git",
@@ -12,7 +12,7 @@
     "types",
     "typescript"
   ],
-  "author": "Greg Heitz",
+  "author": "Gregory Heitz",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.5.1",
+  "version": "1.6.0-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -59,7 +59,7 @@
     "@graphql-tools/load": "^8.0.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0"
+    "@graphql-markdown/types": "^1.0.0-next.0"
   },
   "peerDependencies": {
     "graphql": "^14.0 || ^15.0 || ^16.0",


### PR DESCRIPTION
# Description

This is a pre-release migrating the code base from JS to TS.

## Breaking change
- Custom directive helpers have been moved to dedicated packages, see docs.

## Patch change
- Helper `directiveDescriptor` now supports `description` placeholder, where `description` is the default directive description.

## Technical change
 - Typing is available in a dedicated package `@graphql-markdown/types`.
 - Modules `helpers`, `graphql` and `logger` have been extracted from `@graphql-markdown/utils` into their own package.
 - `Logger` has now a single method called `Logger()`.
 - TS API is getting documented, see `API` in our docs.
 - More and better tests.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
