### PR TITLE
:label: release 1.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19099,23 +19099,23 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/graphql": "^1.0.2",
-        "@graphql-markdown/logger": "^1.0.1",
-        "@graphql-markdown/utils": "^1.6.2"
+        "@graphql-markdown/graphql": "^1.1.0",
+        "@graphql-markdown/logger": "^1.0.2",
+        "@graphql-markdown/utils": "^1.6.3"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.0"
+        "@graphql-markdown/types": "^1.2.0"
       },
       "engines": {
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@graphql-markdown/diff": "^1.1.2",
-        "@graphql-markdown/helpers": "^1.0.2",
-        "@graphql-markdown/printer-legacy": "^1.6.0",
+        "@graphql-markdown/diff": "^1.1.3",
+        "@graphql-markdown/helpers": "^1.0.3",
+        "@graphql-markdown/printer-legacy": "^1.7.0",
         "graphql-config": "^5.0.3"
       },
       "peerDependenciesMeta": {
@@ -19135,17 +19135,17 @@
     },
     "packages/diff": {
       "name": "@graphql-markdown/diff",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
         "@graphql-inspector/core": "^5.0.0",
-        "@graphql-markdown/graphql": "^1.0.2",
-        "@graphql-markdown/utils": "^1.6.2",
+        "@graphql-markdown/graphql": "^1.1.0",
+        "@graphql-markdown/utils": "^1.6.3",
         "@graphql-tools/graphql-file-loader": "^8.0.0",
         "@graphql-tools/load": "^8.0.1"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.1"
+        "@graphql-markdown/types": "^1.2.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -19153,16 +19153,16 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.22.0",
+      "version": "1.23.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.8.0",
-        "@graphql-markdown/logger": "^1.0.1",
-        "@graphql-markdown/printer-legacy": "^1.6.0"
+        "@graphql-markdown/core": "^1.9.0",
+        "@graphql-markdown/logger": "^1.0.2",
+        "@graphql-markdown/printer-legacy": "^1.7.0"
       },
       "devDependencies": {
-        "@docusaurus/types": "^3.0.0",
-        "@graphql-markdown/types": "^1.0.1"
+        "@docusaurus/types": "^3.1.1",
+        "@graphql-markdown/types": "^1.2.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -19173,14 +19173,14 @@
     },
     "packages/graphql": {
       "name": "@graphql-markdown/graphql",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.6.2",
+        "@graphql-markdown/utils": "^1.6.3",
         "@graphql-tools/load": "8.0.1"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.1"
+        "@graphql-markdown/types": "^1.2.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -19188,14 +19188,14 @@
     },
     "packages/helpers": {
       "name": "@graphql-markdown/helpers",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/graphql": "^1.0.2",
-        "@graphql-markdown/utils": "^1.6.2"
+        "@graphql-markdown/graphql": "^1.1.0",
+        "@graphql-markdown/utils": "^1.6.3"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.1"
+        "@graphql-markdown/types": "^1.2.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -19203,10 +19203,10 @@
     },
     "packages/logger": {
       "name": "@graphql-markdown/logger",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.1"
+        "@graphql-markdown/types": "^1.2.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -19214,15 +19214,15 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/utils": ">=2.0.0",
-        "@graphql-markdown/graphql": "^1.0.2",
-        "@graphql-markdown/utils": "^1.6.2"
+        "@graphql-markdown/graphql": "^1.1.0",
+        "@graphql-markdown/utils": "^1.6.3"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.1"
+        "@graphql-markdown/types": "^1.2.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -19230,7 +19230,7 @@
     },
     "packages/types": {
       "name": "@graphql-markdown/types",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@graphql-tools/load": "8.0.1",
@@ -19240,10 +19240,10 @@
     },
     "packages/utils": {
       "name": "@graphql-markdown/utils",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "MIT",
       "devDependencies": {
-        "@graphql-markdown/types": "^1.0.1"
+        "@graphql-markdown/types": "^1.2.0"
       },
       "engines": {
         "node": ">=16.14"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.8.0",
+  "version": "1.9.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -62,18 +62,18 @@
     "clean": "rm -rf ./dist"
   },
   "dependencies": {
-    "@graphql-markdown/graphql": "^1.0.2",
-    "@graphql-markdown/logger": "^1.0.1",
-    "@graphql-markdown/utils": "^1.6.2"
+    "@graphql-markdown/graphql": "^1.1.0",
+    "@graphql-markdown/logger": "^1.0.2",
+    "@graphql-markdown/utils": "^1.6.3"
   },
   "peerDependencies": {
-    "@graphql-markdown/diff": "^1.1.2",
-    "@graphql-markdown/helpers": "^1.0.2",
-    "@graphql-markdown/printer-legacy": "^1.6.0",
+    "@graphql-markdown/diff": "^1.1.3",
+    "@graphql-markdown/helpers": "^1.0.3",
+    "@graphql-markdown/printer-legacy": "^1.7.0",
     "graphql-config": "^5.0.3"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.0"
+    "@graphql-markdown/types": "^1.2.0"
   },
   "peerDependenciesMeta": {
     "@graphql-markdown/printer-legacy": {

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,13 +56,13 @@
   },
   "dependencies": {
     "@graphql-inspector/core": "^5.0.0",
-    "@graphql-markdown/graphql": "^1.0.2",
-    "@graphql-markdown/utils": "^1.6.2",
+    "@graphql-markdown/graphql": "^1.1.0",
+    "@graphql-markdown/utils": "^1.6.3",
     "@graphql-tools/graphql-file-loader": "^8.0.0",
     "@graphql-tools/load": "^8.0.1"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.1"
+    "@graphql-markdown/types": "^1.2.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.22.0",
+  "version": "1.23.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -50,13 +50,13 @@
     "clean": "rm -rf ./dist"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.8.0",
-    "@graphql-markdown/logger": "^1.0.1",
-    "@graphql-markdown/printer-legacy": "^1.6.0"
+    "@graphql-markdown/core": "^1.9.0",
+    "@graphql-markdown/logger": "^1.0.2",
+    "@graphql-markdown/printer-legacy": "^1.7.0"
   },
   "devDependencies": {
     "@docusaurus/types": "^3.0.0",
-    "@graphql-markdown/types": "^1.0.1"
+    "@graphql-markdown/types": "^1.2.0"
   },
   "peerDependencies": {
     "@docusaurus/logger": "*"

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -55,7 +55,7 @@
     "@graphql-markdown/printer-legacy": "^1.7.0"
   },
   "devDependencies": {
-    "@docusaurus/types": "^3.0.0",
+    "@docusaurus/types": "^3.1.1",
     "@graphql-markdown/types": "^1.2.0"
   },
   "peerDependencies": {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.2",
+  "version": "1.1.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -57,10 +57,10 @@
   },
   "dependencies": {
     "@graphql-tools/load": "8.0.1",
-    "@graphql-markdown/utils": "^1.6.2"
+    "@graphql-markdown/utils": "^1.6.3"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.1"
+    "@graphql-markdown/types": "^1.2.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,11 +56,11 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/graphql": "^1.0.2",
-    "@graphql-markdown/utils": "^1.6.2"
+    "@graphql-markdown/graphql": "^1.1.0",
+    "@graphql-markdown/utils": "^1.6.3"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.1"
+    "@graphql-markdown/types": "^1.2.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -42,7 +42,7 @@
     "docs": "typedoc"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.1"
+    "@graphql-markdown/types": "^1.2.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.6.0",
+  "version": "1.7.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,11 +56,11 @@
   },
   "dependencies": {
     "@docusaurus/utils": ">=2.0.0",
-    "@graphql-markdown/graphql": "^1.0.2",
-    "@graphql-markdown/utils": "^1.6.2"
+    "@graphql-markdown/graphql": "^1.1.0",
+    "@graphql-markdown/utils": "^1.6.3"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.1"
+    "@graphql-markdown/types": "^1.2.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-markdown/types",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Common types for @graphql-markdown packages",
   "repository": {
     "type": "git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.6.2",
+  "version": "1.6.3",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,7 +56,7 @@
     "docs": "typedoc"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.0.1"
+    "@graphql-markdown/types": "^1.2.0"
   },
   "peerDependencies": {
     "graphql": "^14.0 || ^15.0 || ^16.0",


### PR DESCRIPTION
# Description

Release 1.23.0

## What's changed

:sparkle: Executable types (operations and related directives) and system types (entity types) have now separate sections. The behaviour can be disabled by setting the option `printTypeOptions.useApiGrou`  to `false` or using the cli flag `--noApiGroup`.

![Screenshot from 2024-02-10 16-37-28](https://github.com/graphql-markdown/graphql-markdown/assets/324670/d339e140-4738-4df6-8631-d1e1d4fe9954)

The online examples have been updated with one using the new sections and one with the option disabled. Note that the examples have some custom CSS that is not part of the default package.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
