### PR TITLE
:construction_worker:  remove setup nodejs from publish docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -47,12 +47,6 @@ jobs:
           path: website
           token: ${{ secrets.BOT_PAT }}
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "lts/*"
-          cache: "npm"
-          cache-dependency-path: package/package-lock.json
-
       - name: Build docs
         run: |
           cd project


### PR DESCRIPTION
# Description

remove setup nodejs from publish docs workflow, no more needed since all the job is perfomed by earthly

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
