### PR TITLE
🔖 Release 1.26.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17260,11 +17260,11 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/graphql": "^1.1.4",
-        "@graphql-markdown/logger": "^1.0.4",
+        "@graphql-markdown/logger": "^1.0.5",
         "@graphql-markdown/utils": "^1.7.0"
       },
       "devDependencies": {
@@ -17314,11 +17314,11 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.26.2",
+      "version": "1.26.3",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.12.0",
-        "@graphql-markdown/logger": "^1.0.4",
+        "@graphql-markdown/core": "^1.12.1",
+        "@graphql-markdown/logger": "^1.0.5",
         "@graphql-markdown/printer-legacy": "^1.9.0"
       },
       "devDependencies": {
@@ -17370,7 +17370,7 @@
     },
     "packages/logger": {
       "name": "@graphql-markdown/logger",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "devDependencies": {
         "@graphql-markdown/types": "^1.4.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17299,7 +17299,7 @@
       "version": "1.1.8",
       "license": "MIT",
       "dependencies": {
-        "@graphql-inspector/core": "^6.2.0",
+        "@graphql-inspector/core": "^6.1.0",
         "@graphql-markdown/graphql": "^1.1.4",
         "@graphql-markdown/utils": "^1.7.0",
         "@graphql-tools/graphql-file-loader": "^8.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.12.0",
+  "version": "1.12.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@graphql-markdown/graphql": "^1.1.4",
-    "@graphql-markdown/logger": "^1.0.4",
+    "@graphql-markdown/logger": "^1.0.5",
     "@graphql-markdown/utils": "^1.7.0"
   },
   "peerDependencies": {

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.26.2",
+  "version": "1.26.3",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -51,8 +51,8 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.12.0",
-    "@graphql-markdown/logger": "^1.0.4",
+    "@graphql-markdown/core": "^1.12.1",
+    "@graphql-markdown/logger": "^1.0.5",
     "@graphql-markdown/printer-legacy": "^1.9.0"
   },
   "devDependencies": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

Fix @graphql-markdown logs not being printed by Docusaurus 3 (#1802).

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
