### PR TITLE
:recycle:  replace deprecated fs.rmdir by fs.rm

### DIFF
--- a/packages/utils/src/fs.ts
+++ b/packages/utils/src/fs.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import { mkdir, rmdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, rm, stat, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import type {
@@ -67,7 +67,7 @@ export const ensureDir = async (
   }
 
   if (options && options.forceEmpty === true) {
-    await rmdir(location, { recursive: true });
+    await rm(location, { recursive: true });
     await ensureDir(location);
   }
 };

--- a/packages/utils/tests/__mocks__/node:fs/promises.ts
+++ b/packages/utils/tests/__mocks__/node:fs/promises.ts
@@ -5,4 +5,10 @@ import type { IFS } from "unionfs";
 
 const fs = jest.requireActual("node:fs");
 
-module.exports = ufs.use(fs).use(vol as unknown as IFS).promises;
+const promises = ufs.use(fs).use(vol as unknown as IFS).promises;
+
+module.exports = { ...promises, rm: promises.rmdir };
+
+if ("rm" in promises) {
+  module.exports = promises;
+}


### PR DESCRIPTION
# Description

Replace deprecated `fs.rmdir` by `fs.rm`, see https://nodejs.org/api/deprecations.html#DEP0147

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
