### PR TITLE
:bookmark:  release 1.21.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17423,7 +17423,7 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/graphql": "^1.0.1",
@@ -17439,7 +17439,7 @@
       "peerDependencies": {
         "@graphql-markdown/diff": "^1.1.1",
         "@graphql-markdown/helpers": "^1.0.1",
-        "@graphql-markdown/printer-legacy": "^1.5.1",
+        "@graphql-markdown/printer-legacy": "^1.5.2",
         "graphql-config": "^5.0.3"
       },
       "peerDependenciesMeta": {
@@ -17477,12 +17477,12 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.21.1",
+      "version": "1.21.2",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.7.1",
+        "@graphql-markdown/core": "^1.7.2",
         "@graphql-markdown/logger": "^1.0.0",
-        "@graphql-markdown/printer-legacy": "^1.5.1"
+        "@graphql-markdown/printer-legacy": "^1.5.2"
       },
       "devDependencies": {
         "@docusaurus/types": "^3.0.0",
@@ -17536,7 +17536,7 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/utils": ">=2.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.7.1",
+  "version": "1.7.2",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -69,7 +69,7 @@
   "peerDependencies": {
     "@graphql-markdown/diff": "^1.1.1",
     "@graphql-markdown/helpers": "^1.0.1",
-    "@graphql-markdown/printer-legacy": "^1.5.1",
+    "@graphql-markdown/printer-legacy": "^1.5.2",
     "graphql-config": "^5.0.3"
   },
   "devDependencies": {

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.21.1",
+  "version": "1.21.2",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -50,9 +50,9 @@
     "clean": "rm -rf ./dist"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.7.1",
+    "@graphql-markdown/core": "^1.7.2",
     "@graphql-markdown/logger": "^1.0.0",
-    "@graphql-markdown/printer-legacy": "^1.5.1"
+    "@graphql-markdown/printer-legacy": "^1.5.2"
   },
   "devDependencies": {
     "@docusaurus/types": "^3.0.0",

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

Release implementation of #1096

---

:magic_wand:   Improve compatibility with Docusaurus 3 to use new [admonition format](https://docusaurus.io/docs/markdown-features/admonitions) for the `deprecated` admonition (see #1096).

| Docusaurus 2 | Docusaurus 3 |
|---|---|
|<code>:::caution DEPRECATED</code>|<code>:::warning[DEPRECATED]</code>|

## What's Changed

### @graphql-markdown/docusaurus@1.21.2
* :package: bump dependency @graphql-markdown/core to 1.7.2 #1103 
* :package: bump dependency @graphql-markdown/printer-legacy to 1.5.2 #1103 

### @graphql-markdown/core@1.7.2
* :package: bump peer dependency @graphql-markdown/printer-legacy to 1.5.2 #1103 

### @graphql-markdown/printer-legacy@1.5.2
* :sparkles:  (feat) replace caution admonition by warning for docusaurus v3 by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/1101

---

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
