### PR TITLE
:recycle:  clean up types and imports

### DIFF
--- a/packages/core/tests/unit/generator.test.ts
+++ b/packages/core/tests/unit/generator.test.ts
@@ -10,7 +10,7 @@ import type {
   SchemaMap,
 } from "@graphql-markdown/types";
 
-import { GraphQLDirective } from "graphql";
+import { GraphQLDirective } from "graphql/type";
 
 import * as GraphQL from "@graphql-markdown/graphql";
 jest.mock("@graphql-markdown/graphql", () => {

--- a/packages/core/tests/unit/printer.test.ts
+++ b/packages/core/tests/unit/printer.test.ts
@@ -1,4 +1,4 @@
-import { GraphQLSchema } from "graphql";
+import { GraphQLSchema } from "graphql/type";
 
 import type { PackageName } from "@graphql-markdown/types";
 

--- a/packages/core/tests/unit/renderer.test.ts
+++ b/packages/core/tests/unit/renderer.test.ts
@@ -1,4 +1,5 @@
-import { GraphQLScalarType, Kind } from "graphql";
+import { GraphQLScalarType } from "graphql/type";
+import { Kind } from "graphql/language";
 
 import type {
   IPrinter,

--- a/packages/graphql/src/directive.ts
+++ b/packages/graphql/src/directive.ts
@@ -19,7 +19,7 @@ import type {
 import { isEmpty } from "@graphql-markdown/utils";
 
 import { getDirective } from "./introspection";
-import { DirectiveLocation } from "graphql";
+import { DirectiveLocation } from "graphql/language";
 
 /**
  * Wildcard `*` character for matching any directive name.

--- a/packages/graphql/src/formatter.ts
+++ b/packages/graphql/src/formatter.ts
@@ -13,7 +13,7 @@ import {
   GraphQLString,
   isEnumType,
   isListType,
-} from "graphql";
+} from "graphql/type";
 
 import type { GraphQLType, Maybe } from "@graphql-markdown/types";
 

--- a/packages/graphql/src/group.ts
+++ b/packages/graphql/src/group.ts
@@ -10,8 +10,8 @@ import type {
   ConstArgumentNode,
   ConstDirectiveNode,
   StringValueNode,
-} from "graphql";
-import { Kind } from "graphql";
+} from "graphql/language";
+import { Kind } from "graphql/language";
 
 import type {
   SchemaMap,

--- a/packages/graphql/tests/unit/directive.test.ts
+++ b/packages/graphql/tests/unit/directive.test.ts
@@ -1,4 +1,6 @@
-import { DirectiveLocation, GraphQLDirective, buildSchema } from "graphql";
+import { DirectiveLocation } from "graphql/language";
+import { GraphQLDirective } from "graphql/type";
+import { buildSchema } from "graphql/utilities";
 
 import type {
   DirectiveName,

--- a/packages/graphql/tests/unit/formatter.test.ts
+++ b/packages/graphql/tests/unit/formatter.test.ts
@@ -6,7 +6,7 @@ import {
   GraphQLInt,
   GraphQLList,
   GraphQLString,
-} from "graphql";
+} from "graphql/type";
 
 import { getFormattedDefaultValue } from "../../src/formatter";
 

--- a/packages/graphql/tests/unit/group.test.ts
+++ b/packages/graphql/tests/unit/group.test.ts
@@ -1,11 +1,11 @@
-import type { GraphQLObjectType } from "graphql";
-import { buildSchema } from "graphql";
+import { buildSchema } from "graphql/utilities";
 
 import type {
+  DirectiveName,
+  GraphQLObjectType,
+  GraphQLOperationType,
   GroupByDirectiveOptions,
   SchemaMap,
-  DirectiveName,
-  GraphQLOperationType,
 } from "@graphql-markdown/types";
 
 import { getGroups, getGroupName } from "../../src/group";

--- a/packages/graphql/tests/unit/guard.test.ts
+++ b/packages/graphql/tests/unit/guard.test.ts
@@ -1,8 +1,9 @@
 import { loadSchema as gqlToolsLoadSchema } from "@graphql-tools/load";
 import { GraphQLFileLoader } from "@graphql-tools/graphql-file-loader";
 
-import type { GraphQLSchema } from "graphql";
-import { buildSchema, GraphQLObjectType } from "graphql";
+import type { GraphQLSchema } from "graphql/type";
+import { GraphQLObjectType } from "graphql/type";
+import { buildSchema } from "graphql/utilities";
 
 import { getOperation, getTypeFromSchema } from "../../src/introspection";
 import {

--- a/packages/graphql/tests/unit/loader.test.ts
+++ b/packages/graphql/tests/unit/loader.test.ts
@@ -1,6 +1,6 @@
 import { loadSchema as gqlToolsLoadSchema } from "@graphql-tools/load";
 import { GraphQLFileLoader } from "@graphql-tools/graphql-file-loader";
-import type { GraphQLSchema } from "graphql";
+import type { GraphQLSchema } from "graphql/type";
 
 import type { LoaderOption } from "@graphql-markdown/types";
 

--- a/packages/graphql/tests/unit/relation.test.ts
+++ b/packages/graphql/tests/unit/relation.test.ts
@@ -1,4 +1,4 @@
-import { buildSchema } from "graphql";
+import { buildSchema } from "graphql/utilities";
 
 import { getSchemaMap } from "../../src/introspection";
 

--- a/packages/helpers/tests/unit/directives/tag.test.ts
+++ b/packages/helpers/tests/unit/directives/tag.test.ts
@@ -1,4 +1,7 @@
-import type { GraphQLDirective, GraphQLNamedType } from "graphql";
+import type {
+  GraphQLDirective,
+  GraphQLNamedType,
+} from "@graphql-markdown/types";
 
 import { directiveTag } from "../../../src";
 

--- a/packages/printer-legacy/src/graphql/directive.ts
+++ b/packages/printer-legacy/src/graphql/directive.ts
@@ -1,7 +1,6 @@
 import type {
   PrintDirectiveOptions,
   GraphQLDirective,
-  GraphQLArgument,
   MDXString,
 } from "@graphql-markdown/types";
 
@@ -33,12 +32,7 @@ export const printDirectiveMetadata = (
     return "";
   }
 
-  return printMetadataSection(
-    type,
-    type.args as GraphQLArgument[],
-    "Arguments",
-    options,
-  );
+  return printMetadataSection(type, type.args, "Arguments", options);
 };
 
 export const printCodeDirective = (

--- a/packages/printer-legacy/src/graphql/enum.ts
+++ b/packages/printer-legacy/src/graphql/enum.ts
@@ -34,7 +34,7 @@ export const printCodeEnum = (
   }
 
   let code = `enum ${getTypeName(type)} {${MARKDOWN_EOL}`;
-  code += (type as GraphQLEnumType)
+  code += type
     .getValues()
     .map((value): string => {
       if (!hasPrintableDirective(value, options)) {

--- a/packages/printer-legacy/src/graphql/enum.ts
+++ b/packages/printer-legacy/src/graphql/enum.ts
@@ -1,8 +1,4 @@
-import type {
-  GraphQLEnumType,
-  MDXString,
-  PrintTypeOptions,
-} from "@graphql-markdown/types";
+import type { MDXString, PrintTypeOptions } from "@graphql-markdown/types";
 
 import {
   isEnumType,

--- a/packages/printer-legacy/src/graphql/scalar.ts
+++ b/packages/printer-legacy/src/graphql/scalar.ts
@@ -10,7 +10,7 @@ export const printSpecification = (type: unknown): MDXString | string => {
     typeof type !== "object" ||
     type === null ||
     !("specifiedByURL" in type) ||
-    !type.specifiedByURL
+    typeof type.specifiedByURL !== "string"
   ) {
     return "";
   }

--- a/packages/printer-legacy/src/graphql/union.ts
+++ b/packages/printer-legacy/src/graphql/union.ts
@@ -1,6 +1,5 @@
 import type {
   PrintTypeOptions,
-  GraphQLUnionType,
   MDXString,
   GraphQLObjectType,
 } from "@graphql-markdown/types";

--- a/packages/printer-legacy/src/graphql/union.ts
+++ b/packages/printer-legacy/src/graphql/union.ts
@@ -17,9 +17,9 @@ export const printUnionMetadata = (
     return "";
   }
 
-  return printSection((type as GraphQLUnionType).getTypes(), "Possible types", {
+  return printSection(type.getTypes(), "Possible types", {
     ...options,
-    parentType: (type as GraphQLUnionType).name,
+    parentType: type.name,
   });
 };
 
@@ -32,7 +32,7 @@ export const printCodeUnion = (
   }
 
   let code = `union ${getTypeName(type)} = `;
-  code += (type as GraphQLUnionType)
+  code += type
     .getTypes()
     .map((v: GraphQLObjectType<unknown, unknown>): string => {
       return getTypeName(v);

--- a/packages/printer-legacy/tests/unit/code.test.ts
+++ b/packages/printer-legacy/tests/unit/code.test.ts
@@ -3,7 +3,7 @@ import {
   GraphQLInt,
   GraphQLScalarType,
   GraphQLString,
-} from "graphql";
+} from "graphql/type";
 
 jest.mock("@graphql-markdown/graphql", () => {
   return {

--- a/packages/printer-legacy/tests/unit/common.test.ts
+++ b/packages/printer-legacy/tests/unit/common.test.ts
@@ -1,11 +1,10 @@
-import type { ConstDirectiveNode } from "graphql";
+import type { ConstDirectiveNode } from "graphql/language";
 import {
-  DirectiveLocation,
   GraphQLDirective,
   GraphQLEnumType,
   GraphQLScalarType,
-  Kind,
-} from "graphql";
+} from "graphql/type";
+import { DirectiveLocation, Kind } from "graphql/language";
 
 import {
   hasPrintableDirective,

--- a/packages/printer-legacy/tests/unit/directive.test.ts
+++ b/packages/printer-legacy/tests/unit/directive.test.ts
@@ -1,4 +1,5 @@
-import { GraphQLDirective, buildSchema } from "graphql";
+import { buildSchema } from "graphql/utilities";
+import { GraphQLDirective } from "graphql/type";
 
 import type {
   DirectiveName,
@@ -21,6 +22,7 @@ jest.mock("@graphql-markdown/utils", () => {
 import * as Utils from "@graphql-markdown/utils";
 
 jest.mock("@graphql-markdown/graphql", () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return {
     ...jest.requireActual("@graphql-markdown/graphql"),
     getConstDirectiveMap: jest.fn(),

--- a/packages/printer-legacy/tests/unit/example.test.ts
+++ b/packages/printer-legacy/tests/unit/example.test.ts
@@ -1,4 +1,4 @@
-import { buildSchema } from "graphql";
+import { buildSchema } from "graphql/utilities";
 
 import { printExample } from "../../src/example";
 

--- a/packages/printer-legacy/tests/unit/graphql/directive.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/directive.test.ts
@@ -1,4 +1,5 @@
-import { GraphQLDirective, GraphQLBoolean, DirectiveLocation } from "graphql";
+import { GraphQLDirective, GraphQLBoolean } from "graphql/type";
+import { DirectiveLocation } from "graphql/language";
 
 import { DEFAULT_OPTIONS } from "../../../src/const/options";
 

--- a/packages/printer-legacy/tests/unit/graphql/enum.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/enum.test.ts
@@ -1,4 +1,4 @@
-import { GraphQLEnumType, GraphQLScalarType } from "graphql";
+import { GraphQLEnumType, GraphQLScalarType } from "graphql/type";
 
 import { printCodeEnum, printEnumMetadata } from "../../../src/graphql/enum";
 

--- a/packages/printer-legacy/tests/unit/graphql/input.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/input.test.ts
@@ -1,4 +1,8 @@
-import { GraphQLBoolean, GraphQLString, GraphQLInputObjectType } from "graphql";
+import {
+  GraphQLBoolean,
+  GraphQLString,
+  GraphQLInputObjectType,
+} from "graphql/type";
 
 import { DEFAULT_OPTIONS } from "../../../src/const/options";
 

--- a/packages/printer-legacy/tests/unit/graphql/interface.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/interface.test.ts
@@ -1,4 +1,8 @@
-import { GraphQLBoolean, GraphQLString, GraphQLInterfaceType } from "graphql";
+import {
+  GraphQLBoolean,
+  GraphQLString,
+  GraphQLInterfaceType,
+} from "graphql/type";
 
 import { DEFAULT_OPTIONS } from "../../../src/const/options";
 

--- a/packages/printer-legacy/tests/unit/graphql/object.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/object.test.ts
@@ -3,7 +3,7 @@ import {
   GraphQLBoolean,
   GraphQLString,
   GraphQLInterfaceType,
-} from "graphql";
+} from "graphql/type";
 
 import { DEFAULT_OPTIONS } from "../../../src/const/options";
 

--- a/packages/printer-legacy/tests/unit/graphql/operation.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/operation.test.ts
@@ -1,10 +1,12 @@
-import type { GraphQLSchema } from "graphql";
-import { GraphQLID, GraphQLObjectType, GraphQLString } from "graphql";
+import type { GraphQLSchema } from "@graphql-markdown/types";
+import { GraphQLID, GraphQLObjectType, GraphQLString } from "graphql/type";
 
 jest.mock("@graphql-markdown/graphql", () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return {
     ...jest.requireActual("@graphql-markdown/graphql"),
     isDirectiveType: jest.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     isDeprecated: jest.fn((T: any) => {
       return "deprecationReason" in T;
     }), // eslint-disable-line @typescript-eslint/no-explicit-any

--- a/packages/printer-legacy/tests/unit/graphql/scalar.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/scalar.test.ts
@@ -1,4 +1,4 @@
-import { GraphQLScalarType } from "graphql";
+import { GraphQLScalarType } from "graphql/type";
 
 import {
   printCodeScalar,

--- a/packages/printer-legacy/tests/unit/graphql/union.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/union.test.ts
@@ -2,7 +2,7 @@ import {
   GraphQLObjectType,
   GraphQLScalarType,
   GraphQLUnionType,
-} from "graphql";
+} from "graphql/type";
 
 import { printCodeUnion, printUnionMetadata } from "../../../src/graphql/union";
 

--- a/packages/printer-legacy/tests/unit/link.test.ts
+++ b/packages/printer-legacy/tests/unit/link.test.ts
@@ -1,12 +1,15 @@
-import type { GraphQLNamedType } from "graphql";
 import {
   GraphQLList,
   GraphQLDirective,
   GraphQLObjectType,
   GraphQLScalarType,
-} from "graphql";
+} from "graphql/type";
 
-import type { PrintLinkOptions, TypeLocale } from "@graphql-markdown/types";
+import type {
+  PrintLinkOptions,
+  TypeLocale,
+  GraphQLNamedType,
+} from "@graphql-markdown/types";
 
 import * as Utils from "@graphql-markdown/utils";
 jest.mock("@graphql-markdown/utils", () => {

--- a/packages/printer-legacy/tests/unit/printer.test.ts
+++ b/packages/printer-legacy/tests/unit/printer.test.ts
@@ -11,7 +11,7 @@ import {
   GraphQLUnionType,
   GraphQLSchema,
   GraphQLString,
-} from "graphql";
+} from "graphql/type";
 
 import type { PrintTypeOptions } from "@graphql-markdown/types";
 

--- a/packages/printer-legacy/tests/unit/relation.test.ts
+++ b/packages/printer-legacy/tests/unit/relation.test.ts
@@ -1,10 +1,10 @@
-import type { GraphQLSchema } from "graphql";
-import { GraphQLScalarType } from "graphql";
+import { GraphQLScalarType } from "graphql/type";
 jest.mock("graphql");
 
 import type {
   GraphQLOperationType,
   IGetRelation,
+  GraphQLSchema,
 } from "@graphql-markdown/types";
 
 jest.mock("@graphql-markdown/utils", () => {

--- a/packages/printer-legacy/tests/unit/section.test.ts
+++ b/packages/printer-legacy/tests/unit/section.test.ts
@@ -7,9 +7,8 @@ import {
   GraphQLObjectType,
   GraphQLString,
   GraphQLDirective,
-  Kind,
-  DirectiveLocation,
-} from "graphql";
+} from "graphql/type";
+import { Kind, DirectiveLocation } from "graphql/language";
 
 import {
   printSection,


### PR DESCRIPTION
# Description

Clean up type and narrow graphql imports

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
