### PR TITLE
:bookmark:  release 1.26.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16699,23 +16699,23 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/graphql": "^1.1.4",
+        "@graphql-markdown/graphql": "^1.1.5",
         "@graphql-markdown/logger": "^1.0.5",
-        "@graphql-markdown/utils": "^1.7.0"
+        "@graphql-markdown/utils": "^1.7.1"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.4.0"
+        "@graphql-markdown/types": "^1.4.2"
       },
       "engines": {
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@graphql-markdown/diff": "^1.1.8",
-        "@graphql-markdown/helpers": "^1.0.7",
-        "@graphql-markdown/printer-legacy": "^1.9.0",
+        "@graphql-markdown/diff": "^1.1.9",
+        "@graphql-markdown/helpers": "^1.0.8",
+        "@graphql-markdown/printer-legacy": "^1.9.1",
         "graphql-config": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -16735,17 +16735,17 @@
     },
     "packages/diff": {
       "name": "@graphql-markdown/diff",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "license": "MIT",
       "dependencies": {
         "@graphql-inspector/core": "^6.1.0",
-        "@graphql-markdown/graphql": "^1.1.4",
-        "@graphql-markdown/utils": "^1.7.0",
+        "@graphql-markdown/graphql": "^1.1.5",
+        "@graphql-markdown/utils": "^1.7.1",
         "@graphql-tools/graphql-file-loader": "^8.0.1",
         "@graphql-tools/load": "^8.0.2"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.4.0"
+        "@graphql-markdown/types": "^1.4.2"
       },
       "engines": {
         "node": ">=16.14"
@@ -16753,16 +16753,16 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.26.3",
+      "version": "1.26.4",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.12.1",
+        "@graphql-markdown/core": "^1.12.2",
         "@graphql-markdown/logger": "^1.0.5",
-        "@graphql-markdown/printer-legacy": "^1.9.0"
+        "@graphql-markdown/printer-legacy": "^1.9.1"
       },
       "devDependencies": {
         "@docusaurus/types": "^3.5.0",
-        "@graphql-markdown/types": "^1.4.0"
+        "@graphql-markdown/types": "^1.4.2"
       },
       "engines": {
         "node": ">=16.14"
@@ -16773,14 +16773,14 @@
     },
     "packages/graphql": {
       "name": "@graphql-markdown/graphql",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.7.0",
+        "@graphql-markdown/utils": "^1.7.1",
         "@graphql-tools/load": "^8.0.2"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.4.0"
+        "@graphql-markdown/types": "^1.4.2"
       },
       "engines": {
         "node": ">=16.14"
@@ -16791,14 +16791,14 @@
     },
     "packages/helpers": {
       "name": "@graphql-markdown/helpers",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/graphql": "^1.1.4",
-        "@graphql-markdown/utils": "^1.7.0"
+        "@graphql-markdown/graphql": "^1.1.5",
+        "@graphql-markdown/utils": "^1.7.1"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.4.0"
+        "@graphql-markdown/types": "^1.4.2"
       },
       "engines": {
         "node": ">=16.14"
@@ -16820,15 +16820,15 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/utils": ">=3.2.0",
-        "@graphql-markdown/graphql": "^1.1.4",
-        "@graphql-markdown/utils": "^1.7.0"
+        "@graphql-markdown/graphql": "^1.1.5",
+        "@graphql-markdown/utils": "^1.7.1"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.4.0"
+        "@graphql-markdown/types": "^1.4.2"
       },
       "engines": {
         "node": ">=16.14"
@@ -16836,7 +16836,7 @@
     },
     "packages/types": {
       "name": "@graphql-markdown/types",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "devDependencies": {
         "@graphql-tools/load": "8.0.9",
@@ -16847,10 +16847,10 @@
     },
     "packages/utils": {
       "name": "@graphql-markdown/utils",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "devDependencies": {
-        "@graphql-markdown/types": "^1.3.1"
+        "@graphql-markdown/types": "^1.4.2"
       },
       "engines": {
         "node": ">=16.14"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.12.1",
+  "version": "1.12.2",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -63,18 +63,18 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/graphql": "^1.1.4",
+    "@graphql-markdown/graphql": "^1.1.5",
     "@graphql-markdown/logger": "^1.0.5",
-    "@graphql-markdown/utils": "^1.7.0"
+    "@graphql-markdown/utils": "^1.7.1"
   },
   "peerDependencies": {
-    "@graphql-markdown/diff": "^1.1.8",
-    "@graphql-markdown/helpers": "^1.0.7",
-    "@graphql-markdown/printer-legacy": "^1.9.0",
+    "@graphql-markdown/diff": "^1.1.9",
+    "@graphql-markdown/helpers": "^1.0.8",
+    "@graphql-markdown/printer-legacy": "^1.9.1",
     "graphql-config": "^5.1.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.4.0"
+    "@graphql-markdown/types": "^1.4.2"
   },
   "peerDependenciesMeta": {
     "@graphql-markdown/printer-legacy": {

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.8",
+  "version": "1.1.9",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -57,13 +57,13 @@
   },
   "dependencies": {
     "@graphql-inspector/core": "^6.1.0",
-    "@graphql-markdown/graphql": "^1.1.4",
-    "@graphql-markdown/utils": "^1.7.0",
+    "@graphql-markdown/graphql": "^1.1.5",
+    "@graphql-markdown/utils": "^1.7.1",
     "@graphql-tools/graphql-file-loader": "^8.0.1",
     "@graphql-tools/load": "^8.0.2"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.4.0"
+    "@graphql-markdown/types": "^1.4.2"
   },
   "resolutions": {
     "braces": "3.0.3"

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.26.3",
+  "version": "1.26.4",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -51,13 +51,13 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.12.1",
+    "@graphql-markdown/core": "^1.12.2",
     "@graphql-markdown/logger": "^1.0.5",
-    "@graphql-markdown/printer-legacy": "^1.9.0"
+    "@graphql-markdown/printer-legacy": "^1.9.1"
   },
   "devDependencies": {
     "@docusaurus/types": "^3.5.0",
-    "@graphql-markdown/types": "^1.4.0"
+    "@graphql-markdown/types": "^1.4.2"
   },
   "peerDependencies": {
     "@docusaurus/logger": "*"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.4",
+  "version": "1.1.5",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -57,13 +57,13 @@
   },
   "dependencies": {
     "@graphql-tools/load": "^8.0.2",
-    "@graphql-markdown/utils": "^1.7.0"
+    "@graphql-markdown/utils": "^1.7.1"
   },
   "peerDependencies": {
     "graphql": "^16.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.4.0"
+    "@graphql-markdown/types": "^1.4.2"
   },
   "directories": {
     "test": "tests"

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.7",
+  "version": "1.0.8",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,14 +56,14 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/graphql": "^1.1.4",
-    "@graphql-markdown/utils": "^1.7.0"
+    "@graphql-markdown/graphql": "^1.1.5",
+    "@graphql-markdown/utils": "^1.7.1"
   },
   "peerDependencies": {
     "graphql": "^16.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.4.0"
+    "@graphql-markdown/types": "^1.4.2"
   },
   "directories": {
     "test": "tests"

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.9.0",
+  "version": "1.9.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -57,11 +57,11 @@
   },
   "dependencies": {
     "@docusaurus/utils": ">=3.2.0",
-    "@graphql-markdown/graphql": "^1.1.4",
-    "@graphql-markdown/utils": "^1.7.0"
+    "@graphql-markdown/graphql": "^1.1.5",
+    "@graphql-markdown/utils": "^1.7.1"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.4.0"
+    "@graphql-markdown/types": "^1.4.2"
   },
   "resolutions": {
     "micromatch": "4.0.8"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-markdown/types",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Common types for @graphql-markdown packages",
   "repository": {
     "type": "git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,7 +56,7 @@
     "docs": "typedoc"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.3.1"
+    "@graphql-markdown/types": "^1.4.2"
   },
   "peerDependencies": {
     "prettier": "^2.8 || ^3.0"


### PR DESCRIPTION
# Description

Release 1.26.4

---

🐛 Bug fixes for [`printTypeOptions`](https://graphql-markdown.dev/docs/settings#printtypeoptions) parameters `hierarchy` and `example`.

## What's Changed
* ♻️ remove circular dependencies by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/1820
* :bug:  fix error when hierarchy defined in cli but validation failed by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/1884
* 🐛 fix example option with schema containing recursive types by @edno in https://github.com/graphql-markdown/graphql-markdown/pull/1887 reported in #1883 by XXXX

**Full Changelog**: https://github.com/graphql-markdown/graphql-markdown/compare/1.26.3...1.26.4

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
