### PR TITLE
:memo: use github security advisories report

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,12 @@ We release patches for security vulnerabilities for any version from 1.5.
 
 ## Reporting a Vulnerability
 
-The GraphQL-Markdown team and community take all security bugs in GraphLQ-Markdown seriously. Thank you for improving the security of GraphQL-Markdown. We appreciate your efforts to disclose the issue responsibly, and will make every effort to acknowledge your contributions.
+The GraphQL-Markdown team and community take all security bugs in GraphLQ-Markdown seriously. 
 
-Report security bugs by emailing the lead maintainer at graphql-markdown[@]edno.io and include the word "SECURITY" in the subject line.
+Thank you for improving the security of GraphQL-Markdown. We appreciate your efforts to disclose the issue responsibly, and will make every effort to acknowledge your contributions.
 
-The lead maintainer will acknowledge your email within a week (7 days). If the issue is confirmed, we will release a patch as soon as possible depending on complexity.
+Report security vulnerabilities at https://github.com/graphql-markdown/graphql-markdown/security/advisories
+
+If the issue is confirmed, we will release a patch as soon as possible depending on complexity.
 
 Report security bugs in third-party modules to the person or team maintaining the module.


### PR DESCRIPTION
# Description

Use github security advisories report instead of email report.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
