### PR TITLE
:test_tube:  fix smoke tests for runOnBuild

### DIFF
--- a/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-build.js
+++ b/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-build.js
@@ -41,7 +41,12 @@ module.exports = {
     [
       "@graphql-markdown/docusaurus",
       // override .graphqlrc
-      { id: "schema_tweets", rootPath: "./docs", linkRoot: "/" },
+      {
+        id: "schema_tweets",
+        rootPath: "./docs",
+        linkRoot: "/",
+        runOnBuild: true,
+      },
     ],
   ],
 };

--- a/packages/docusaurus/tests/e2e/specs/cli.spec.js
+++ b/packages/docusaurus/tests/e2e/specs/cli.spec.js
@@ -144,7 +144,7 @@ describe("loadContent", () => {
     await fs.writeFile(`${docsDir}/groups.md`, "");
   });
 
-  test("should generate plugin files on build", async () => {
+  test("should generate plugin files on build when runOnBuild is true", async () => {
     const generateOutput = await cli({
       cmd: "build",
       args: ["--config docusaurus2-graphql-doc-build.js"],


### PR DESCRIPTION
# Description

Fix smoke tests for `runOnBuild` broken by  commit 66d956b

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
