### PR TITLE
:memo:  fix typedoc custom frontmatter script

### DIFF
--- a/scripts/custom-frontmatter.js
+++ b/scripts/custom-frontmatter.js
@@ -1,18 +1,18 @@
 const path = require("node:path/posix");
 const { ReflectionKind } = require("typedoc");
-const { FrontmatterEvent } = require("typedoc-plugin-frontmatter");
+const { MarkdownPageEvent } = require("typedoc-plugin-markdown");
 
 // All plugins should export a `load()` function
 module.exports = {
   load: (app) => {
     // Listen to PREPARE_FRONTMATTER event
-    app.renderer.on(FrontmatterEvent.PREPARE_FRONTMATTER, (event) => {
+    app.renderer.on(MarkdownPageEvent.BEGIN, (event) => {
       // Update event.frontmatter object using information from the page model as JSON
       event.frontmatter = {
         // add a title
-        title: path.basename(event.page.model?.name),
+        title: path.basename(event.model?.name),
         // add sidebar position for root project page
-        ...(event.page.model?.kindOf(ReflectionKind.Project) && {
+        ...(event.model?.kindOf(ReflectionKind.Project) && {
           sidebar_position: 1,
         }),
         // spread the existing frontmatter


### PR DESCRIPTION
# Description

Fix `typedoc` custom frontmatter script (upgrade deprecation) reported in https://github.com/graphql-markdown/graphql-markdown/actions/runs/9632755071/job/26566326411

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
