### PR TITLE
📝 add warning upgrade 1.3.0 in docs

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -279,6 +279,14 @@ plugins: [
 
 <br/>
 
+:::warning[useApiGroup]
+
+**If you upgraded to version [1.23.0](https://github.com/graphql-markdown/graphql-markdown/releases/tag/1.23.0) or higher**, then in some case the old GraphQL documentation structure is not being removed.
+
+To resolve this, you will need to delete manually all files to get a clean folder and regenerate the documentation, or disable `useApiGroup` to keep the previous behavior.
+
+:::
+
 :::info
 
 See **[customize deprecated sections](/docs/advanced/custom-deprecated-section)** to customize the rendering of `printTypeOptions.deprecated: "group"`.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -283,7 +283,7 @@ plugins: [
 
 **If you upgraded to version [1.23.0](https://github.com/graphql-markdown/graphql-markdown/releases/tag/1.23.0) or higher**, then in some case the old GraphQL documentation structure is not being removed.
 
-To resolve this, you will need to delete manually all files to get a clean folder and regenerate the documentation, or disable `useApiGroup` to keep the previous behavior.
+To resolve this, you need to delete manually all files to get a clean folder and then regenerate the documentation; or you can disable `useApiGroup` to keep the previous behavior.
 
 :::
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -281,7 +281,7 @@ plugins: [
 
 :::warning[useApiGroup]
 
-**If you upgraded to version [1.23.0](https://github.com/graphql-markdown/graphql-markdown/releases/tag/1.23.0) or higher**, then in some case the old GraphQL documentation structure is not being removed.
+**If you upgraded to version [1.23.0](https://github.com/graphql-markdown/graphql-markdown/releases/tag/1.23.0) or higher**, then in some cases the old GraphQL documentation structure is not being removed.
 
 To resolve this, you need to delete manually all files to get a clean folder and then regenerate the documentation; or you can disable `useApiGroup` to keep the previous behavior.
 


### PR DESCRIPTION
# Description

Add warning about docs structure after upgrade to 1.3.0 in docs

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
