### PR TITLE
:construction_worker:  remove deprecated option for typedoc-markdown breaking doc ci

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -5,7 +5,6 @@
     "typedoc-plugin-frontmatter",
     "./scripts/custom-frontmatter.js"
   ],
-  "anchorFormat": "slug",
   "entryFileName": "index.md",
   "entryPoints": ["packages/*"],
   "entryPointStrategy": "packages",


### PR DESCRIPTION
# Description

Remove the deprecated option `anchorFormat` breaking API doc generation with Typedoc Markdown

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
