### PR TITLE
:memo:  clean up docs

### DIFF
--- a/docs/advanced/custom-directive.md
+++ b/docs/advanced/custom-directive.md
@@ -83,7 +83,7 @@ plugins: [
 
 The `tag` allows rendering custom badges (tags) based on the custom directive applicable to entities.
 
-```js {8} title="docusaurus.config.js"
+```js title="docusaurus.config.js"
 plugins: [
   [
     "@graphql-markdown/docusaurus",
@@ -92,6 +92,7 @@ plugins: [
       // ... other options
       customDirective: {
         beta: {
+          // highlight-next-line
           tag: (directive, node) => ({ text: directive.name, classname: "badge--info" }),
         }
         // ... other custom directive options
@@ -105,7 +106,7 @@ plugins: [
 
 You can use **`"*"` as a wildcard** for the directive name. This will allow all directives not declared with their name under `customDirective` to be handled by the wildcard `descriptor` and/or `tag`.
 
-```js {11-14} title="docusaurus.config.js"
+```js title="docusaurus.config.js"
 const { directiveDescriptor, tagDescriptor } = require("@graphql-markdown/helpers");
 
 //...//
@@ -117,10 +118,12 @@ plugins: [
     {
       // ... other options
       customDirective: {
+        // highlight-start
         "*": {
           descriptor: directiveDescriptor,
           tag: tagDescriptor,
         },
+        // highlight-end
         // ... optionally specific custom directive options
       },
     },

--- a/docs/advanced/custom-root-types.md
+++ b/docs/advanced/custom-root-types.md
@@ -28,10 +28,12 @@ plugins: [
         GraphQLFileLoader: {
           module: "@graphql-tools/graphql-file-loader",
           options: {
+            // highlight-start
             rootTypes: {
               query: "Root", // use custom root type Root for queries, instead of Query
               subscription: "" // disable Subscription type
             },
+            // highlight-end
           },
         },
       },

--- a/docs/advanced/docs-multi-instance.md
+++ b/docs/advanced/docs-multi-instance.md
@@ -16,6 +16,7 @@ plugins: [
       id: "api",
       path: "api",
       routeBasePath: "api",
+      /// highlight-next-line
       sidebarPath: require.resolve("./api/sidebar-schema.js"),
       // ... other options
     },

--- a/docs/advanced/schema-loading.md
+++ b/docs/advanced/schema-loading.md
@@ -7,25 +7,27 @@ pagination_next: null
 
 GraphQL-Markdown use external loaders for loading GraphQL schemas (see [full list](https://github.com/ardatan/graphql-tools/tree/master/packages/loaders)).
 
-You can declare as many loaders as you need using the structure:
+You can declare as many loaders as you need using a `LoaderOption` map:
 
 ```ts
-type RootTypes = { query?: string; mutation?: string; subscription?: string };
+// highlight-start
+type LoaderOption = {
+  [name: ClassName]: PackageName | PackageConfig;
+};
+// highlight-end
 
-type PackageOptionsConfig = BaseLoaderOptions & RootTypes;
+type PackageName = string & { _opaque: typeof PackageName };
+
+type ClassName = string & { _opaque: typeof ClassName };
 
 type PackageConfig = {
   module: PackageName;
   options?: PackageOptionsConfig;
 };
 
-type PackageName = string & { _opaque: typeof PackageName };
+type RootTypes = { query?: string; mutation?: string; subscription?: string };
 
-type ClassName = string & { _opaque: typeof ClassName };
-
-type LoaderOption = {
-  [name: ClassName]: PackageName | PackageConfig;
-};
+type PackageOptionsConfig = BaseLoaderOptions & RootTypes;
 ```
 
 ## Local schema (file)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,7 +12,7 @@ Add a `resolutions` entry to your `package.json` file:
 
 ```json title="package.json"
 "resolutions": {
-  "graphql": "15.5.2"
+  "graphql": "16.9.0"
 }
 ```
 


### PR DESCRIPTION
# Description

Clean up docs to fix code lines highlights and bump the troubleshooting graphql resolution.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
