### PR TITLE
:recycle:  tidy up types

### DIFF
--- a/docs/advanced/additional-schema.md
+++ b/docs/advanced/additional-schema.md
@@ -13,6 +13,7 @@ Assign a unique `id` attribute to each plugin instance (if not set, then `id` va
 plugins: [
   [
     "@graphql-markdown/docusaurus",
+    /** @type {import('@graphql-markdown/types').ConfigOptions} */
     {
       // highlight-next-line
       // id: 'default', // omitted => default instance
@@ -27,6 +28,7 @@ plugins: [
   ],
   [
     "@graphql-markdown/docusaurus",
+    /** @type {import('@graphql-markdown/types').ConfigOptions} */
     {
       // highlight-next-line
       id: "admin",
@@ -57,6 +59,7 @@ plugins: [
   "@graphql-markdown/docusaurus", // default instance
   [
     "@graphql-markdown/docusaurus",
+    /** @type {import('@graphql-markdown/types').ConfigOptions} */
     {
       // highlight-next-line
       id: "admin",

--- a/docs/advanced/custom-directive.md
+++ b/docs/advanced/custom-directive.md
@@ -58,6 +58,7 @@ The `descriptor` allows rendering custom directive description applicable to ent
 plugins: [
   [
     "@graphql-markdown/docusaurus",
+    /** @type {import('@graphql-markdown/types').ConfigOptions} */
     {
       // ... other options
       customDirective: {
@@ -86,6 +87,7 @@ The `tag` allows rendering custom badges (tags) based on custom directive applic
 plugins: [
   [
     "@graphql-markdown/docusaurus",
+    /** @type {import('@graphql-markdown/types').ConfigOptions} */
     {
       // ... other options
       customDirective: {
@@ -111,6 +113,7 @@ const { directiveDescriptor, tagDescriptor } = require("@graphql-markdown/helper
 plugins: [
   [
     "@graphql-markdown/docusaurus",
+    /** @type {import('@graphql-markdown/types').ConfigOptions} */
     {
       // ... other options
       customDirective: {

--- a/docs/advanced/custom-root-types.md
+++ b/docs/advanced/custom-root-types.md
@@ -21,6 +21,7 @@ Add the option `rootTypes` to the loader options under `@graphql-markdown/docusa
 plugins: [
   [
     "@graphql-markdown/docusaurus",
+    /** @type {import('@graphql-markdown/types').ConfigOptions} */
     {
       // ... other options
       loaders: {

--- a/docs/advanced/docs-multi-instance.md
+++ b/docs/advanced/docs-multi-instance.md
@@ -11,6 +11,7 @@ In this use case, you have multiple sets of documentation (a.k.a. [Docs Multi-in
 plugins: [
   [
     "@docusaurus/plugin-content-docs",
+    /** @type {import('@graphql-markdown/types').ConfigOptions} */
     {
       id: "api",
       path: "api",

--- a/docs/advanced/examples.md
+++ b/docs/advanced/examples.md
@@ -5,7 +5,7 @@ pagination_next: null
 
 # Examples
 
-Using the option [`printTypeOptions.exampleSection`](/docs/settings#printtypeoptions), you can add examples to types documentation.
+By enabling the option [`printTypeOptions.exampleSection`](/docs/settings#printtypeoptions), you can add examples to types documentation.
 
 ## Usage
 
@@ -74,6 +74,7 @@ type CustomExampleDirective {
 plugins: [
   [
     "@graphql-markdown/docusaurus",
+    /** @type {import('@graphql-markdown/types').ConfigOptions} */
     {
       // ... other options
       printTypeOptions: {

--- a/docs/advanced/group-by-directive.md
+++ b/docs/advanced/group-by-directive.md
@@ -47,6 +47,7 @@ or the plugin configuration `groupByDirective`:
 plugins: [
   [
     "@graphql-markdown/docusaurus",
+    /** @type {import('@graphql-markdown/types').ConfigOptions} */
     {
       // ... other options
       // highlight-start

--- a/docs/advanced/schema-loading.md
+++ b/docs/advanced/schema-loading.md
@@ -42,6 +42,7 @@ Once done, you can declare the loader into `@graphql-markdown/docusaurus` config
 plugins: [
   [
     "@graphql-markdown/docusaurus",
+    /** @type {import('@graphql-markdown/types').ConfigOptions} */
     {
       // ... other options
       loaders: {
@@ -66,6 +67,7 @@ Once done, you can declare the loader into `docusaurus2-graphql-doc-generator` c
 plugins: [
   [
     "@graphql-markdown/docusaurus",
+    /** @type {import('@graphql-markdown/types').ConfigOptions} */
     {
       // ... other options
       loaders: {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,6 +12,7 @@ module.exports = {
   plugins: [
     [
       "@graphql-markdown/docusaurus",
+      /** @type {import('@graphql-markdown/types').ConfigOptions} */
       {
         schema: "./schema/swapi.graphql",
         rootPath: "./docs", // docs will be generated under './docs/swapi' (rootPath/baseURL)

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -238,7 +238,7 @@ Use these options to toggle type information rendered on pages:
 | ------------------------------------- | ----------------------- | --------- |
 | `printTypeOptions.codeSection`        | `--noCode`              | `true`    |
 | `printTypeOptions.deprecated`         | `--deprecated <option>` | `default` |
-| `printTypeOptions.exampleSection`     | `--noExample`           | `true`    |
+| `printTypeOptions.exampleSection`     | `--noExample`           | `false`   |
 | `printTypeOptions.parentTypePrefix`   | `--noParentType`        | `true`    |
 | `printTypeOptions.relatedTypeSection` | `--noRelatedType`       | `true`    |
 | `printTypeOptions.typeBadges`         | `--noTypeBadges`        | `true`    |

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -10,11 +10,12 @@ import type {
   DeprecatedCliOptions,
   DeprecatedConfigDocOptions,
   DirectiveName,
+  FrontMatterOptions,
   GroupByDirectiveOptions,
-  LoaderOption,
   Maybe,
   Options,
   PackageName,
+  Pointer,
   TypeDeprecatedOption,
   TypeDiffMethod,
 } from "@graphql-markdown/types";
@@ -43,46 +44,43 @@ export const ASSET_HOMEPAGE_LOCATION = join(
   "generated.md",
 );
 
-export const DEFAULT_OPTIONS: Required<
-  Omit<
-    ConfigOptions,
-    "customDirective" | "groupByDirective" | "loaders" | "metatags"
-  >
-> & {
-  customDirective: Maybe<CustomDirective>;
-  groupByDirective: Maybe<GroupByDirectiveOptions>;
-  loaders: Maybe<LoaderOption>;
-  metatags: Record<string, string>[];
-} = {
+export const DEFAULT_OPTIONS: Readonly<
+  Pick<ConfigOptions, "customDirective" | "groupByDirective" | "loaders"> &
+    Required<
+      Omit<ConfigOptions, "customDirective" | "groupByDirective" | "loaders">
+    >
+> = {
   id: "default",
   baseURL: "schema",
   customDirective: undefined,
   diffMethod: DiffMethod.NONE as TypeDiffMethod,
   docOptions: {
-    index: false,
-    frontMatter: {},
-  },
+    index: false as boolean,
+    frontMatter: {} as FrontMatterOptions,
+  } as Required<
+    Pick<ConfigDocOptions & DeprecatedConfigDocOptions, "frontMatter" | "index">
+  >,
   groupByDirective: undefined,
   homepage: ASSET_HOMEPAGE_LOCATION,
   linkRoot: "/",
   loaders: undefined,
   metatags: [] as Record<string, string>[],
-  pretty: false,
+  pretty: false as boolean,
   printer: "@graphql-markdown/printer-legacy" as PackageName,
   printTypeOptions: {
-    codeSection: true,
-    deprecated: DeprecatedOption.DEFAULT,
-    exampleSection: true,
-    parentTypePrefix: true,
-    relatedTypeSection: true,
-    typeBadges: true,
-    useApiGroup: true,
-  },
+    codeSection: true as boolean,
+    deprecated: DeprecatedOption.DEFAULT as TypeDeprecatedOption,
+    exampleSection: false as boolean,
+    parentTypePrefix: true as boolean,
+    relatedTypeSection: true as boolean,
+    typeBadges: true as boolean,
+    useApiGroup: true as boolean,
+  } as Required<ConfigPrintTypeOptions>,
   rootPath: "./docs",
-  schema: "./schema.graphql",
+  schema: "./schema.graphql" as Pointer,
   tmpDir: join(tmpdir(), PACKAGE_NAME),
-  skipDocDirective: [],
-  onlyDocDirective: [],
+  skipDocDirective: [] as DirectiveName[],
+  onlyDocDirective: [] as DirectiveName[],
 } as const;
 
 export const getDocDirective = (name: Maybe<DirectiveName>): DirectiveName => {
@@ -261,7 +259,7 @@ export const getDocOptions = (
     index:
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       (cliOpts?.index || configOptions?.index) ??
-      DEFAULT_OPTIONS.docOptions.index!,
+      DEFAULT_OPTIONS.docOptions!.index!,
     frontMatter: {
       ...deprecated,
       ...configOptions?.frontMatter,
@@ -276,27 +274,27 @@ export const getPrintTypeOptions = (
   return {
     codeSection:
       (!cliOpts?.noCode && configOptions?.codeSection) ??
-      DEFAULT_OPTIONS.printTypeOptions.codeSection!,
+      DEFAULT_OPTIONS.printTypeOptions!.codeSection!,
     deprecated: (
       (cliOpts?.deprecated ??
         configOptions?.deprecated ??
-        DEFAULT_OPTIONS.printTypeOptions.deprecated!) as string
+        DEFAULT_OPTIONS.printTypeOptions!.deprecated!) as string
     ).toLocaleLowerCase() as TypeDeprecatedOption,
     exampleSection:
       (!cliOpts?.noExample && configOptions?.exampleSection) ??
-      DEFAULT_OPTIONS.printTypeOptions.exampleSection!,
+      DEFAULT_OPTIONS.printTypeOptions!.exampleSection!,
     parentTypePrefix:
       (!cliOpts?.noParentType && configOptions?.parentTypePrefix) ??
-      DEFAULT_OPTIONS.printTypeOptions.parentTypePrefix!,
+      DEFAULT_OPTIONS.printTypeOptions!.parentTypePrefix!,
     relatedTypeSection:
       (!cliOpts?.noRelatedType && configOptions?.relatedTypeSection) ??
-      DEFAULT_OPTIONS.printTypeOptions.relatedTypeSection!,
+      DEFAULT_OPTIONS.printTypeOptions!.relatedTypeSection!,
     typeBadges:
       (!cliOpts?.noTypeBadges && configOptions?.typeBadges) ??
-      DEFAULT_OPTIONS.printTypeOptions.typeBadges!,
+      DEFAULT_OPTIONS.printTypeOptions!.typeBadges!,
     useApiGroup:
       (!cliOpts?.noApiGroup && configOptions?.useApiGroup) ??
-      DEFAULT_OPTIONS.printTypeOptions.useApiGroup!,
+      DEFAULT_OPTIONS.printTypeOptions!.useApiGroup!,
   } as Required<ConfigPrintTypeOptions>;
 };
 
@@ -345,7 +343,7 @@ export const buildConfig = async (
     ...configFileOpts,
   } as const;
 
-  const baseURL: string = cliOpts.base ?? config.baseURL;
+  const baseURL: string = cliOpts.base ?? config.baseURL!;
   const { onlyDocDirective, skipDocDirective } = getVisibilityDirectives(
     cliOpts,
     config,
@@ -357,7 +355,10 @@ export const buildConfig = async (
       config.customDirective,
       skipDocDirective,
     ),
-    diffMethod: getDiffMethod(cliOpts.diff ?? config.diffMethod, cliOpts.force),
+    diffMethod: getDiffMethod(
+      cliOpts.diff ?? config.diffMethod!,
+      cliOpts.force,
+    ),
     docOptions: getDocOptions(cliOpts, config.docOptions),
     groupByDirective:
       parseGroupByOption(cliOpts.groupByDirective) ?? config.groupByDirective,
@@ -368,7 +369,7 @@ export const buildConfig = async (
     loaders: config.loaders,
     metatags: config.metatags ?? DEFAULT_OPTIONS.metatags,
     onlyDocDirective,
-    outputDir: join(cliOpts.root ?? config.rootPath, baseURL),
+    outputDir: join(cliOpts.root ?? config.rootPath!, baseURL),
     prettify: cliOpts.pretty ?? config.pretty ?? DEFAULT_OPTIONS.pretty,
     printer: (config.printer ?? DEFAULT_OPTIONS.printer)!,
     printTypeOptions: getPrintTypeOptions(cliOpts, config.printTypeOptions),

--- a/packages/core/src/generator.ts
+++ b/packages/core/src/generator.ts
@@ -111,8 +111,8 @@ export const generateDocFromSchema = async ({
   );
   const renderer = new Renderer(printer, outputDir, baseURL, groups, prettify, {
     ...docOptions,
-    deprecated: printTypeOptions.deprecated,
-    useApiGroup: printTypeOptions.useApiGroup,
+    deprecated: printTypeOptions?.deprecated,
+    useApiGroup: printTypeOptions?.useApiGroup,
   });
 
   const pages = await Promise.all(

--- a/packages/core/src/graphql-config.ts
+++ b/packages/core/src/graphql-config.ts
@@ -88,7 +88,7 @@ export const loadConfiguration = async (
 
         if (typeof projectConfig.loaders !== "undefined") {
           projectConfig.loaders = setLoaderOptions(
-            projectConfig.loaders,
+            projectConfig.loaders ?? {},
             Object.values(schema)[0] as PackageOptionsConfig,
           );
         }

--- a/packages/core/tests/integration/generator.spec.ts
+++ b/packages/core/tests/integration/generator.spec.ts
@@ -162,7 +162,7 @@ describe("renderer", () => {
       await generateDocFromSchema(config);
 
       expect(vol.toJSON(config.outputDir, undefined, true)).toMatchSnapshot();
-      expect(vol.toJSON(config.tmpDir!, undefined, true)).toMatchSnapshot();
+      expect(vol.toJSON(config.tmpDir, undefined, true)).toMatchSnapshot();
     });
   });
 });

--- a/packages/core/tests/integration/generator.spec.ts
+++ b/packages/core/tests/integration/generator.spec.ts
@@ -6,8 +6,12 @@ jest.mock("node:fs/promises");
 
 import type {
   ClassName,
+  ConfigPrintTypeOptions,
+  DirectiveName,
   GeneratorOptions,
   MDXString,
+  PackageName,
+  TypeDiffMethod,
 } from "@graphql-markdown/types";
 
 jest.mock("@graphql-markdown/printer-legacy");
@@ -52,25 +56,28 @@ describe("renderer", () => {
 
       const config: GeneratorOptions = {
         baseURL: "graphql",
-        schemaLocation: join(__dirname, "../__data__/tweet.graphql"),
-        outputDir: "/output",
-        linkRoot: "docs",
-        homepageLocation: "/assets/generated.md",
         diffMethod: DiffMethod.NONE,
-        tmpDir: "/temp",
+        docOptions: {},
+        homepageLocation: "/assets/generated.md",
+        linkRoot: "docs",
         loaders: {
           ["GraphQLFileLoader" as ClassName]:
-            "@graphql-tools/graphql-file-loader",
+            "@graphql-tools/graphql-file-loader" as PackageName,
         },
-        printer: "@graphql-markdown/printer-legacy",
+        metatags: [],
+        onlyDocDirective: [],
+        outputDir: "/output",
+        prettify: false,
+        printer: "@graphql-markdown/printer-legacy" as PackageName,
         printTypeOptions: {
           ...DEFAULT_OPTIONS.printTypeOptions,
           deprecated: DeprecatedOption.DEFAULT,
           useApiGroup: false,
         },
-        onlyDocDirective: [],
+        schemaLocation: join(__dirname, "../__data__/tweet.graphql"),
         skipDocDirective: [],
-      } as GeneratorOptions;
+        tmpDir: "/temp",
+      };
 
       await generateDocFromSchema(config);
 
@@ -84,25 +91,29 @@ describe("renderer", () => {
 
       const config: GeneratorOptions = {
         baseURL: "graphql",
-        schemaLocation: join(__dirname, "../__data__/tweet.graphql"),
-        outputDir: "/output",
-        linkRoot: "docs",
+        customDirective: undefined,
+        diffMethod: "SCHEMA-HASH" as TypeDiffMethod,
+        docOptions: {},
         homepageLocation: "/assets/generated.md",
-        diffMethod: "SCHEMA-HASH",
-        tmpDir: "/temp",
+        linkRoot: "docs",
         loaders: {
           ["GraphQLFileLoader" as ClassName]:
-            "@graphql-tools/graphql-file-loader",
+            "@graphql-tools/graphql-file-loader" as PackageName,
         },
-        printer: "@graphql-markdown/printer-legacy",
+        metatags: [],
+        onlyDocDirective: [],
+        outputDir: "/output",
+        prettify: false,
+        printer: "@graphql-markdown/printer-legacy" as PackageName,
         printTypeOptions: {
           ...DEFAULT_OPTIONS.printTypeOptions,
           deprecated: DeprecatedOption.DEFAULT,
           useApiGroup: false,
-        },
-        onlyDocDirective: [],
+        } as Required<ConfigPrintTypeOptions>,
+        schemaLocation: join(__dirname, "../__data__/tweet.graphql"),
         skipDocDirective: [],
-      } as GeneratorOptions;
+        tmpDir: "/temp",
+      };
 
       jest.spyOn(diff, "checkSchemaChanges").mockResolvedValue(false);
       await generateDocFromSchema(config);
@@ -121,34 +132,37 @@ describe("renderer", () => {
           __dirname,
           "../__data__/schema_with_grouping.graphql",
         ),
-        outputDir: "/output",
-        linkRoot: "docs",
-        homepageLocation: "/assets/generated.md",
         diffMethod: DiffMethod.NONE,
-        tmpDir: "/temp",
-        loaders: {
-          ["GraphQLFileLoader" as ClassName]:
-            "@graphql-tools/graphql-file-loader",
-        },
+        docOptions: {},
         groupByDirective: {
-          directive: "doc",
+          directive: "doc" as DirectiveName,
           field: "category",
           fallback: "misc",
         },
-        printer: "@graphql-markdown/printer-legacy",
+        homepageLocation: "/assets/generated.md",
+        linkRoot: "docs",
+        loaders: {
+          ["GraphQLFileLoader" as ClassName]:
+            "@graphql-tools/graphql-file-loader" as PackageName,
+        },
+        metatags: [],
+        onlyDocDirective: [],
+        outputDir: "/output",
+        prettify: false,
+        printer: "@graphql-markdown/printer-legacy" as PackageName,
         printTypeOptions: {
           ...DEFAULT_OPTIONS.printTypeOptions,
           deprecated: DeprecatedOption.DEFAULT,
           useApiGroup: false,
         },
-        onlyDocDirective: [],
         skipDocDirective: [],
-      } as GeneratorOptions;
+        tmpDir: "/temp",
+      };
 
       await generateDocFromSchema(config);
 
       expect(vol.toJSON(config.outputDir, undefined, true)).toMatchSnapshot();
-      expect(vol.toJSON(config.tmpDir, undefined, true)).toMatchSnapshot();
+      expect(vol.toJSON(config.tmpDir!, undefined, true)).toMatchSnapshot();
     });
   });
 });

--- a/packages/core/tests/unit/config.test.ts
+++ b/packages/core/tests/unit/config.test.ts
@@ -7,6 +7,7 @@ import type {
   GraphQLDirective,
   Maybe,
   PackageName,
+  TypeDeprecatedOption,
   TypeDiffMethod,
 } from "@graphql-markdown/types";
 
@@ -68,7 +69,7 @@ describe("config", () => {
         options: {
           cliOpt: undefined,
           configFileOpts: {
-            printTypeOptions: { deprecated: "skip" },
+            printTypeOptions: { deprecated: "skip" as TypeDeprecatedOption },
           },
         },
       },
@@ -77,7 +78,7 @@ describe("config", () => {
         options: {
           cliOpt: { deprecated: "skip" },
           configFileOpts: {
-            printTypeOptions: { deprecated: "group" },
+            printTypeOptions: { deprecated: "group" as TypeDeprecatedOption },
           },
         },
       },
@@ -193,7 +194,7 @@ describe("config", () => {
           linkRoot: DEFAULT_OPTIONS.linkRoot,
           loaders: DEFAULT_OPTIONS.loaders,
           metatags: DEFAULT_OPTIONS.metatags,
-          outputDir: join(DEFAULT_OPTIONS.rootPath, DEFAULT_OPTIONS.baseURL),
+          outputDir: join(DEFAULT_OPTIONS.rootPath!, DEFAULT_OPTIONS.baseURL!),
           onlyDocDirective: DEFAULT_OPTIONS.onlyDocDirective,
           prettify: DEFAULT_OPTIONS.pretty,
           printer: DEFAULT_OPTIONS.printer,
@@ -379,7 +380,7 @@ describe("config", () => {
         loaders: configFileOpts.loaders,
         metatags: DEFAULT_OPTIONS.metatags,
         onlyDocDirective: DEFAULT_OPTIONS.onlyDocDirective,
-        outputDir: join(DEFAULT_OPTIONS.rootPath, configFileOpts.baseURL!),
+        outputDir: join(DEFAULT_OPTIONS.rootPath!, configFileOpts.baseURL!),
         prettify: cliOpts.pretty,
         printer: DEFAULT_OPTIONS.printer,
         printTypeOptions: DEFAULT_OPTIONS.printTypeOptions,
@@ -408,7 +409,7 @@ describe("config", () => {
         loaders: {},
         metatags: DEFAULT_OPTIONS.metatags,
         onlyDocDirective: DEFAULT_OPTIONS.onlyDocDirective,
-        outputDir: join(DEFAULT_OPTIONS.rootPath, DEFAULT_OPTIONS.baseURL),
+        outputDir: join(DEFAULT_OPTIONS.rootPath!, DEFAULT_OPTIONS.baseURL!),
         prettify: DEFAULT_OPTIONS.pretty,
         printer: DEFAULT_OPTIONS.printer,
         printTypeOptions: DEFAULT_OPTIONS.printTypeOptions,

--- a/packages/core/tests/unit/generator.test.ts
+++ b/packages/core/tests/unit/generator.test.ts
@@ -1,10 +1,12 @@
 jest.useFakeTimers();
 
 import type {
+  DirectiveName,
   GeneratorOptions,
   GraphQLSchema,
   IPrinter,
   LoadSchemaOptions,
+  PackageName,
   SchemaMap,
 } from "@graphql-markdown/types";
 
@@ -33,30 +35,34 @@ import { generateDocFromSchema } from "../../src";
 
 describe("generator", () => {
   describe("generateDocFromSchema()", () => {
-    const options = {
+    const options: GeneratorOptions = {
       baseURL: "base URL",
-      schemaLocation: "schema location",
-      outputDir: "output dir",
-      linkRoot: "link root",
-      homepageLocation: "homepage location",
-      tmpDir: "temp dir",
-      diffMethod: "diff method",
+      diffMethod: "diff method" as DiffMethod,
       docOptions: {
         index: true,
+        frontMatter: {},
+        useApiGroup: true,
       },
+      homepageLocation: "homepage location",
+      linkRoot: "link root",
+      metatags: [],
+      onlyDocDirective: [],
+      prettify: true,
+      printer: "printer module" as PackageName,
       printTypeOptions: {
         codeSection: true,
         deprecated: "skip",
+        exampleSection: false,
         parentTypePrefix: true,
         relatedTypeSection: true,
         typeBadges: true,
         useApiGroup: true,
       },
-      prettify: true,
-      printer: "printer module",
-      skipDocDirective: ["docDirective"],
-      onlyDocDirective: [],
-    } as GeneratorOptions;
+      outputDir: "output dir",
+      schemaLocation: "schema location",
+      tmpDir: "temp dir",
+      skipDocDirective: ["docDirective" as DirectiveName],
+    };
 
     beforeAll(() => {
       Object.assign(global, { logger: global.console });
@@ -112,6 +118,7 @@ describe("generator", () => {
         {
           customDirectives: undefined,
           groups: undefined,
+          metatags: [],
           printTypeOptions: options.printTypeOptions,
           onlyDocDirectives: [],
           skipDocDirectives: [
@@ -127,8 +134,8 @@ describe("generator", () => {
         options.prettify,
         {
           ...options.docOptions,
-          deprecated: options.printTypeOptions.deprecated,
-          useApiGroup: options.printTypeOptions.useApiGroup,
+          deprecated: options.printTypeOptions!.deprecated,
+          useApiGroup: options.printTypeOptions!.useApiGroup,
         },
       );
     });

--- a/packages/core/tests/unit/graphql-config.test.ts
+++ b/packages/core/tests/unit/graphql-config.test.ts
@@ -70,21 +70,19 @@ describe("graphql-config", () => {
       const spy = jest
         .spyOn(GraphQLConfig, "loadConfig")
         .mockResolvedValueOnce({
-          getProject: () =>
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            {
-              return {
-                extension: (): any => {
-                  return {
-                    documents: undefined,
-                    exclude: undefined,
-                    include: undefined,
-                    schema: graphqlConfig.schema,
-                    ...graphqlConfig.extensions["graphql-markdown"],
-                  } as unknown as any;
-                },
-              } as unknown as any;
-            },
+          getProject: () => {
+            return {
+              extension: (): any => {
+                return {
+                  documents: undefined,
+                  exclude: undefined,
+                  include: undefined,
+                  schema: graphqlConfig.schema,
+                  ...graphqlConfig.extensions["graphql-markdown"],
+                } as unknown as any;
+              },
+            } as unknown as any;
+          },
         } as unknown as any);
 
       await expect(
@@ -133,21 +131,19 @@ describe("graphql-config", () => {
       };
 
       jest.spyOn(GraphQLConfig, "loadConfig").mockResolvedValueOnce({
-        getProject: () =>
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-          {
-            return {
-              extension: (): any => {
-                return {
-                  documents: undefined,
-                  exclude: undefined,
-                  include: undefined,
-                  schema: graphqlConfig.schema,
-                  ...graphqlConfig.extensions["graphql-markdown"],
-                } as unknown as any;
-              },
-            } as unknown as any;
-          },
+        getProject: () => {
+          return {
+            extension: (): any => {
+              return {
+                documents: undefined,
+                exclude: undefined,
+                include: undefined,
+                schema: graphqlConfig.schema,
+                ...graphqlConfig.extensions["graphql-markdown"],
+              } as unknown as any;
+            },
+          } as unknown as any;
+        },
       } as unknown as any);
 
       await expect(
@@ -200,21 +196,19 @@ describe("graphql-config", () => {
       };
 
       jest.spyOn(GraphQLConfig, "loadConfig").mockResolvedValueOnce({
-        getProject: () =>
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-          {
-            return {
-              extension: (): any => {
-                return {
-                  documents: undefined,
-                  exclude: undefined,
-                  include: undefined,
-                  schema: graphqlConfig.projects.foo.schema,
-                  ...graphqlConfig.projects.foo.extensions["graphql-markdown"],
-                } as unknown as any;
-              },
-            } as unknown as any;
-          },
+        getProject: () => {
+          return {
+            extension: (): any => {
+              return {
+                documents: undefined,
+                exclude: undefined,
+                include: undefined,
+                schema: graphqlConfig.projects.foo.schema,
+                ...graphqlConfig.projects.foo.extensions["graphql-markdown"],
+              } as unknown as any;
+            },
+          } as unknown as any;
+        },
       } as unknown as any);
 
       await expect(
@@ -289,21 +283,19 @@ describe("config", () => {
       };
 
       jest.spyOn(GraphQLConfig, "loadConfig").mockResolvedValueOnce({
-        getProject: () =>
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-          {
-            return {
-              extension: (): any => {
-                return {
-                  documents: undefined,
-                  exclude: undefined,
-                  include: undefined,
-                  schema: graphqlConfig.schema,
-                  ...graphqlConfig.extensions["graphql-markdown"],
-                } as unknown as any;
-              },
-            } as unknown as any;
-          },
+        getProject: () => {
+          return {
+            extension: (): any => {
+              return {
+                documents: undefined,
+                exclude: undefined,
+                include: undefined,
+                schema: graphqlConfig.schema,
+                ...graphqlConfig.extensions["graphql-markdown"],
+              } as unknown as any;
+            },
+          } as unknown as any;
+        },
       } as unknown as any);
 
       const config = await buildConfig(undefined, undefined);
@@ -320,7 +312,7 @@ describe("config", () => {
           linkRoot: DEFAULT_OPTIONS.linkRoot,
           loaders: DEFAULT_OPTIONS.loaders,
           outputDir: join(
-            DEFAULT_OPTIONS.rootPath,
+            DEFAULT_OPTIONS.rootPath!,
             graphqlConfig.extensions["graphql-markdown"].baseURL,
           ),
           prettify: DEFAULT_OPTIONS.pretty,

--- a/packages/core/tests/unit/renderer.test.ts
+++ b/packages/core/tests/unit/renderer.test.ts
@@ -3,6 +3,7 @@ import { GraphQLScalarType, Kind } from "graphql";
 import type {
   IPrinter,
   MDXString,
+  RendererDocOptions,
   SchemaEntity,
   TypeDeprecatedOption,
 } from "@graphql-markdown/types";
@@ -48,10 +49,10 @@ import * as GraphQL from "@graphql-markdown/graphql";
 import { Renderer } from "../../src/renderer";
 import { DEFAULT_OPTIONS } from "../../src/config";
 
-const DEFAULT_RENDERER_OPTIONS = {
+const DEFAULT_RENDERER_OPTIONS: RendererDocOptions = {
   ...DEFAULT_OPTIONS.docOptions,
-  deprecated: DEFAULT_OPTIONS.printTypeOptions
-    .deprecated as TypeDeprecatedOption,
+  deprecated: DEFAULT_OPTIONS.printTypeOptions!
+    .deprecated! as TypeDeprecatedOption,
 };
 
 describe("renderer", () => {
@@ -65,11 +66,11 @@ describe("renderer", () => {
         "/output",
         baseURL,
         undefined,
-        DEFAULT_OPTIONS.pretty,
+        DEFAULT_OPTIONS.pretty!,
         {
           ...DEFAULT_OPTIONS.docOptions,
-          deprecated: DEFAULT_OPTIONS.printTypeOptions
-            .deprecated as TypeDeprecatedOption,
+          deprecated: DEFAULT_OPTIONS.printTypeOptions!
+            .deprecated! as TypeDeprecatedOption,
         },
       );
 

--- a/packages/docusaurus/scripts/config-plugin.js
+++ b/packages/docusaurus/scripts/config-plugin.js
@@ -1,10 +1,26 @@
-const fs = require("node:fs");
+const { writeFile } = require("node:fs");
+const { resolve } = require("node:path");
 
-const pluginConfigFilename = "docusaurus2-graphql-doc-generator.config.js";
-const pluginGroupConfigFilename =
-  "docusaurus2-graphql-doc-generator-groups.config.js";
-const pluginGraphqlrcConfigFilename =
-  "docusaurus2-graphql-doc-generator-tweets.graphqlrc.js";
+/** @type {import('@graphql-markdown/types').ConfigOptions} */
+const pluginConfig = require(
+  resolve(__dirname, "data", "docusaurus2-graphql-doc-generator.config.js"),
+);
+/** @type {import('@graphql-markdown/types').ConfigOptions} */
+const pluginGroupConfig = require(
+  resolve(
+    __dirname,
+    "data",
+    "docusaurus2-graphql-doc-generator-groups.config.js",
+  ),
+);
+/** @type {import('@graphql-markdown/types').ConfigOptions} */
+const pluginGraphqlrcConfig = require(
+  resolve(
+    __dirname,
+    "data",
+    "docusaurus2-graphql-doc-generator-tweets.graphqlrc.js",
+  ),
+);
 
 const docusaurusConfigFilepath = require.resolve("./docusaurus.config.js");
 
@@ -69,30 +85,15 @@ const config = {
     ],
   ],
   plugins: [
-    ["@graphql-markdown/docusaurus", "@config1@"],
-    ["@graphql-markdown/docusaurus", "@config2@"],
-    ["@graphql-markdown/docusaurus", "@config3@"],
+    ["@graphql-markdown/docusaurus", pluginConfig],
+    ["@graphql-markdown/docusaurus", pluginGroupConfig],
+    ["@graphql-markdown/docusaurus", pluginGraphqlrcConfig],
   ],
 };
 
-const configExportString = `
-const path = require("path");
+const configExportString = `module.exports = ${JSON.stringify(config)};`;
 
-module.exports = ${JSON.stringify(config)};\n`
-  .replace(
-    `"@config1@"`,
-    `require(path.resolve(__dirname, "data/${pluginConfigFilename}"))`,
-  )
-  .replace(
-    `"@config2@"`,
-    `require(path.resolve(__dirname, "data/${pluginGroupConfigFilename}"))`,
-  )
-  .replace(
-    `"@config3@"`,
-    `require(path.resolve(__dirname, "data/${pluginGraphqlrcConfigFilename}"))`,
-  );
-
-fs.writeFile(docusaurusConfigFilepath, configExportString, (err) => {
+writeFile(docusaurusConfigFilepath, configExportString, (err) => {
   if (err) {
     console.log(`Error updating '${docusaurusConfigFilepath}'`, err);
   } else {
@@ -103,20 +104,19 @@ fs.writeFile(docusaurusConfigFilepath, configExportString, (err) => {
 const sidebarConfig = require.resolve(`${process.cwd()}/sidebars.js`);
 
 const sidebarConfigString = `
-const path = require("path");
-const { existsSync } = require("fs");
+const { resolve } = require("node:path");
+const { existsSync } = require("node:fs");
 
+const sidebarFile = "sidebar-schema.js"
 let sidebar = {};
 
-const basicSchema = require(path.resolve(__dirname, "data/${pluginConfigFilename}"));
-const basicSidebarFile = path.resolve(__dirname, basicSchema.rootPath, basicSchema.baseURL, "sidebar-schema.js");
+const basicSidebarFile = resolve(__dirname, ${pluginConfig.rootPath}, ${pluginConfig.baseURL}, sidebarFile);
 if (existsSync(basicSidebarFile)) {
   const { schemaSidebar } = require(basicSidebarFile);
   sidebar = { ...sidebar, basic: schemaSidebar };
 }
 
-const groupSchema = require(path.resolve(__dirname, "data/${pluginGroupConfigFilename}"));
-const groupBySidebarFile = path.resolve(__dirname, groupSchema.rootPath, groupSchema.baseURL, "sidebar-schema.js");
+const groupBySidebarFile = resolve(__dirname, ${pluginGroupConfig.rootPath}, ${pluginGroupConfig.baseURL}, sidebarFile);
 if (existsSync(groupBySidebarFile)) {
   const { schemaSidebar } = require(groupBySidebarFile);
   sidebar = { ...sidebar, group: schemaSidebar };
@@ -125,7 +125,7 @@ if (existsSync(groupBySidebarFile)) {
 module.exports = sidebar;
 \n`;
 
-fs.writeFile(sidebarConfig, sidebarConfigString, (err) => {
+writeFile(sidebarConfig, sidebarConfigString, (err) => {
   if (err) {
     console.log(`Error updating '${sidebarConfig}'`, err);
   } else {

--- a/packages/docusaurus/scripts/config-plugin.js
+++ b/packages/docusaurus/scripts/config-plugin.js
@@ -1,4 +1,4 @@
-const fs = require("fs");
+const fs = require("node:fs");
 
 const pluginConfigFilename = "docusaurus2-graphql-doc-generator.config.js";
 const pluginGroupConfigFilename =
@@ -8,6 +8,7 @@ const pluginGraphqlrcConfigFilename =
 
 const docusaurusConfigFilepath = require.resolve("./docusaurus.config.js");
 
+/** @type {import('@docusaurus/types').Config} */
 const config = {
   url: "https://graphql-markdown.github.io",
   baseUrl: "/",

--- a/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-build.js
+++ b/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-build.js
@@ -1,3 +1,4 @@
+/** @type {import('@docusaurus/types').Config} */
 module.exports = {
   url: "https://graphql-markdown.github.io",
   baseUrl: "/",
@@ -41,6 +42,7 @@ module.exports = {
     [
       "@graphql-markdown/docusaurus",
       // override .graphqlrc
+      /** @type {import('@graphql-markdown/types').ConfigOptions} */
       {
         id: "schema_tweets",
         rootPath: "./docs",

--- a/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator-groups.config.js
+++ b/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator-groups.config.js
@@ -16,14 +16,14 @@ module.exports = {
   loaders: { GraphQLFileLoader: "@graphql-tools/graphql-file-loader" },
   groupByDirective: {
     directive: "doc",
-    field: "category",
     fallback: "Common",
+    field: "category",
   },
   printTypeOptions: {
     parentTypePrefix: false,
     relatedTypeSection: false,
-    typeBadges: true,
     sectionExample: true,
+    typeBadges: true,
   },
   docOptions: {
     index: true,

--- a/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator-groups.config.js
+++ b/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator-groups.config.js
@@ -5,6 +5,7 @@ const {
   directiveTag,
 } = require("@graphql-markdown/helpers");
 
+/** @type {import('@graphql-markdown/types').ConfigOptions} */
 module.exports = {
   id: "schema_with_grouping",
   schema: "data/schema_with_grouping.graphql",
@@ -22,6 +23,7 @@ module.exports = {
     parentTypePrefix: false,
     relatedTypeSection: false,
     typeBadges: true,
+    sectionExample: true,
   },
   docOptions: {
     index: true,

--- a/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator-tweets.graphqlrc.js
+++ b/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator-tweets.graphqlrc.js
@@ -1,3 +1,4 @@
+/** @type {import('@graphql-markdown/types').ConfigOptions} */
 module.exports = {
   id: "schema_tweets",
   // this config uses .graphqlrc

--- a/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator.config.js
+++ b/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-generator.config.js
@@ -1,3 +1,4 @@
+/** @type {import('@graphql-markdown/types').ConfigOptions} */
 module.exports = {
   schema: "data/tweet.graphql",
   rootPath: "./docs",

--- a/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-nobuild.js
+++ b/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-nobuild.js
@@ -1,3 +1,4 @@
+/** @type {import('@docusaurus/types').Config} */
 module.exports = {
   url: "https://graphql-markdown.github.io",
   baseUrl: "/",
@@ -41,6 +42,7 @@ module.exports = {
     [
       "@graphql-markdown/docusaurus",
       // override .graphqlrc
+      /** @type {import('@graphql-markdown/types').ConfigOptions} */
       {
         id: "schema_tweets",
         rootPath: "./docs",

--- a/packages/docusaurus/tests/__data__/groups.md
+++ b/packages/docusaurus/tests/__data__/groups.md
@@ -36,7 +36,8 @@ This is an example of documentation grouping with GraphQL directive using the `g
     parentTypePrefix: false,
     relatedTypeSection: false,
     typeBadges: true,
-    useApiGroup: false
+    sectionExample: true,
+    useApiGroup: false,
   },
   skipDocDirective: ["@noDoc"],
   customDirective: {
@@ -85,7 +86,8 @@ This is an example of documentation grouping with GraphQL directive using the `g
         parentTypePrefix: false,
         relatedTypeSection: false,
         typeBadges: true,
-        useApiGroup: false
+        sectionExample: true,
+        useApiGroup: false,
       },
       skipDocDirective: ["@noDoc"],
       customDirective: {

--- a/packages/graphql/src/directive.ts
+++ b/packages/graphql/src/directive.ts
@@ -151,11 +151,12 @@ export const getCustomDirectiveOptions = (
  */
 export const getCustomDirectives = (
   { directives: schemaDirectives }: Pick<SchemaMap, "directives">,
-  customDirectiveOptions?: CustomDirective,
+  customDirectiveOptions?: Maybe<CustomDirective>,
 ): Maybe<CustomDirectiveMap> => {
   const customDirectives: CustomDirectiveMap = {};
 
   if (
+    !customDirectiveOptions ||
     typeof schemaDirectives !== "object" ||
     typeof customDirectiveOptions !== "object"
   ) {

--- a/packages/printer-legacy/src/const/options.ts
+++ b/packages/printer-legacy/src/const/options.ts
@@ -21,7 +21,7 @@ export const PRINT_TYPE_DEFAULT_OPTIONS: Required<PrinterConfigPrintTypeOptions>
   {
     codeSection: true,
     deprecated: "default",
-    exampleSection: true,
+    exampleSection: false,
     metatags: [],
     parentTypePrefix: true,
     relatedTypeSection: true,

--- a/packages/printer-legacy/tests/unit/printer.test.ts
+++ b/packages/printer-legacy/tests/unit/printer.test.ts
@@ -174,7 +174,7 @@ describe("Printer", () => {
           "collapsible": undefined,
           "customDirectives": undefined,
           "deprecated": "default",
-          "exampleSection": true,
+          "exampleSection": false,
           "frontMatter": {},
           "groups": undefined,
           "level": undefined,
@@ -216,7 +216,7 @@ describe("Printer", () => {
         groups: {},
         printTypeOptions: {
           codeSection: false,
-          exampleSection: false,
+          exampleSection: true,
           parentTypePrefix: false,
           relatedTypeSection: false,
           typeBadges: false,
@@ -232,7 +232,7 @@ describe("Printer", () => {
           "collapsible": undefined,
           "customDirectives": undefined,
           "deprecated": "default",
-          "exampleSection": false,
+          "exampleSection": true,
           "frontMatter": {},
           "groups": {},
           "level": undefined,
@@ -481,6 +481,7 @@ describe("Printer", () => {
 
       const code = Printer.printExample(GraphQLString, {
         ...DEFAULT_OPTIONS,
+        exampleSection: true,
         schema: {
           getDirective: (name: string) => {
             return { name } as GraphQLDirective;

--- a/packages/types/src/core.d.ts
+++ b/packages/types/src/core.d.ts
@@ -6,18 +6,19 @@ import type {
   DirectiveName,
   GraphQLDirective,
   GraphQLSchema,
+  Maybe,
 } from ".";
 
 export type FrontMatterOptions = Record<string, unknown>;
 
 export interface ConfigDocOptions {
   index?: boolean;
-  frontMatter: Maybe<FrontMatterOptions>;
+  frontMatter?: Maybe<FrontMatterOptions>;
+  useApiGroup?: boolean;
 }
 
 export type RendererDocOptions = ConfigDocOptions & {
-  deprecated: TypeDeprecatedOption;
-  useApiGroup: boolean;
+  deprecated?: Maybe<TypeDeprecatedOption>;
 };
 
 export interface DeprecatedConfigDocOptions {
@@ -113,21 +114,30 @@ export interface DeprecatedCliOptions {
 
 export type Options = Omit<
   ConfigOptions,
-  "homepage" | "pretty" | "rootPath" | "schema"
-> & {
-  baseURL: string;
-  docOptions: Required<ConfigDocOptions>;
-  homepageLocation: string;
-  linkRoot: string;
-  onlyDocDirective: DirectiveName[];
-  outputDir: string;
-  prettify: boolean;
-  printer: PackageName;
-  printTypeOptions: Required<ConfigPrintTypeOptions>;
-  schemaLocation: Pointer;
-  skipDocDirective: DirectiveName[];
-  tmpDir: string;
-};
+  "homepage" | "linkRoot" | "pretty" | "rootPath"
+> &
+  Required<
+    Pick<
+      ConfigOptions,
+      | "diffMethod"
+      | "docOptions"
+      | "metatags"
+      | "onlyDocDirective"
+      | "printer"
+      | "printTypeOptions"
+      | "skipDocDirective"
+    > & {
+      baseURL: string;
+      homepageLocation: string;
+      linkRoot: string;
+      onlyDocDirective: DirectiveName[];
+      outputDir: string;
+      prettify: boolean;
+      schemaLocation: Pointer;
+      tmpDir: string;
+      skipDocDirective: DirectiveName[];
+    }
+  >;
 
 export type FunctionCheckSchemaChanges = (
   schema: GraphQLSchema,

--- a/packages/types/src/printer.d.ts
+++ b/packages/types/src/printer.d.ts
@@ -1,12 +1,12 @@
 import type {
-  Maybe,
-  TypeDeprecatedOption,
-  SchemaEntitiesGroupMap,
-  GraphQLSchema,
-  CustomDirectiveMap,
   ConfigPrintTypeOptions,
-  GraphQLDirective,
+  CustomDirectiveMap,
   FrontMatterOptions,
+  GraphQLDirective,
+  GraphQLSchema,
+  Maybe,
+  SchemaEntitiesGroupMap,
+  TypeDeprecatedOption,
   TypeExampleSectionOption,
 } from ".";
 


### PR DESCRIPTION
# Description

Tidy up types as `Maybe` was not clearly declared for `core` types.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
