### PR TITLE
:sparkles:  add list and object support for frontMatter option

### DIFF
--- a/packages/printer-legacy/src/const/strings.ts
+++ b/packages/printer-legacy/src/const/strings.ts
@@ -16,7 +16,7 @@ export const ROOT_TYPE_LOCALE: RootTypeLocale = {
 
 export const NO_DESCRIPTION_TEXT = "No description" as const;
 
-export const FRONT_MATTER = "---" as const;
+export const FRONT_MATTER_DELIMITER = "---" as const;
 export const MARKDOWN_CODE_INDENTATION = "  " as const;
 export const MARKDOWN_EOL = "\n" as const;
 export const MARKDOWN_EOP = "\n\n" as const;

--- a/packages/printer-legacy/src/frontmatter.ts
+++ b/packages/printer-legacy/src/frontmatter.ts
@@ -85,15 +85,10 @@ export const printFrontMatter = (
   title: string,
   props?: Maybe<FrontMatterOptions>,
 ): string => {
-  const frontMatter = formatFrontMatterObject(
-    props as Record<string, unknown>,
-    -1,
-  );
+  const frontMatter = formatFrontMatterObject({ ...props, id, title }, -1);
 
   const header = [
     FRONT_MATTER_DELIMITER,
-    `id: ${id}`,
-    `title: ${title}`,
     ...frontMatter,
     FRONT_MATTER_DELIMITER,
   ];

--- a/packages/printer-legacy/src/frontmatter.ts
+++ b/packages/printer-legacy/src/frontmatter.ts
@@ -1,0 +1,105 @@
+import type { FrontMatterOptions, Maybe } from "@graphql-markdown/types";
+import {
+  FRONT_MATTER_DELIMITER,
+  MARKDOWN_CODE_INDENTATION,
+  MARKDOWN_EOL,
+} from "./const/strings";
+
+const formatFrontMatterObject = (
+  props: unknown,
+  indentation: number = 0,
+  prefix?: string,
+): string[] => {
+  const frontMatter: string[] = [];
+
+  if (!props || typeof props !== "object") {
+    return frontMatter;
+  }
+
+  for (const [key, value] of Object.entries(props)) {
+    frontMatter.push(
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      ...formatFrontMatterProp({ [key]: value }, indentation + 1, prefix),
+    );
+    prefix = " ".repeat(prefix?.length ?? 0);
+  }
+
+  return frontMatter;
+};
+
+const formatFrontMatterList = (
+  prop: unknown,
+  indentation: number = 0,
+  prefix: string = "- ",
+): string[] => {
+  const frontMatter: string[] = [];
+
+  if (!Array.isArray(prop)) {
+    return frontMatter;
+  }
+
+  const tabs = MARKDOWN_CODE_INDENTATION.repeat(indentation);
+
+  prop.forEach((entry: unknown) => {
+    if (typeof entry === "object") {
+      frontMatter.push(
+        ...formatFrontMatterObject(entry, -1, prefix).map((item) => {
+          return `${tabs}${item}`;
+        }),
+      );
+    } else {
+      frontMatter.push(`${tabs}- ${entry}`);
+    }
+  });
+
+  return frontMatter;
+};
+
+export const formatFrontMatterProp = (
+  prop: unknown,
+  indentation: number = 0,
+  prefix?: string,
+): string[] => {
+  if (typeof prop === "undefined" || prop === null) {
+    return [];
+  }
+
+  const tabs = MARKDOWN_CODE_INDENTATION.repeat(indentation);
+  const [key, value] = Object.entries(prop)[0];
+
+  switch (true) {
+    case typeof value !== "string" && Array.isArray(value):
+      return [
+        `${tabs}${prefix ?? ""}${key}:`,
+        ...formatFrontMatterList(value, indentation + 1, prefix),
+      ];
+    case typeof value === "object" && value !== null:
+      return [
+        `${tabs}${prefix ?? ""}${key}:`,
+        ...formatFrontMatterObject(value, indentation, prefix),
+      ];
+    default:
+      return [`${tabs}${prefix ?? ""}${key}: ${value}`];
+  }
+};
+
+export const printFrontMatter = (
+  id: string,
+  title: string,
+  props?: Maybe<FrontMatterOptions>,
+): string => {
+  const frontMatter = formatFrontMatterObject(
+    props as Record<string, unknown>,
+    -1,
+  );
+
+  const header = [
+    FRONT_MATTER_DELIMITER,
+    `id: ${id}`,
+    `title: ${title}`,
+    ...frontMatter,
+    FRONT_MATTER_DELIMITER,
+  ];
+
+  return header.join(MARKDOWN_EOL);
+};

--- a/packages/printer-legacy/src/frontmatter.ts
+++ b/packages/printer-legacy/src/frontmatter.ts
@@ -5,6 +5,10 @@ import {
   MARKDOWN_EOL,
 } from "./const/strings";
 
+const tabs = (indentation: number = 0): string => {
+  return MARKDOWN_CODE_INDENTATION.repeat(indentation);
+};
+
 const formatFrontMatterObject = (
   props: unknown,
   indentation: number = 0,
@@ -38,17 +42,15 @@ const formatFrontMatterList = (
     return frontMatter;
   }
 
-  const tabs = MARKDOWN_CODE_INDENTATION.repeat(indentation);
-
   prop.forEach((entry: unknown) => {
     if (typeof entry === "object") {
       frontMatter.push(
         ...formatFrontMatterObject(entry, -1, prefix).map((item) => {
-          return `${tabs}${item}`;
+          return `${tabs(indentation)}${item}`;
         }),
       );
     } else {
-      frontMatter.push(`${tabs}- ${entry}`);
+      frontMatter.push(`${tabs(indentation)}- ${entry}`);
     }
   });
 
@@ -66,20 +68,15 @@ export const formatFrontMatterProp = (
 
   const tabs = MARKDOWN_CODE_INDENTATION.repeat(indentation);
   const [key, value] = Object.entries(prop)[0];
+  const index = `${tabs}${prefix ?? ""}${key}:`;
 
   switch (true) {
     case typeof value !== "string" && Array.isArray(value):
-      return [
-        `${tabs}${prefix ?? ""}${key}:`,
-        ...formatFrontMatterList(value, indentation + 1, prefix),
-      ];
+      return [index, ...formatFrontMatterList(value, indentation + 1, prefix)];
     case typeof value === "object" && value !== null:
-      return [
-        `${tabs}${prefix ?? ""}${key}:`,
-        ...formatFrontMatterObject(value, indentation, prefix),
-      ];
+      return [index, ...formatFrontMatterObject(value, indentation, prefix)];
     default:
-      return [`${tabs}${prefix ?? ""}${key}: ${value}`];
+      return [`${index} ${value}`];
   }
 };
 

--- a/packages/printer-legacy/src/printer.ts
+++ b/packages/printer-legacy/src/printer.ts
@@ -35,6 +35,7 @@ import { pathUrl } from "@graphql-markdown/utils";
 import { printRelations } from "./relation";
 import { hasPrintableDirective, printDescription } from "./common";
 import { printCustomDirectives, printCustomTags } from "./directive";
+import { printFrontMatter } from "./frontmatter";
 import {
   printCodeDirective,
   printCodeEnum,
@@ -55,7 +56,6 @@ import {
 } from "./graphql";
 
 import {
-  FRONT_MATTER,
   MARKDOWN_EOC,
   MARKDOWN_EOL,
   MARKDOWN_EOP,
@@ -134,18 +134,9 @@ export class Printer implements IPrinter {
     title: string,
     options: PrintTypeOptions,
   ): string => {
-    const frontMatter = options.frontMatter ?? DEFAULT_OPTIONS.frontMatter!;
+    const fmOptions = options.frontMatter ?? DEFAULT_OPTIONS.frontMatter;
 
-    const header: string[] = [FRONT_MATTER, `id: ${id}`, `title: ${title}`];
-
-    if (typeof frontMatter === "object") {
-      for (const [key, value] of Object.entries(frontMatter)) {
-        header.push(`${key}: ${value}`);
-      }
-    }
-    header.push(FRONT_MATTER);
-
-    return header.join(MARKDOWN_EOL);
+    return printFrontMatter(id, title, fmOptions);
   };
 
   static printCode = (type: unknown, options: PrintTypeOptions): string => {

--- a/packages/printer-legacy/tests/unit/frontmatter.test.ts
+++ b/packages/printer-legacy/tests/unit/frontmatter.test.ts
@@ -2,6 +2,12 @@ import { formatFrontMatterProp } from "../../src/frontmatter";
 
 describe("frontMatter", () => {
   describe("formatFrontMatterProp", () => {
+    test("returns empty structure if undefined", () => {
+      expect.hasAssertions();
+
+      expect(formatFrontMatterProp(undefined)).toStrictEqual([]);
+    });
+
     test("returns flat structure for simple object", () => {
       expect.hasAssertions();
 

--- a/packages/printer-legacy/tests/unit/frontmatter.test.ts
+++ b/packages/printer-legacy/tests/unit/frontmatter.test.ts
@@ -1,0 +1,95 @@
+import { formatFrontMatterProp } from "../../src/frontmatter";
+
+describe("frontMatter", () => {
+  describe("formatFrontMatterProp", () => {
+    test("returns flat structure for simple object", () => {
+      expect.hasAssertions();
+
+      expect(formatFrontMatterProp({ item: "test" })).toStrictEqual([
+        "item: test",
+      ]);
+    });
+
+    test("returns null for null object", () => {
+      expect.hasAssertions();
+
+      expect(formatFrontMatterProp({ item: null })).toStrictEqual([
+        "item: null",
+      ]);
+    });
+
+    test("returns indented structure for nested object", () => {
+      expect.hasAssertions();
+
+      expect(formatFrontMatterProp({ item: { foo: "test" } })).toStrictEqual([
+        "item:",
+        "  foo: test",
+      ]);
+    });
+
+    test("returns indented structure for deep nested object", () => {
+      expect.hasAssertions();
+
+      expect(
+        formatFrontMatterProp({ level1: { level2: { level3: "value" } } }),
+      ).toStrictEqual(["level1:", "  level2:", "    level3: value"]);
+    });
+
+    test("returns indented list for array", () => {
+      expect.hasAssertions();
+
+      expect(formatFrontMatterProp({ item: ["a", "b", "c"] })).toStrictEqual([
+        "item:",
+        "  - a",
+        "  - b",
+        "  - c",
+      ]);
+    });
+
+    test("returns indented structure for object with array", () => {
+      expect.hasAssertions();
+
+      expect(formatFrontMatterProp({ item: { bar: ["value"] } })).toStrictEqual(
+        ["item:", "  bar:", "    - value"],
+      );
+    });
+
+    test("returns indented structure for array with object", () => {
+      expect.hasAssertions();
+
+      expect(formatFrontMatterProp({ item: [{ foo: "test" }] })).toStrictEqual([
+        "item:",
+        "  - foo: test",
+      ]);
+    });
+
+    test("returns indented structure for complex object", () => {
+      expect.hasAssertions();
+
+      expect(
+        formatFrontMatterProp({
+          item: [
+            {
+              foo: "test",
+              bar: ["a", "b", "c"],
+              baz: { foo: "baz", zap: ["a", "b", "c"] },
+            },
+          ],
+        }),
+      ).toStrictEqual([
+        "item:",
+        "  - foo: test",
+        "    bar:",
+        "    - a",
+        "    - b",
+        "    - c",
+        "    baz:",
+        "      foo: baz",
+        "      zap:",
+        "      - a",
+        "      - b",
+        "      - c",
+      ]);
+    });
+  });
+});

--- a/packages/printer-legacy/tests/unit/printer.test.ts
+++ b/packages/printer-legacy/tests/unit/printer.test.ts
@@ -304,10 +304,10 @@ describe("Printer", () => {
 
       expect(header).toMatchInlineSnapshot(`
             "---
-            id: an-object-type-name
-            title: An Object Type Name
             draft: true
             hide_table_of_contents: null
+            id: an-object-type-name
+            title: An Object Type Name
             ---"
           `);
     });


### PR DESCRIPTION
# Description

Add list and object support for `frontMatter` option needed for #1168.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
