### PR TITLE
:construction_worker:  add prepare script to package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,10 +56,13 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "prepare": "npm run build",
+    "clean": "tsc --build --clean && rm -rf ./dist",
+    "compile": "tsc --build",
+    "build": "npm run clean && npm run compile",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
-    "stryker": "stryker run",
-    "clean": "rm -rf ./dist"
+    "stryker": "stryker run"
   },
   "dependencies": {
     "@graphql-markdown/graphql": "^1.0.1",

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -49,10 +49,13 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "prepare": "npm run build",
+    "clean": "tsc --build --clean && rm -rf ./dist",
+    "compile": "tsc --build",
+    "build": "npm run clean && npm run compile",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
-    "stryker": "stryker run",
-    "clean": "rm -rf ./dist"
+    "stryker": "stryker run"
   },
   "dependencies": {
     "@graphql-inspector/core": "^5.0.0",

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -44,10 +44,13 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "prepare": "npm run build",
+    "clean": "tsc --build --clean && rm -rf ./dist",
+    "compile": "tsc --build",
+    "build": "npm run clean && npm run compile",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
-    "stryker": "stryker run",
-    "clean": "rm -rf ./dist"
+    "stryker": "stryker run"
   },
   "dependencies": {
     "@graphql-markdown/core": "^1.7.2",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -49,10 +49,13 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "prepare": "npm run build",
+    "clean": "tsc --build --clean && rm -rf ./dist",
+    "compile": "tsc --build",
+    "build": "npm run clean && npm run compile",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
     "stryker": "stryker run",
-    "clean": "rm -rf ./dist",
     "docs": "typedoc"
   },
   "dependencies": {

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -49,10 +49,13 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "prepare": "npm run build",
+    "clean": "tsc --build --clean && rm -rf ./dist",
+    "compile": "tsc --build",
+    "build": "npm run clean && npm run compile",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
     "stryker": "stryker run",
-    "clean": "rm -rf ./dist",
     "docs": "typedoc"
   },
   "dependencies": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -35,10 +35,13 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "prepare": "npm run build",
+    "clean": "tsc --build --clean && rm -rf ./dist",
+    "compile": "tsc --build",
+    "build": "npm run clean && npm run compile",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
     "stryker": "stryker run",
-    "clean": "rm -rf ./dist",
     "docs": "typedoc"
   },
   "devDependencies": {

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -49,10 +49,13 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "prepare": "npm run build",
+    "clean": "tsc --build --clean && rm -rf ./dist",
+    "compile": "tsc --build",
+    "build": "npm run clean && npm run compile",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
-    "stryker": "stryker run",
-    "clean": "rm -rf ./dist"
+    "stryker": "stryker run"
   },
   "dependencies": {
     "@docusaurus/utils": ">=2.0.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -49,10 +49,13 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "prepare": "npm run build",
+    "clean": "tsc --build --clean && rm -rf ./dist",
+    "compile": "tsc --build",
+    "build": "npm run clean && npm run compile",
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
     "stryker": "stryker run",
-    "clean": "rm -rf ./dist",
     "docs": "typedoc"
   },
   "dependencies": {


### PR DESCRIPTION
# Description

Add npm  `prepare` script to ensure that packages are build before publishing.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
