### PR TITLE
✨ support relative paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "chalk": "^5.3.0"
-      },
       "devDependencies": {
         "@graphql-eslint/eslint-plugin": "3.20.1",
         "@graphql-tools/graphql-file-loader": "8.0.1",
@@ -6376,6 +6373,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
       "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"

--- a/packages/printer-legacy/src/const/strings.ts
+++ b/packages/printer-legacy/src/const/strings.ts
@@ -14,6 +14,8 @@ export const ROOT_TYPE_LOCALE: RootTypeLocale = {
   UNION: { singular: "union", plural: "unions" },
 } as const;
 
+export const LINK_MDX_EXTENSION = ".mdx" as const;
+
 export const DEPRECATED = "deprecated" as const;
 export const GRAPHQL = "graphql" as const;
 export const NO_DESCRIPTION_TEXT = "No description" as const;

--- a/packages/printer-legacy/src/link.ts
+++ b/packages/printer-legacy/src/link.ts
@@ -31,7 +31,11 @@ import {
 import { slugify, pathUrl } from "@graphql-markdown/utils";
 
 import { getGroup } from "./group";
-import { DEPRECATED, ROOT_TYPE_LOCALE } from "./const/strings";
+import {
+  DEPRECATED,
+  LINK_MDX_EXTENSION,
+  ROOT_TYPE_LOCALE,
+} from "./const/strings";
 import { hasPrintableDirective } from "./common";
 
 export const getCategoryLocale = (type: unknown): Maybe<TypeLocale> => {
@@ -146,7 +150,7 @@ export const toLink = (
     apiGroupFolder,
     groupFolder,
     category,
-    slugify(text),
+    `${slugify(text)}${LINK_MDX_EXTENSION}`,
   );
 
   return {

--- a/packages/printer-legacy/tests/unit/__snapshots__/link.test.ts.snap
+++ b/packages/printer-legacy/tests/unit/__snapshots__/link.test.ts.snap
@@ -19,55 +19,55 @@ exports[`link getLinkCategoryFolder() returns a category object matching the gra
 exports[`link toLink() returns markdown link for GraphQL Directive 1`] = `
 {
   "text": "TestDirective",
-  "url": "docs/graphql/api/directives/test-directive",
+  "url": "docs/graphql/api/directives/test-directive.mdx",
 }
 `;
 
 exports[`link toLink() returns markdown link for GraphQL Enum 1`] = `
 {
   "text": "TestEnum",
-  "url": "docs/graphql/api/enums/test-enum",
+  "url": "docs/graphql/api/enums/test-enum.mdx",
 }
 `;
 
 exports[`link toLink() returns markdown link for GraphQL Input 1`] = `
 {
   "text": "TestInput",
-  "url": "docs/graphql/api/inputs/test-input",
+  "url": "docs/graphql/api/inputs/test-input.mdx",
 }
 `;
 
 exports[`link toLink() returns markdown link for GraphQL Interface 1`] = `
 {
   "text": "TestInterface",
-  "url": "docs/graphql/api/interfaces/test-interface",
+  "url": "docs/graphql/api/interfaces/test-interface.mdx",
 }
 `;
 
 exports[`link toLink() returns markdown link for GraphQL Object 1`] = `
 {
   "text": "TestObject",
-  "url": "docs/graphql/api/objects/test-object",
+  "url": "docs/graphql/api/objects/test-object.mdx",
 }
 `;
 
 exports[`link toLink() returns markdown link for GraphQL Operation 1`] = `
 {
   "text": "TestOperation",
-  "url": "docs/graphql/api/queries/test-operation",
+  "url": "docs/graphql/api/queries/test-operation.mdx",
 }
 `;
 
 exports[`link toLink() returns markdown link for GraphQL Scalar 1`] = `
 {
   "text": "TestScalar",
-  "url": "docs/graphql/api/scalars/test-scalar",
+  "url": "docs/graphql/api/scalars/test-scalar.mdx",
 }
 `;
 
 exports[`link toLink() returns markdown link for GraphQL Union 1`] = `
 {
   "text": "TestUnion",
-  "url": "docs/graphql/api/unions/test-union",
+  "url": "docs/graphql/api/unions/test-union.mdx",
 }
 `;

--- a/packages/printer-legacy/tests/unit/graphql/directive.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/directive.test.ts
@@ -39,14 +39,14 @@ describe("directive", () => {
       const code = printDirectiveMetadata(type, DEFAULT_OPTIONS);
 
       expect(code).toMatchInlineSnapshot(`
-        "### Arguments
+"### Arguments
 
-        #### [<code style={{ fontWeight: 'normal' }}>FooBar.<b>ArgFooBar</b></code>](#)<Bullet />[\`Boolean\`](/types/scalars/boolean) <Badge class="badge badge--secondary" text="scalar"/> 
-        
-        
+#### [<code style={{ fontWeight: 'normal' }}>FooBar.<b>ArgFooBar</b></code>](#)<Bullet />[\`Boolean\`](/types/scalars/boolean.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
-        "
-      `);
+
+
+"
+`);
     });
 
     test("returns directive metadata with grouped deprecated", () => {
@@ -74,7 +74,7 @@ describe("directive", () => {
       expect(code).toMatchInlineSnapshot(`
 "### Arguments
 
-#### [<code style={{ fontWeight: 'normal' }}>FooBar.<b>Foo</b></code>](#)<Bullet />[\`Boolean\`](/types/scalars/boolean) <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>FooBar.<b>Foo</b></code>](#)<Bullet />[\`Boolean\`](/types/scalars/boolean.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
 
 
@@ -82,7 +82,7 @@ describe("directive", () => {
 
 <Details dataOpen={<><span className="deprecated">Hide deprecated</span></>} dataClose={<><span className="deprecated">Show deprecated</span></>}>
 
-#### [<code style={{ fontWeight: 'normal' }}>FooBar.<b>Bar</b></code>](#)<Bullet />[\`Boolean\`](/types/scalars/boolean) <Badge class="badge badge--deprecated badge--secondary" text="deprecated"/> <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>FooBar.<b>Bar</b></code>](#)<Bullet />[\`Boolean\`](/types/scalars/boolean.mdx) <Badge class="badge badge--deprecated badge--secondary" text="deprecated"/> <Badge class="badge badge--secondary" text="scalar"/> 
 :::warning[DEPRECATED]
 
 Deprecated

--- a/packages/printer-legacy/tests/unit/graphql/input.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/input.test.ts
@@ -26,11 +26,11 @@ describe("input", () => {
       expect(metadata).toMatchInlineSnapshot(`
 "### Fields
 
-#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>one</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>one</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
 
 
-#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>two</b></code>](#)<Bullet />[\`Boolean\`](/types/scalars/boolean) <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>two</b></code>](#)<Bullet />[\`Boolean\`](/types/scalars/boolean.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
 
 

--- a/packages/printer-legacy/tests/unit/graphql/interface.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/interface.test.ts
@@ -37,17 +37,17 @@ describe("interface", () => {
       expect(metadata).toMatchInlineSnapshot(`
 "### Fields
 
-#### [<code style={{ fontWeight: 'normal' }}>TestInterfaceName.<b>one</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>TestInterfaceName.<b>one</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
 
 
-#### [<code style={{ fontWeight: 'normal' }}>TestInterfaceName.<b>two</b></code>](#)<Bullet />[\`Boolean\`](/types/scalars/boolean) <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>TestInterfaceName.<b>two</b></code>](#)<Bullet />[\`Boolean\`](/types/scalars/boolean.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
 
 
-#### [<code style={{ fontWeight: 'normal' }}>TestInterfaceName.<b>three</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>TestInterfaceName.<b>three</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
-##### [<code style={{ fontWeight: 'normal' }}>TestInterfaceName.three.<b>four</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--secondary" text="scalar"/> 
+##### [<code style={{ fontWeight: 'normal' }}>TestInterfaceName.three.<b>four</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
 
 

--- a/packages/printer-legacy/tests/unit/graphql/object.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/object.test.ts
@@ -43,11 +43,11 @@ describe("object", () => {
       expect(metadata).toMatchInlineSnapshot(`
 "### Fields
 
-#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>one</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>one</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
 
 
-#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>two</b></code>](#)<Bullet />[\`Boolean\`](/types/scalars/boolean) <Badge class="badge badge--deprecated badge--secondary" text="deprecated"/> <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>two</b></code>](#)<Bullet />[\`Boolean\`](/types/scalars/boolean.mdx) <Badge class="badge badge--deprecated badge--secondary" text="deprecated"/> <Badge class="badge badge--secondary" text="scalar"/> 
 :::warning[DEPRECATED]
 
 Deprecated
@@ -55,15 +55,15 @@ Deprecated
 :::
 
 
-#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>three</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>three</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
-##### [<code style={{ fontWeight: 'normal' }}>TestName.three.<b>four</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--secondary" text="scalar"/> 
+##### [<code style={{ fontWeight: 'normal' }}>TestName.three.<b>four</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
 
 
 ### Interfaces
 
-#### [\`TestInterfaceName\`](/types/interfaces/test-interface-name) <Badge class="badge badge--secondary" text="interface"/> 
+#### [\`TestInterfaceName\`](/types/interfaces/test-interface-name.mdx) <Badge class="badge badge--secondary" text="interface"/> 
 
 
 
@@ -82,13 +82,13 @@ Deprecated
       expect(metadata).toMatchInlineSnapshot(`
 "### Fields
 
-#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>one</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>one</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
 
 
-#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>three</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>three</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
-##### [<code style={{ fontWeight: 'normal' }}>TestName.three.<b>four</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--secondary" text="scalar"/> 
+##### [<code style={{ fontWeight: 'normal' }}>TestName.three.<b>four</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
 
 
@@ -96,7 +96,7 @@ Deprecated
 
 <Details dataOpen={<><span className="deprecated">Hide deprecated</span></>} dataClose={<><span className="deprecated">Show deprecated</span></>}>
 
-#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>two</b></code>](#)<Bullet />[\`Boolean\`](/types/scalars/boolean) <Badge class="badge badge--deprecated badge--secondary" text="deprecated"/> <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>TestName.<b>two</b></code>](#)<Bullet />[\`Boolean\`](/types/scalars/boolean.mdx) <Badge class="badge badge--deprecated badge--secondary" text="deprecated"/> <Badge class="badge badge--secondary" text="scalar"/> 
 :::warning[DEPRECATED]
 
 Deprecated
@@ -108,7 +108,7 @@ Deprecated
 
 ### Interfaces
 
-#### [\`TestInterfaceName\`](/types/interfaces/test-interface-name) <Badge class="badge badge--secondary" text="interface"/> 
+#### [\`TestInterfaceName\`](/types/interfaces/test-interface-name.mdx) <Badge class="badge badge--secondary" text="interface"/> 
 
 
 

--- a/packages/printer-legacy/tests/unit/graphql/operation.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/operation.test.ts
@@ -46,7 +46,7 @@ describe("operation", () => {
       expect(metadata).toMatchInlineSnapshot(`
 "### Type
 
-#### [\`Test\`](/types/objects/test) <Badge class="badge badge--secondary" text="object"/> 
+#### [\`Test\`](/types/objects/test.mdx) <Badge class="badge badge--secondary" text="object"/> 
 
 
 
@@ -83,13 +83,13 @@ describe("operation", () => {
       expect(metadata).toMatchInlineSnapshot(`
 "### Arguments
 
-#### [<code style={{ fontWeight: 'normal' }}>TestQuery.<b>ArgFooBar</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>TestQuery.<b>ArgFooBar</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
 
 
 ### Type
 
-#### [\`Test\`](/types/objects/test) <Badge class="badge badge--secondary" text="object"/> 
+#### [\`Test\`](/types/objects/test.mdx) <Badge class="badge badge--secondary" text="object"/> 
 
 
 
@@ -132,7 +132,7 @@ describe("operation", () => {
       expect(metadata).toMatchInlineSnapshot(`
 "### Arguments
 
-#### [<code style={{ fontWeight: 'normal' }}>TestQuery.<b>Foo</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>TestQuery.<b>Foo</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
 
 
@@ -140,7 +140,7 @@ describe("operation", () => {
 
 <Details dataOpen={<><span className="deprecated">Hide deprecated</span></>} dataClose={<><span className="deprecated">Show deprecated</span></>}>
 
-#### [<code style={{ fontWeight: 'normal' }}>TestQuery.<b>Bar</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--deprecated badge--secondary" text="deprecated"/> <Badge class="badge badge--secondary" text="scalar"/> 
+#### [<code style={{ fontWeight: 'normal' }}>TestQuery.<b>Bar</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--deprecated badge--secondary" text="deprecated"/> <Badge class="badge badge--secondary" text="scalar"/> 
 :::warning[DEPRECATED]
 
 Deprecated
@@ -152,7 +152,7 @@ Deprecated
 
 ### Type
 
-#### [\`Test\`](/types/objects/test) <Badge class="badge badge--secondary" text="object"/> 
+#### [\`Test\`](/types/objects/test.mdx) <Badge class="badge badge--secondary" text="object"/> 
 
 
 

--- a/packages/printer-legacy/tests/unit/graphql/union.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/union.test.ts
@@ -25,11 +25,11 @@ describe("union", () => {
 
       expect(code).toBe(`### Possible types
 
-#### [<code style={{ fontWeight: 'normal' }}>UnionTypeName.<b>one</b></code>](/types/objects/one) <Badge class="badge badge--secondary" text="object"/> 
+#### [<code style={{ fontWeight: 'normal' }}>UnionTypeName.<b>one</b></code>](/types/objects/one.mdx) <Badge class="badge badge--secondary" text="object"/> 
 
 
 
-#### [<code style={{ fontWeight: 'normal' }}>UnionTypeName.<b>two</b></code>](/types/objects/two) <Badge class="badge badge--secondary" text="object"/> 
+#### [<code style={{ fontWeight: 'normal' }}>UnionTypeName.<b>two</b></code>](/types/objects/two.mdx) <Badge class="badge badge--secondary" text="object"/> 
 
 
 

--- a/packages/printer-legacy/tests/unit/link.test.ts
+++ b/packages/printer-legacy/tests/unit/link.test.ts
@@ -205,7 +205,7 @@ describe("link", () => {
       expect(link).toMatchInlineSnapshot(`
         {
           "text": "TestObjectList",
-          "url": "docs/graphql/types/objects/test-object-list",
+          "url": "docs/graphql/types/objects/test-object-list.mdx",
         }
       `);
     });
@@ -284,7 +284,7 @@ describe("link", () => {
       expect(link).toMatchInlineSnapshot(`
         {
           "text": "TestDirective",
-          "url": "docs/graphql/api/group/directives/test-directive",
+          "url": "docs/graphql/api/group/directives/test-directive.mdx",
         }
       `);
     });
@@ -316,7 +316,7 @@ describe("link", () => {
       expect(link).toMatchInlineSnapshot(`
         {
           "text": "TestDirective",
-          "url": "docs/graphql/deprecated/api/directives/test-directive",
+          "url": "docs/graphql/deprecated/api/directives/test-directive.mdx",
         }
       `);
     });
@@ -346,7 +346,7 @@ describe("link", () => {
       expect(link).toMatchInlineSnapshot(`
         {
           "text": "TestDirective",
-          "url": "docs/graphql/directives/test-directive",
+          "url": "docs/graphql/directives/test-directive.mdx",
         }
       `);
     });
@@ -591,7 +591,7 @@ describe("link", () => {
 
       expect(link).toStrictEqual({
         text: "TestScalar",
-        url: "docs/graphql/types/scalars/test-scalar",
+        url: "docs/graphql/types/scalars/test-scalar.mdx",
       });
     });
 

--- a/packages/printer-legacy/tests/unit/section.test.ts
+++ b/packages/printer-legacy/tests/unit/section.test.ts
@@ -156,7 +156,7 @@ describe("section", () => {
       const section = printSectionItem(type, DEFAULT_OPTIONS);
 
       expect(section).toMatchInlineSnapshot(`
-"#### [\`EntityTypeName\`](/types/objects/entity-type-name) <Badge class="badge badge--secondary" text="object"/> 
+"#### [\`EntityTypeName\`](/types/objects/entity-type-name.mdx) <Badge class="badge badge--secondary" text="object"/> 
 Lorem ipsum
 "
 `);
@@ -183,7 +183,7 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.`,
       const section = printSectionItem(type, DEFAULT_OPTIONS);
 
       expect(section).toMatchInlineSnapshot(`
-"#### [\`EntityTypeName\`](/types/objects/entity-type-name) <Badge class="badge badge--secondary" text="object"/> 
+"#### [\`EntityTypeName\`](/types/objects/entity-type-name.mdx) <Badge class="badge badge--secondary" text="object"/> 
 Lorem ipsum dolor sit amet, 
 consectetur adipiscing elit, 
 sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
@@ -214,7 +214,7 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.
       const section = printSectionItem(type, DEFAULT_OPTIONS);
 
       expect(section).toMatchInlineSnapshot(`
-"#### [\`EntityTypeName\`](#)<Bullet />[\`NonNullableObjectType!\`](/types/objects/non-nullable-object-type) <Badge class="badge badge--secondary" text="non-null"/> <Badge class="badge badge--secondary" text="object"/> 
+"#### [\`EntityTypeName\`](#)<Bullet />[\`NonNullableObjectType!\`](/types/objects/non-nullable-object-type.mdx) <Badge class="badge badge--secondary" text="non-null"/> <Badge class="badge badge--secondary" text="object"/> 
 
 "
 `);
@@ -238,7 +238,7 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.
       const section = printSectionItem(type, DEFAULT_OPTIONS);
 
       expect(section).toMatchInlineSnapshot(`
-"#### [\`EntityTypeName\`](#)<Bullet />[\`[NonNullableObjectType]!\`](/types/objects/non-nullable-object-type) <Badge class="badge badge--secondary" text="non-null"/> <Badge class="badge badge--secondary" text="object"/> 
+"#### [\`EntityTypeName\`](#)<Bullet />[\`[NonNullableObjectType]!\`](/types/objects/non-nullable-object-type.mdx) <Badge class="badge badge--secondary" text="non-null"/> <Badge class="badge badge--secondary" text="object"/> 
 
 "
 `);
@@ -280,7 +280,7 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.
       expect(section).toMatchInlineSnapshot(`
 "#### [\`EntityTypeName\`](#)  
 
-##### [<code style={{ fontWeight: 'normal' }}>EntityTypeName.<b>ParameterTypeName</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--secondary" text="scalar"/> 
+##### [<code style={{ fontWeight: 'normal' }}>EntityTypeName.<b>ParameterTypeName</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
 "
 `);
@@ -297,7 +297,7 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.
       const section = printSectionItem(type, DEFAULT_OPTIONS);
 
       expect(section).toMatchInlineSnapshot(`
-"#### [\`EntityTypeNameList\`](#)<Bullet />[\`[Int!]\`](/types/scalars/int) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> 
+"#### [\`EntityTypeNameList\`](#)<Bullet />[\`[Int!]\`](/types/scalars/int.mdx) <Badge class="badge badge--secondary" text="list"/> <Badge class="badge badge--secondary" text="scalar"/> 
 
 "
 `);
@@ -316,7 +316,7 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.
       const section = printSectionItem(type, DEFAULT_OPTIONS);
 
       expect(section).toMatchInlineSnapshot(`
-"#### [\`EntityTypeNameList\`](#)<Bullet />[\`[Int!]!\`](/types/scalars/int) <Badge class="badge badge--secondary" text="non-null"/> <Badge class="badge badge--secondary" text="scalar"/> 
+"#### [\`EntityTypeNameList\`](#)<Bullet />[\`[Int!]!\`](/types/scalars/int.mdx) <Badge class="badge badge--secondary" text="non-null"/> <Badge class="badge badge--secondary" text="scalar"/> 
 
 "
 `);
@@ -400,7 +400,7 @@ sunt in culpa qui officia deserunt mollit anim id est laborum.
 :::warning[DEPRECATED]
 
 :::
-##### [<code style={{ fontWeight: 'normal' }}>EntityTypeName.<b>ParameterTypeName</b></code>](#)<Bullet />[\`String\`](/types/scalars/string) <Badge class="badge badge--secondary" text="scalar"/> 
+##### [<code style={{ fontWeight: 'normal' }}>EntityTypeName.<b>ParameterTypeName</b></code>](#)<Bullet />[\`String\`](/types/scalars/string.mdx) <Badge class="badge badge--secondary" text="scalar"/> 
 
 
 


### PR DESCRIPTION
# Description

Follows Docusaurus best practices by appending `.mdx` to links in order to have 1st class support for relative paths.

This should fix #1427 .

Demo preview: https://codesandbox.io/p/devbox/determined-spence-mrpnmp

![image](https://github.com/user-attachments/assets/13f423d6-8f63-4194-b072-1d51fa03ad52)


# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
