### PR TITLE
:memo:  (doc) update docusaurus admonition for v3 compatibility

### DIFF
--- a/docs/advanced/custom-directive.md
+++ b/docs/advanced/custom-directive.md
@@ -128,11 +128,13 @@ plugins: [
 The packages `@graphql-markdown/helpers` and `@graphql-markdown/graphql` provide few helper functions to quick start.
 
 :::info
+
 `@graphql-markdown/helpers` is an optional peer dependency, and it needs to be installed before using it.
 
 ```shell
 npm i @graphql-markdown/helpers
 ```
+
 
 :::
 

--- a/docs/advanced/homepage.md
+++ b/docs/advanced/homepage.md
@@ -19,6 +19,7 @@ This documentation has been automatically generated from the GraphQL schema.
 ```
 
 :::tip
+
 If you want to hide the homepage from the sidebar, then set the front matter `sidebar_class_name` (or `className` depending on your Docusaurus version) to `navbar__toggle`.
 
 ```markdown {6}
@@ -30,5 +31,6 @@ sidebar_position: 1
 sidebar_class_name: navbar__toggle
 ---
 ```
+
 
 :::

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,9 @@ module.exports = {
 All settings are described in the page **[settings](/docs/settings)**.
 
 :::tip
+
 If you want to use several GraphQL schemas, read our guide for **[additional schema](/docs/advanced/additional-schema)**.
+
 :::
 
 ## Sidebar
@@ -45,14 +47,18 @@ module.exports = {
 };
 ```
 
-:::caution
+:::warning
+
 The sidebar path must be relative to the `sidebars.js` location. By default, the plugin provides a relative path from the root folder of Docusaurus.
 
 For example, if your `sidebars.js` is located under `./src` folder, then you need to go one level up in the path: `./../docs/swapi/sidebar-schema`.
+
 :::
 
 :::tip
+
 See **[docs multi-instance](/docs/advanced/docs-multi-instance)** for sidebar settings when using multiple sets of documentation.
+
 :::
 
 ## Site Settings
@@ -79,7 +85,9 @@ For more details about `navbar`, please refer to Docusaurus [documentation](http
 ## GraphQL Config
 
 :::tip
+
 The GraphQL-Markdown template provides GraphQL Config as default configuration file.
+
 :::
 
 Instead of defining the configuration alongside the Docusaurus config file, you can use a [GraphQL Config](https://the-guild.dev/graphql/config/docs/user/usage) file (multiple formats supported).
@@ -116,8 +124,10 @@ extensions:
       toc: false
 ```
 
-:::caution
+:::warning
+
 Note that **`schema` is not part of the extension configuration**, but part of the default graphql-config configuration.
+
 :::
 
 **Current limitations:**

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -34,7 +34,9 @@ The command also installs all necessary dependencies you need to run Docusaurus.
 See [schema loading](/docs/advanced/schema-loading).
 
 :::tip
+
 The template comes by default with `@graphql-tools/url-loader` for remote schemas.
+
 :::
 
 ### Start your site
@@ -49,7 +51,9 @@ npm start
 The `cd` command changes the directory you're working with. In order to work with your newly created Docusaurus site, you'll need to navigate the terminal there.
 
 :::tip
+
 The `npm run doc` is a template shortcut for command line document generation `npm run docusaurus graphql-to-doc`.
+
 :::
 
 The `npm run start` command builds your website locally and serves it through a development server, ready for you to view at [http://localhost:3000/](http://localhost:3000/).
@@ -72,7 +76,9 @@ npm install @graphql-markdown/docusaurus graphql
 ```
 
 :::info
+
 The `graphql` package is a peer-dependency, and it should be installed if not yet present.
+
 :::
 
 ### Add a GraphQL schema loader

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -40,12 +40,14 @@ The possible values are:
 <br/>
 
 :::info
+
 The package `@graphql-markdown/diff` is required for using `diffMethod`.
 If the package is missing, then the change detection is always skipped.
 
 ```shell
 npm install @graphql-markdown/diff
 ```
+
 
 :::
 
@@ -110,7 +112,9 @@ The plugin provides a default page in `assets/generated`.
 <br/>
 
 :::info
+
 The GraphQL-Markdown template for Docusaurus provides a customized homepage located at `static/index.md`.
+
 :::
 
 ## `linkRoot`
@@ -179,7 +183,9 @@ See also [`skipDocDirective`](#skipdocdirective).
 <br/>
 
 :::info
+
 It only applies to types with a location compatible with the directive, i.e. if the `onlyDocDirective` cannot be applied to a type (e.g. `ENUM`) then the type will be displayed.
+
 :::
 
 ## `printTypeOptions`
@@ -234,7 +240,9 @@ plugins: [
 <br/>
 
 :::info
+
 See **[customize deprecated sections](/docs/advanced/custom-deprecated-section)** to customize the rendering of `printTypeOptions.deprecated: "group"`.
+
 :::
 
 ## `pretty`
@@ -248,13 +256,17 @@ Use [`prettier`](https://prettier.io) to format generated files.
 <br/>
 
 :::info
+
 The `prettier` package has to be installed separately. If the package is not present locally, then the formatting will always be skipped.
+
 :::
 
 ## `runOnBuild`
 
-:::caution
+:::warning
+
 `runOnBuild` is an experimental feature, and it should not be used in production.
+
 :::
 
 When set to `true` enables running doc generation on `docusaurus build`.
@@ -296,11 +308,15 @@ See also [`onlyDocDirective`](#onlydocdirective).
 <br/>
 
 :::danger
+
 Declaring the same type in both `onlyDocDirective` and `skipDocDirective` will generate an error.
+
 :::
 
 :::info
+
 Types with `@deprecated` directive can also be skipped using the setting **[`printTypeOptions.deprecated: "skip"`](#printtypeoptions)** or the flag `--deprecated skip`.
+
 :::
 
 ## `tmpDir`


### PR DESCRIPTION
# Description

Update admonition used in docs with Docusaurus syntax:
- https://docusaurus.io/docs/migration/v3#admonition-warning
- https://docusaurus.io/docs/markdown-features/admonitions

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
