### PR TITLE
🔖 release 1.21.0

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -253,12 +253,16 @@ The `prettier` package has to be installed separately. If the package is not pre
 
 ## `runOnBuild`
 
-When set to `false` disables running doc generation on `docusaurus build`.
+:::warn
+`runOnBuild` is an experimental feature, and it should not be used in production.
+:::
+
+When set to `true` enables running doc generation on `docusaurus build`.
 If `false`, then the documentation can only be generated with the Docusaurus command `graphql-to-doc`.
 
 | Setting      | CLI flag | Default  |
 | ------------ | -------- | -------- |
-| `runOnBuild` | n/a      | `true`   |
+| `runOnBuild` | n/a      | `false`  |
 
 ## `rootPath`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15479,23 +15479,23 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.7.0-next.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/graphql": "^1.0.0-next.0",
-        "@graphql-markdown/logger": "^1.0.0-next.0",
-        "@graphql-markdown/utils": "^1.6.0-next.0"
+        "@graphql-markdown/graphql": "^1.0.0",
+        "@graphql-markdown/logger": "^1.0.0",
+        "@graphql-markdown/utils": "^1.6.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0-next.0"
+        "@graphql-markdown/types": "^1.0.0"
       },
       "engines": {
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@graphql-markdown/diff": "^1.1.0-next.0",
-        "@graphql-markdown/helpers": "^1.0.0-next.0",
-        "@graphql-markdown/printer-legacy": "^1.5.0-next.0",
+        "@graphql-markdown/diff": "^1.1.0",
+        "@graphql-markdown/helpers": "^1.0.0",
+        "@graphql-markdown/printer-legacy": "^1.5.0",
         "graphql-config": "^5.0.2"
       },
       "peerDependenciesMeta": {
@@ -15515,17 +15515,17 @@
     },
     "packages/diff": {
       "name": "@graphql-markdown/diff",
-      "version": "1.1.0-next.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-inspector/core": "^5.0.0",
-        "@graphql-markdown/graphql": "^1.0.0-next.0",
-        "@graphql-markdown/utils": "^1.6.0-next.0",
+        "@graphql-markdown/graphql": "^1.0.0",
+        "@graphql-markdown/utils": "^1.6.0",
         "@graphql-tools/graphql-file-loader": "^8.0.0",
         "@graphql-tools/load": "^8.0.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0-next.0"
+        "@graphql-markdown/types": "^1.0.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15533,16 +15533,16 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.21.0-next.0",
+      "version": "1.21.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.7.0-next.0",
-        "@graphql-markdown/logger": "^1.0.0-next.0",
-        "@graphql-markdown/printer-legacy": "^1.5.0-next.0"
+        "@graphql-markdown/core": "^1.7.0",
+        "@graphql-markdown/logger": "^1.0.0",
+        "@graphql-markdown/printer-legacy": "^1.5.0"
       },
       "devDependencies": {
         "@docusaurus/types": "^2.4.1",
-        "@graphql-markdown/types": "^1.0.0-next.0"
+        "@graphql-markdown/types": "^1.0.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15553,13 +15553,13 @@
     },
     "packages/graphql": {
       "name": "@graphql-markdown/graphql",
-      "version": "1.0.0-next.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.6.0-next.0"
+        "@graphql-markdown/utils": "^1.6.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0-next.0"
+        "@graphql-markdown/types": "^1.0.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15567,13 +15567,13 @@
     },
     "packages/helpers": {
       "name": "@graphql-markdown/helpers",
-      "version": "1.0.0-next.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/graphql": "^1.0.0-next.0"
+        "@graphql-markdown/graphql": "^1.0.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0-next.0"
+        "@graphql-markdown/types": "^1.0.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15581,10 +15581,10 @@
     },
     "packages/logger": {
       "name": "@graphql-markdown/logger",
-      "version": "1.0.0-next.0",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0-next.0"
+        "@graphql-markdown/types": "^1.0.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15592,14 +15592,14 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.5.0-next.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/graphql": "^1.0.0-next.0",
-        "@graphql-markdown/utils": "^1.6.0-next.0"
+        "@graphql-markdown/graphql": "^1.0.0",
+        "@graphql-markdown/utils": "^1.6.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0-next.0"
+        "@graphql-markdown/types": "^1.0.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15607,18 +15607,18 @@
     },
     "packages/types": {
       "name": "@graphql-markdown/types",
-      "version": "1.0.0-next.0",
+      "version": "1.0.0",
       "license": "MIT"
     },
     "packages/utils": {
       "name": "@graphql-markdown/utils",
-      "version": "1.6.0-next.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/load": "^8.0.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0-next.0"
+        "@graphql-markdown/types": "^1.0.0"
       },
       "engines": {
         "node": ">=16.14"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.7.0-next.0",
+  "version": "1.7.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -62,18 +62,18 @@
     "clean": "rm -rf ./dist"
   },
   "dependencies": {
-    "@graphql-markdown/graphql": "^1.0.0-next.0",
-    "@graphql-markdown/logger": "^1.0.0-next.0",
-    "@graphql-markdown/utils": "^1.6.0-next.0"
+    "@graphql-markdown/graphql": "^1.0.0",
+    "@graphql-markdown/logger": "^1.0.0",
+    "@graphql-markdown/utils": "^1.6.0"
   },
   "peerDependencies": {
-    "@graphql-markdown/diff": "^1.1.0-next.0",
-    "@graphql-markdown/helpers": "^1.0.0-next.0",
-    "@graphql-markdown/printer-legacy": "^1.5.0-next.0",
+    "@graphql-markdown/diff": "^1.1.0",
+    "@graphql-markdown/helpers": "^1.0.0",
+    "@graphql-markdown/printer-legacy": "^1.5.0",
     "graphql-config": "^5.0.2"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0-next.0"
+    "@graphql-markdown/types": "^1.0.0"
   },
   "peerDependenciesMeta": {
     "@graphql-markdown/printer-legacy": {

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.0-next.0",
+  "version": "1.1.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,13 +56,13 @@
   },
   "dependencies": {
     "@graphql-inspector/core": "^5.0.0",
-    "@graphql-markdown/graphql": "^1.0.0-next.0",
-    "@graphql-markdown/utils": "^1.6.0-next.0",
+    "@graphql-markdown/graphql": "^1.0.0",
+    "@graphql-markdown/utils": "^1.6.0",
     "@graphql-tools/graphql-file-loader": "^8.0.0",
     "@graphql-tools/load": "^8.0.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0-next.0"
+    "@graphql-markdown/types": "^1.0.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.21.0-next.0",
+  "version": "1.21.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -50,13 +50,13 @@
     "clean": "rm -rf ./dist"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.7.0-next.0",
-    "@graphql-markdown/logger": "^1.0.0-next.0",
-    "@graphql-markdown/printer-legacy": "^1.5.0-next.0"
+    "@graphql-markdown/core": "^1.7.0",
+    "@graphql-markdown/logger": "^1.0.0",
+    "@graphql-markdown/printer-legacy": "^1.5.0"
   },
   "devDependencies": {
     "@docusaurus/types": "^2.4.1",
-    "@graphql-markdown/types": "^1.0.0-next.0"
+    "@graphql-markdown/types": "^1.0.0"
   },
   "peerDependencies": {
     "@docusaurus/logger": "*"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.0-next.0",
+  "version": "1.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,10 +56,10 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/utils": "^1.6.0-next.0"
+    "@graphql-markdown/utils": "^1.6.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0-next.0"
+    "@graphql-markdown/types": "^1.0.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.0-next.0",
+  "version": "1.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,10 +56,10 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/graphql": "^1.0.0-next.0"
+    "@graphql-markdown/graphql": "^1.0.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0-next.0"
+    "@graphql-markdown/types": "^1.0.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.0-next.0",
+  "version": "1.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -42,7 +42,7 @@
     "docs": "typedoc"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0-next.0"
+    "@graphql-markdown/types": "^1.0.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.5.0-next.0",
+  "version": "1.5.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -55,11 +55,11 @@
     "clean": "rm -rf ./dist"
   },
   "dependencies": {
-    "@graphql-markdown/graphql": "^1.0.0-next.0",
-    "@graphql-markdown/utils": "^1.6.0-next.0"
+    "@graphql-markdown/graphql": "^1.0.0",
+    "@graphql-markdown/utils": "^1.6.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0-next.0"
+    "@graphql-markdown/types": "^1.0.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-markdown/types",
-  "version": "1.0.0-next.0",
+  "version": "1.0.0",
   "description": "Common types for @graphql-markdown packages",
   "repository": {
     "type": "git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.6.0-next.0",
+  "version": "1.6.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -59,7 +59,7 @@
     "@graphql-tools/load": "^8.0.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0-next.0"
+    "@graphql-markdown/types": "^1.0.0"
   },
   "peerDependencies": {
     "graphql": "^14.0 || ^15.0 || ^16.0",


### PR DESCRIPTION
# Description

🚀  **BIG release** 🚀 

This is an exceptionally big and packed release with a lot of changes, so read carefully the release notes before upgrading.

The main changes are under the hood as we migrated the codebase from Javascript to Typescript to simplify the coding experience but also to increase the code safety.

### New features
 - `onlyDocDirective` filters the schema entities to be rendered in the documentation. This is the counterpart of `skipDocDirective`, based on a request from XXXX. See documentation.
 - `metatags` adds HTML metadata to pages using [Docusaurus head metadata](https://docusaurus.io/docs/markdown-features/head-metadata), based on a request from XXXX. See documentation.
 - Helper `directiveDescriptor` now supports the `description` placeholder, where `description` is the default directive's description.

### Breaking changes
- Custom directive helpers have been moved to dedicated packages, see [docs](https://graphql-markdown.github.io/docs/advanced/custom-directive#helpers).

### Other changes
- Typing is available in a dedicated package `@graphql-markdown/types`.
- Modules helpers, graphql and logger have been extracted from `@graphql-markdown/utils` into dedicated packages.
- Logger has now a single method called log().
- TS API is getting documented, see [API](https://graphql-markdown.github.io/api/) in the docs.
- More and better tests.
- Upgrade dependencies version.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
