### PR TITLE
:memo:  add missing alt prop for website main page images

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -14,6 +14,7 @@ function HomepageHeader() {
         <img
           className={clsx("hero", styles.heroImage)}
           src="/img/preview.svg"
+          alt=""
         />
         <p className="hero__subtitle">
           <span style={{ color: "#36c46f" }}>Flexible</span> documentation for{" "}
@@ -69,7 +70,7 @@ function Thanks() {
       <div className="text--center">
         <h3 className="padding-bottom--md">Thanks to our contributors</h3>
         <a href="https://github.com/graphql-markdown/graphql-markdown/graphs/contributors">
-          <img src="https://contrib.rocks/image?repo=graphql-markdown/graphql-markdown&columns=8" />
+          <img src="https://contrib.rocks/image?repo=graphql-markdown/graphql-markdown&columns=8" alt="contributors" />
         </a>
       </div>
     </div>


### PR DESCRIPTION
# Description

Add missing `alt` prop for website main page images reported by SonarCloud.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
