### PR TITLE
:bug:  fix error when hierarchy defined in cli but validation failed

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -54,6 +54,8 @@ export const ASSET_HOMEPAGE_LOCATION = join(
   "generated.md",
 );
 
+export const DEFAULT_HIERARCHY = { [TypeHierarchy.API]: {} };
+
 export const DEFAULT_OPTIONS: Readonly<
   Pick<ConfigOptions, "customDirective" | "groupByDirective" | "loaders"> &
     Required<
@@ -92,9 +94,6 @@ export const DEFAULT_OPTIONS: Readonly<
     parentTypePrefix: true as const,
     relatedTypeSection: true as const,
     typeBadges: true as const,
-    hierarchy: { [TypeHierarchy.API]: {} } as Required<
-      Pick<TypeHierarchyObjectType, TypeHierarchy.API>
-    >,
   } as Required<Omit<ConfigPrintTypeOptions, "hierarchy">> & {
     hierarchy: Required<Pick<TypeHierarchyObjectType, TypeHierarchy.API>>;
   },
@@ -330,11 +329,7 @@ export const getTypeHierarchyOption = (
     }
   }
 
-  return (
-    cliHierarchy ??
-    configHierarchy ??
-    DEFAULT_OPTIONS.printTypeOptions.hierarchy
-  );
+  return cliHierarchy ?? configHierarchy ?? DEFAULT_HIERARCHY;
 };
 
 export const parseDeprecatedPrintTypeOptions = (

--- a/packages/core/tests/unit/config.test.ts
+++ b/packages/core/tests/unit/config.test.ts
@@ -17,6 +17,7 @@ import { join } from "node:path";
 
 import {
   buildConfig,
+  DEFAULT_HIERARCHY,
   DEFAULT_OPTIONS,
   DiffMethod,
   getCustomDirectives,
@@ -206,7 +207,10 @@ describe("config", () => {
           onlyDocDirective: DEFAULT_OPTIONS.onlyDocDirective,
           prettify: DEFAULT_OPTIONS.pretty,
           printer: DEFAULT_OPTIONS.printer,
-          printTypeOptions: DEFAULT_OPTIONS.printTypeOptions,
+          printTypeOptions: {
+            ...DEFAULT_OPTIONS.printTypeOptions,
+            hierarchy: DEFAULT_HIERARCHY,
+          },
           schemaLocation: DEFAULT_OPTIONS.schema,
           skipDocDirective: DEFAULT_OPTIONS.skipDocDirective,
           tmpDir: expect.stringMatching(/.+@graphql-markdown\/docusaurus$/),
@@ -404,7 +408,10 @@ describe("config", () => {
         outputDir: join(DEFAULT_OPTIONS.rootPath!, configFileOpts.baseURL!),
         prettify: cliOpts.pretty,
         printer: DEFAULT_OPTIONS.printer,
-        printTypeOptions: DEFAULT_OPTIONS.printTypeOptions,
+        printTypeOptions: {
+          ...DEFAULT_OPTIONS.printTypeOptions,
+          hierarchy: DEFAULT_HIERARCHY,
+        },
         schemaLocation: cliOpts.schema,
         skipDocDirective: DEFAULT_OPTIONS.skipDocDirective,
         tmpDir: DEFAULT_OPTIONS.tmpDir,
@@ -434,7 +441,10 @@ describe("config", () => {
         outputDir: join(DEFAULT_OPTIONS.rootPath!, DEFAULT_OPTIONS.baseURL!),
         prettify: DEFAULT_OPTIONS.pretty,
         printer: DEFAULT_OPTIONS.printer,
-        printTypeOptions: DEFAULT_OPTIONS.printTypeOptions,
+        printTypeOptions: {
+          ...DEFAULT_OPTIONS.printTypeOptions,
+          hierarchy: DEFAULT_HIERARCHY,
+        },
         schemaLocation: DEFAULT_OPTIONS.schema,
         skipDocDirective: DEFAULT_OPTIONS.skipDocDirective,
         tmpDir: DEFAULT_OPTIONS.tmpDir,
@@ -468,7 +478,10 @@ describe("config", () => {
         outputDir: join(DEFAULT_OPTIONS.rootPath!, DEFAULT_OPTIONS.baseURL!),
         prettify: DEFAULT_OPTIONS.pretty,
         printer: DEFAULT_OPTIONS.printer,
-        printTypeOptions: DEFAULT_OPTIONS.printTypeOptions,
+        printTypeOptions: {
+          ...DEFAULT_OPTIONS.printTypeOptions,
+          hierarchy: DEFAULT_HIERARCHY,
+        },
         schemaLocation: DEFAULT_OPTIONS.schema,
         skipDocDirective: DEFAULT_OPTIONS.skipDocDirective,
         tmpDir: DEFAULT_OPTIONS.tmpDir,
@@ -813,9 +826,7 @@ describe("config", () => {
 
       const hierarchy = getTypeHierarchyOption();
 
-      expect(hierarchy).toStrictEqual(
-        DEFAULT_OPTIONS.printTypeOptions.hierarchy,
-      );
+      expect(hierarchy).toStrictEqual(DEFAULT_HIERARCHY);
     });
 
     test("throws an error if cli and config are different", () => {

--- a/packages/core/tests/unit/graphql-config.test.ts
+++ b/packages/core/tests/unit/graphql-config.test.ts
@@ -5,7 +5,11 @@ import { vol } from "memfs";
 import { join } from "node:path";
 
 import * as CoreGraphQLConfig from "../../src/graphql-config";
-import { buildConfig, DEFAULT_OPTIONS } from "../../src/config";
+import {
+  buildConfig,
+  DEFAULT_HIERARCHY,
+  DEFAULT_OPTIONS,
+} from "../../src/config";
 
 jest.mock("graphql-config");
 import * as GraphQLConfig from "graphql-config";
@@ -317,7 +321,10 @@ describe("config", () => {
           ),
           prettify: DEFAULT_OPTIONS.pretty,
           printer: DEFAULT_OPTIONS.printer,
-          printTypeOptions: DEFAULT_OPTIONS.printTypeOptions,
+          printTypeOptions: {
+            ...DEFAULT_OPTIONS.printTypeOptions,
+            hierarchy: DEFAULT_HIERARCHY,
+          },
           schemaLocation: graphqlConfig.schema,
           skipDocDirective: DEFAULT_OPTIONS.skipDocDirective,
           tmpDir: expect.stringMatching(/.+@graphql-markdown\/docusaurus$/),


### PR DESCRIPTION
# Description

Fix validation error report when `--hierarchy` flag passed in CLI, but failed validation because of conflict with the default config value.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
