### PR TITLE
👷 set jest randomize for ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "lint": "eslint \"packages/*/{src,tests}/**.{ts,js,json,gql}\"",
     "prepare": "husky | true",
     "prettier": "prettier \"packages/*/{src,tests,assets}/**/*.{ts,js,json,md,gql}\"",
-    "test:ci": "jest --config=./config/jest.config.js --runInBand --passWithNoTests --ci --silent",
+    "test:ci": "jest --config=./config/jest.config.js --runInBand --passWithNoTests --ci --silent --randomize",
     "test:watch": "jest --config=./config/jest.config.js --watch --maxWorkers=25%",
     "test": "jest --config=./config/jest.config.js --maxWorkers=50% --randomize",
     "ts:check": "tsc --noEmit",

--- a/packages/printer-legacy/src/badge.ts
+++ b/packages/printer-legacy/src/badge.ts
@@ -71,7 +71,7 @@ export const getTypeBadges = (
 };
 
 export const printBadge = ({ text, classname }: Badge): MDXString => {
-  const textString = typeof text === "string" ? text : text.singular;
+  const textString = typeof text === "object" ? text.singular : text.toString();
   const formattedText = escapeMDX(textString);
   return `<Badge class="badge ${classname}" text="${formattedText}"/>` as MDXString;
 };

--- a/packages/printer-legacy/src/relation.ts
+++ b/packages/printer-legacy/src/relation.ts
@@ -64,7 +64,7 @@ export const printRelationOf = <T>(
 
     const category = getRootTypeLocaleFromString(relation)!;
     const badge = printBadge({
-      text: typeof category === "string" ? category : category.singular,
+      text: category,
       classname: DEFAULT_CSS_CLASSNAME,
     });
     data = data.concat(

--- a/packages/printer-legacy/tests/unit/relation.test.ts
+++ b/packages/printer-legacy/tests/unit/relation.test.ts
@@ -48,19 +48,19 @@ const { getRootTypeLocaleFromString, printRelationOf, printRelations } =
 const mockGraphQL = jest.mocked(GraphQL, { shallow: true });
 
 describe("relation", () => {
-  describe("printRelationOf()", () => {
-    afterAll(() => {
-      jest.restoreAllMocks();
-      jest.resetAllMocks();
-    });
+  afterAll(() => {
+    jest.restoreAllMocks();
+    jest.resetAllMocks();
+  });
 
+  describe("printRelationOf()", () => {
     test.concurrent.each([[true], [false]])(
       "returns empty string if type is undefined and isOperation is %p",
       (isOperationMockedValue: boolean) => {
         expect.hasAssertions();
 
-        mockGraphQL.isNamedType.mockReturnValueOnce(false);
-        mockGraphQL.isOperation.mockReturnValueOnce(isOperationMockedValue);
+        mockGraphQL.isNamedType.mockReturnValue(false);
+        mockGraphQL.isOperation.mockReturnValue(isOperationMockedValue);
 
         const relation = printRelationOf(
           undefined,
@@ -83,8 +83,8 @@ describe("relation", () => {
           description: "Lorem Ipsum",
         });
 
-        mockGraphQL.isNamedType.mockReturnValueOnce(isNamedTypeMockedValue);
-        mockGraphQL.isOperation.mockReturnValueOnce(true);
+        mockGraphQL.isNamedType.mockReturnValue(isNamedTypeMockedValue);
+        mockGraphQL.isOperation.mockReturnValue(true);
 
         const relation = printRelationOf(
           type,
@@ -105,8 +105,8 @@ describe("relation", () => {
         description: "Lorem Ipsum",
       });
 
-      mockGraphQL.isNamedType.mockReturnValueOnce(true);
-      mockGraphQL.isOperation.mockReturnValueOnce(false);
+      mockGraphQL.isNamedType.mockReturnValue(true);
+      mockGraphQL.isOperation.mockReturnValue(false);
 
       const relation = printRelationOf(type, "RelationOf", undefined, {
         ...DEFAULT_OPTIONS,
@@ -124,8 +124,8 @@ describe("relation", () => {
         description: "Lorem Ipsum",
       });
 
-      mockGraphQL.isNamedType.mockReturnValueOnce(true);
-      mockGraphQL.isOperation.mockReturnValueOnce(false);
+      mockGraphQL.isNamedType.mockReturnValue(true);
+      mockGraphQL.isOperation.mockReturnValue(false);
 
       const relation = printRelationOf(type, "RelationOf", jest.fn(), {
         ...DEFAULT_OPTIONS,
@@ -143,8 +143,8 @@ describe("relation", () => {
         description: "Lorem Ipsum",
       });
 
-      mockGraphQL.isNamedType.mockReturnValueOnce(true);
-      mockGraphQL.isOperation.mockReturnValueOnce(false);
+      mockGraphQL.isNamedType.mockReturnValue(true);
+      mockGraphQL.isOperation.mockReturnValue(false);
 
       const relation = printRelationOf(
         type,
@@ -196,7 +196,6 @@ describe("relation", () => {
 
       mockGraphQL.isNamedType.mockReturnValue(true);
       mockGraphQL.isOperation.mockReturnValue(false);
-      mockGraphQL.getNamedType.mockImplementation((t) => t as any);
 
       const relation = printRelationOf(
         type,


### PR DESCRIPTION
# Description

Enforce test robustness by enabling randomisation for Jest in CI.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
