### PR TITLE
:test_tube:  chore(tests): use stryker disable comment

### DIFF
--- a/config/stryker.conf.js
+++ b/config/stryker.conf.js
@@ -41,7 +41,7 @@ const config = {
     enableFindRelatedTests: true,
     projectType: "custom",
   },
-  mutate: ["src/**/*.ts", "!src/**/prettier.ts"],
+  mutate: ["src/**/*.ts"],
   packageManager: "npm",
   reporters: ["html"],
   symlinkNodeModules: true,

--- a/packages/utils/src/prettier.ts
+++ b/packages/utils/src/prettier.ts
@@ -8,6 +8,8 @@ import type { LoggerType } from "@graphql-markdown/types";
 
 /* istanbul ignore file */
 
+// Stryker disable all
+
 /**
  * Prettify a string using {@link https://prettier.io/docs/en/api#prettierformatsource-options | prettier.format}.
  *


### PR DESCRIPTION
# Description

Use Stryker [`disable comment`](https://stryker-mutator.io/docs/stryker-js/disable-mutants/#using-a--stryker-disable-comment) instead of config pattern for excluding code from mutation.
This will prevent noisy warning that `prettier.ts` is not found in packages other than `utils`.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
