### PR TITLE
:sparkles:  add flag runOnBuild

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -67,6 +67,7 @@ smoke-init:
   COPY --dir ./packages/docusaurus/tests/__data__ ./data
   COPY ./packages/docusaurus/tests/__data__/.graphqlrc ./.graphqlrc
   COPY ./packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-build.js ./docusaurus2-graphql-doc-build.js
+  COPY ./packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-nobuild.js ./docusaurus2-graphql-doc-nobuild.js
   COPY ./website/static/img ./static/img
   RUN node config-plugin.js
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,3 +124,12 @@ Note that **`schema` is not part of the extension configuration**, but part of t
 
 - single schema only, no schema stitching
 - `include`, `exclude`, `documents` and glob pattern are not supported
+
+## Configuration lifecycle
+
+GraphQL-Markdown allows mixing the different configuration, and build the final configuration as follow:
+
+  1. Default configuration
+  2. `.graphqlrc` configuration file
+  3. Docusaurus plugin configuration
+  4. CLI flags

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -198,6 +198,15 @@ Use [`prettier`](https://prettier.io) to format generated files.
 The `prettier` package has to be installed separately. If the package is not present locally, then the formatting will always be skipped.
 :::
 
+## `runOnBuild`
+
+When set to `false` disables running doc generation on `docusaurus build`.
+If `false`, then the documentation can only be generated with the Docusaurus command `graphql-to-doc`.
+
+| Setting      | CLI flag | Default  |
+| ------------ | -------- | -------- |
+| `runOnBuild` | n/a      | `true`   |
+
 ## `rootPath`
 
 The output root path for the generated documentation, relative to the current workspace.

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -27,6 +27,9 @@ export default function pluginGraphQLDocGenerator(
     name: NAME,
 
     async loadContent(): Promise<void> {
+      if (options.runOnBuild === false) {
+        return;
+      }
       const config = await buildConfig(
         options as ConfigOptions,
         {},

--- a/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-nobuild.js
+++ b/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-nobuild.js
@@ -1,0 +1,52 @@
+module.exports = {
+  url: "https://graphql-markdown.github.io",
+  baseUrl: "/",
+  onBrokenLinks: "log",
+  onBrokenMarkdownLinks: "warn",
+  favicon: "img/favicon.ico",
+  title: "GraphQL-Markdown",
+  tagline: "Flexible GraphQL Documentation Generator",
+  organizationName: "edno",
+  projectName: "graphql-markdown",
+  trailingSlash: false,
+  themeConfig: {
+    image: "img/preview.png",
+    respectPrefersColorScheme: true,
+    navbar: {
+      title: "GraphQL-Markdown",
+      logo: {
+        alt: "GraphQL-Markdown",
+        src: "img/graphql-markdown.svg",
+        target: "_self",
+      },
+    },
+  },
+  presets: [
+    [
+      "@docusaurus/preset-classic",
+      {
+        blog: false,
+        docs: {
+          path: "docs",
+          routeBasePath: "/",
+          sidebarPath: "sidebars.js",
+        },
+        theme: {
+          customCss: require.resolve("./src/css/custom.css"),
+        },
+      },
+    ],
+  ],
+  plugins: [
+    [
+      "@graphql-markdown/docusaurus",
+      // override .graphqlrc
+      {
+        id: "schema_tweets",
+        rootPath: "./docs",
+        linkRoot: "/",
+        runOnBuild: false,
+      },
+    ],
+  ],
+};

--- a/packages/docusaurus/tests/e2e/specs/cli.spec.js
+++ b/packages/docusaurus/tests/e2e/specs/cli.spec.js
@@ -160,4 +160,21 @@ describe("loadContent", () => {
       `[INFO] {Any<Number>} pages generated in {Any<Number>}s from schema "data/tweet.graphql".`,
     );
   }, 60000);
+
+  test("should not generate plugin files on build when runOnBuild is false", async () => {
+    const generateOutput = await cli({
+      cmd: "build",
+      args: ["--config docusaurus2-graphql-doc-nobuild.js"],
+    });
+    expect(generateOutput).toMatchObject({
+      code: 0,
+      error: null,
+      stderr: "",
+      stdout: expect.any(String),
+    });
+    const stdout = generateOutput.stdout.replace(/\d+\.?\d*/g, "{Any<Number>}");
+    expect(stdout).not.toMatch(
+      `[INFO] {Any<Number>} pages generated in {Any<Number>}s from schema "data/tweet.graphql".`,
+    );
+  }, 60000);
 });


### PR DESCRIPTION
# Description

New flag `runOnBuild` that allows disabling the new behaviour of generating docs on Docusaurus build.

Default value is `true`.

NOTE: this flag is only part of `@graphql-markdown/docusaurus`, ie not available for `core`.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
