### PR TITLE
:sparkles:  move docusaurus\utils from printer to docusaurus plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -870,8 +870,6 @@
     },
     "node_modules/@docusaurus/logger": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -897,8 +895,6 @@
     },
     "node_modules/@docusaurus/types": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.7.0.tgz",
-      "integrity": "sha512-kOmZg5RRqJfH31m+6ZpnwVbkqMJrPOG5t0IOl4i/+3ruXyNfWzZ0lVtVrD0u4ONc/0NOsS9sWYaxxWNkH1LdLQ==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -918,8 +914,6 @@
     },
     "node_modules/@docusaurus/types/node_modules/commander": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -927,8 +921,6 @@
     },
     "node_modules/@docusaurus/utils": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/logger": "3.7.0",
@@ -958,8 +950,6 @@
     },
     "node_modules/@docusaurus/utils-common": {
       "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/types": "3.7.0",
@@ -971,8 +961,6 @@
     },
     "node_modules/@docusaurus/utils/node_modules/fs-extra": {
       "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -1102,8 +1090,6 @@
     },
     "node_modules/@gerrit0/mini-shiki": {
       "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.24.1.tgz",
-      "integrity": "sha512-PNP/Gjv3VqU7z7DjRgO3F9Ok5frTKqtpV+LJW1RzMcr2zpRk0ulhEWnbcNGXzPC7BZyWMIHrkfQX2GZRfxrn6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1114,8 +1100,6 @@
     },
     "node_modules/@graphql-eslint/eslint-plugin": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@graphql-eslint/eslint-plugin/-/eslint-plugin-4.3.0.tgz",
-      "integrity": "sha512-9UTJfYNGAK5GuFapsNvA+508ke8YPc9Yt6mgT4Lc+gS18p53oG5wmXd3jdmNeVOfxhUefJcJbn925vIrjg/8/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1148,8 +1132,6 @@
     },
     "node_modules/@graphql-inspector/core": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-inspector/core/-/core-6.2.1.tgz",
-      "integrity": "sha512-PxL3fNblfKx/h/B4MIXN1yGHsGdY+uuySz8MAy/ogDk7eU1+va2zDZicLMEBHf7nsKfHWCAN1WFtD1GQP824NQ==",
       "license": "MIT",
       "dependencies": {
         "dependency-graph": "1.0.0",
@@ -1165,8 +1147,6 @@
     },
     "node_modules/@graphql-inspector/core/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "license": "0BSD"
     },
     "node_modules/@graphql-markdown/cli": {
@@ -1227,8 +1207,6 @@
     },
     "node_modules/@graphql-tools/code-file-loader": {
       "version": "8.1.6",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.6.tgz",
-      "integrity": "sha512-AAD5E+CuSc73UuGmZM5bkXEtz4xlC9Lu+arhjhgLjoVD8M/Bp+0xnyqA+73nJu73eqptd58qKEQ5ZoloOWFQZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1247,8 +1225,6 @@
     },
     "node_modules/@graphql-tools/code-file-loader/node_modules/@graphql-tools/graphql-tag-pluck": {
       "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.5.tgz",
-      "integrity": "sha512-k9h5pRs4nY7X6ZxaPZhNmy6FDXd79ay+//zKfkePT5uGpAiy+PgpDql/CiIySttwNxQ0BisVW/J1oikfKj67LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1358,8 +1334,6 @@
     },
     "node_modules/@graphql-tools/graphql-file-loader": {
       "version": "8.0.14",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.14.tgz",
-      "integrity": "sha512-Mlcd8u1u6WMRgvvERKfFRL0txTLKtmbmq0x8DzIZ7BACrYCv2rwtV79J51LbFUNBO6cMzu8rzoxTneqYm6dRNg==",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/import": "7.0.13",
@@ -1377,8 +1351,6 @@
     },
     "node_modules/@graphql-tools/graphql-tag-pluck": {
       "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.4.tgz",
-      "integrity": "sha512-prb+3Pec8qxgouZVBA4jOXGTxKFEw7w2IPPLnz1P06EgxBvRQXTcHtRo9HNWSGMYO4jUrpYiIqlq/Jzjlgb3rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1399,8 +1371,6 @@
     },
     "node_modules/@graphql-tools/import": {
       "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.13.tgz",
-      "integrity": "sha512-END2Bg0bvLnXDHi8WUbD7xrnf8komlIkKMOzSexFLeGpEYPlMsBOM6m0RW31Zk8zdN01gLPAyyT4tQXSIzCGIw==",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "^10.8.1",
@@ -1416,8 +1386,6 @@
     },
     "node_modules/@graphql-tools/json-file-loader": {
       "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.13.tgz",
-      "integrity": "sha512-T8s05fcWvwkB9iM77RQ8WBGylkzZQ+aFzYZabg51jXvusiXWLCN3BSKPsEvSPpb3Y7JJBAK4e+Hu7UmZxqolkA==",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "^10.8.1",
@@ -1434,8 +1402,6 @@
     },
     "node_modules/@graphql-tools/load": {
       "version": "8.0.14",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.0.14.tgz",
-      "integrity": "sha512-ECdc/hoSs455B6ksO25mEK/FWDPQqWXQ5aMUgjqaApiPasipOfdsZEINHc8ikm/T+hF++/h6+9PDJNsIideWuQ==",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/schema": "^10.0.18",
@@ -1452,8 +1418,6 @@
     },
     "node_modules/@graphql-tools/merge": {
       "version": "9.0.19",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.19.tgz",
-      "integrity": "sha512-iJP3Xke+vgnST58A1Q/1+y3bzfbYalIMnegUNupYHNvHHSE0PXoq8YieqQF8JYzWVACMxiq/M4Y1vW75mS2UVg==",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/utils": "^10.8.1",
@@ -1468,8 +1432,6 @@
     },
     "node_modules/@graphql-tools/schema": {
       "version": "10.0.18",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.18.tgz",
-      "integrity": "sha512-6j2O/07v1zbGvASizMSO7YZdGt/9HfPDx8s9n75sD2xoGfeJ2aRSmI4LkyuvqOpi0ecaa9xErnMEEvUaKBqMbw==",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/merge": "^9.0.19",
@@ -1510,8 +1472,6 @@
     },
     "node_modules/@graphql-tools/utils": {
       "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.8.1.tgz",
-      "integrity": "sha512-fI5NNuqeEAHyp7NuCDjvxWR5PTUXM4AqY9BoC59ZcX4nePAJje27ZsFHbAMS6EKDosY1K/D4ADxsO0P5+FH07A==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -1613,8 +1573,6 @@
     },
     "node_modules/@inquirer/checkbox": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-3.0.1.tgz",
-      "integrity": "sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1630,8 +1588,6 @@
     },
     "node_modules/@inquirer/confirm": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-4.0.1.tgz",
-      "integrity": "sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1644,8 +1600,6 @@
     },
     "node_modules/@inquirer/core": {
       "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
-      "integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1668,15 +1622,11 @@
     },
     "node_modules/@inquirer/core/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@inquirer/core/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1685,8 +1635,6 @@
     },
     "node_modules/@inquirer/core/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1700,8 +1648,6 @@
     },
     "node_modules/@inquirer/core/node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1715,8 +1661,6 @@
     },
     "node_modules/@inquirer/editor": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-3.0.1.tgz",
-      "integrity": "sha512-VA96GPFaSOVudjKFraokEEmUQg/Lub6OXvbIEZU1SDCmBzRkHGhxoFAVaF30nyiB4m5cEbDgiI2QRacXZ2hw9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1730,8 +1674,6 @@
     },
     "node_modules/@inquirer/expand": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-3.0.1.tgz",
-      "integrity": "sha512-ToG8d6RIbnVpbdPdiN7BCxZGiHOTomOX94C2FaT5KOHupV40tKEDozp12res6cMIfRKrXLJyexAZhWVHgbALSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1745,8 +1687,6 @@
     },
     "node_modules/@inquirer/figures": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.6.tgz",
-      "integrity": "sha512-yfZzps3Cso2UbM7WlxKwZQh2Hs6plrbjs1QnzQDZhK2DgyCo6D8AaHps9olkNcUFlcYERMqU3uJSp1gmy3s/qQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1755,8 +1695,6 @@
     },
     "node_modules/@inquirer/input": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-3.0.1.tgz",
-      "integrity": "sha512-BDuPBmpvi8eMCxqC5iacloWqv+5tQSJlUafYWUe31ow1BVXjW2a5qe3dh4X/Z25Wp22RwvcaLCc2siHobEOfzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1769,8 +1707,6 @@
     },
     "node_modules/@inquirer/number": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-2.0.1.tgz",
-      "integrity": "sha512-QpR8jPhRjSmlr/mD2cw3IR8HRO7lSVOnqUvQa8scv1Lsr3xoAMMworcYW3J13z3ppjBFBD2ef1Ci6AE5Qn8goQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1783,8 +1719,6 @@
     },
     "node_modules/@inquirer/password": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-3.0.1.tgz",
-      "integrity": "sha512-haoeEPUisD1NeE2IanLOiFr4wcTXGWrBOyAyPZi1FfLJuXOzNmxCJPgUrGYKVh+Y8hfGJenIfz5Wb/DkE9KkMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1798,8 +1732,6 @@
     },
     "node_modules/@inquirer/prompts": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-6.0.1.tgz",
-      "integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1820,8 +1752,6 @@
     },
     "node_modules/@inquirer/rawlist": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-3.0.1.tgz",
-      "integrity": "sha512-VgRtFIwZInUzTiPLSfDXK5jLrnpkuSOh1ctfaoygKAdPqjcjKYmGh6sCY1pb0aGnCGsmhUxoqLDUAU0ud+lGXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1835,8 +1765,6 @@
     },
     "node_modules/@inquirer/search": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-2.0.1.tgz",
-      "integrity": "sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1851,8 +1779,6 @@
     },
     "node_modules/@inquirer/select": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-3.0.1.tgz",
-      "integrity": "sha512-lUDGUxPhdWMkN/fHy1Lk7pF3nK1fh/gqeyWXmctefhxLYxlDsc7vsPBEpxrfVGDsVdyYJsiJoD4bJ1b623cV1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1868,8 +1794,6 @@
     },
     "node_modules/@inquirer/type": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
-      "integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2584,15 +2508,11 @@
     },
     "node_modules/@microsoft/tsdoc": {
       "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
-      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@microsoft/tsdoc-config": {
       "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.1.tgz",
-      "integrity": "sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2911,8 +2831,6 @@
     },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.0.tgz",
-      "integrity": "sha512-Eua0qNOL73Y82lGA4GF5P+G2+VXX9XnuUxkiUuwcxQPH4wom+tE39kZpBFXfUuwNYxHSkrSxpB1p4kyRW0moSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2922,8 +2840,6 @@
     },
     "node_modules/@shikijs/types": {
       "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.24.0.tgz",
-      "integrity": "sha512-aptbEuq1Pk88DMlCe+FzXNnBZ17LCiLIGWAeCWhoFDzia5Q5Krx3DgnULLiouSdd6+LUM39XwXGppqYE0Ghtug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2933,8 +2849,6 @@
     },
     "node_modules/@shikijs/vscode-textmate": {
       "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.0.tgz",
-      "integrity": "sha512-jn7/7ky30idSkd/O5yDBfAnVt+JJpepofP/POZ1iMOxK59cOfqIgg/Dj0eFsjOTMw+4ycJN0uhZH/Eb0bs/EUA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3011,8 +2925,6 @@
     },
     "node_modules/@stryker-mutator/api": {
       "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-8.7.1.tgz",
-      "integrity": "sha512-56vxcVxIfW0jxJhr7HB9Zx6Xr5/M95RG9MUK1DtbQhlmQesjpfBBsrPLOPzBJaITPH/vOYykuJ69vgSAMccQyw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3027,8 +2939,6 @@
     },
     "node_modules/@stryker-mutator/core": {
       "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-8.7.1.tgz",
-      "integrity": "sha512-r2AwhHWkHq6yEe5U8mAzPSWewULbv9YMabLHRzLjZnjj+Ipxtg+Zo22rrUc2Zl7mnYvb9w34bdlEzGz6MKgX2g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3067,8 +2977,6 @@
     },
     "node_modules/@stryker-mutator/core/node_modules/ajv": {
       "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3084,8 +2992,6 @@
     },
     "node_modules/@stryker-mutator/core/node_modules/chalk": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3097,8 +3003,6 @@
     },
     "node_modules/@stryker-mutator/core/node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3110,8 +3014,6 @@
     },
     "node_modules/@stryker-mutator/instrumenter": {
       "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-8.7.1.tgz",
-      "integrity": "sha512-HSq4VHXesQCMR3hr6bn41DAeJ0yuP2vp9KSnls2TySNawFVWOCaKXpBX29Skj3zJQh7dnm7HuQg8HuXvJK15oA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3144,8 +3046,6 @@
     },
     "node_modules/@stryker-mutator/jest-runner": {
       "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/jest-runner/-/jest-runner-8.7.1.tgz",
-      "integrity": "sha512-507jgu9E0yNDwMN56p4J+iFI77+rPDLDV91qYGbBI6fvy5c7rBQ63l64FtAFMTG75f4gCZ6C/Pq3nXTQx6PMjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3163,8 +3063,6 @@
     },
     "node_modules/@stryker-mutator/jest-runner/node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3176,8 +3074,6 @@
     },
     "node_modules/@stryker-mutator/typescript-checker": {
       "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/typescript-checker/-/typescript-checker-8.7.1.tgz",
-      "integrity": "sha512-ZliTju52pOR9Xnh1AjGn4Oet7lTWjbDbi6RfoBGAPzVSZSYcZNnupr3tBtDJX4p2qVYYfYvmhoAKYXbe30dWBQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3195,8 +3091,6 @@
     },
     "node_modules/@stryker-mutator/typescript-checker/node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3208,8 +3102,6 @@
     },
     "node_modules/@stryker-mutator/util": {
       "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-8.7.1.tgz",
-      "integrity": "sha512-Oj/sIHZI1GLfGOHKnud4Gw0ZRufm7ONoQYNnhcaAYEXTWraYVcV7mue/th8fZComTHvDPA8Ge8U16FvWYEb8dg==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -3299,8 +3191,6 @@
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -3357,8 +3247,6 @@
     },
     "node_modules/@types/jest": {
       "version": "29.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
-      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3398,8 +3286,6 @@
     },
     "node_modules/@types/mute-stream": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
-      "integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3408,8 +3294,6 @@
     },
     "node_modules/@types/node": {
       "version": "22.13.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
-      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -3448,8 +3332,6 @@
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
-      "integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
       "dev": true,
       "license": "MIT"
     },
@@ -3475,8 +3357,6 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.24.0.tgz",
-      "integrity": "sha512-aFcXEJJCI4gUdXgoo/j9udUYIHgF23MFkg09LFz2dzEmU0+1Plk4rQWv/IYKvPHAtlkkGoB3m5e6oUp+JPsNaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3505,8 +3385,6 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.24.0.tgz",
-      "integrity": "sha512-MFDaO9CYiard9j9VepMNa9MTcqVvSny2N4hkY6roquzj8pdCBRENhErrteaQuu7Yjn1ppk0v1/ZF9CG3KIlrTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3530,8 +3408,6 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.24.0.tgz",
-      "integrity": "sha512-HZIX0UByphEtdVBKaQBgTDdn9z16l4aTUz8e8zPQnyxwHBtf5vtl1L+OhH+m1FGV9DrRmoDuYKqzVrvWDcDozw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3548,8 +3424,6 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.24.0.tgz",
-      "integrity": "sha512-8fitJudrnY8aq0F1wMiPM1UUgiXQRJ5i8tFjq9kGfRajU+dbPyOuHbl0qRopLEidy0MwqgTHDt6CnSeXanNIwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3572,8 +3446,6 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.24.0.tgz",
-      "integrity": "sha512-VacJCBTyje7HGAw7xp11q439A+zeGG0p0/p2zsZwpnMzjPB5WteaWqt4g2iysgGFafrqvyLWqq6ZPZAOCoefCw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3586,8 +3458,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.24.0.tgz",
-      "integrity": "sha512-ITjYcP0+8kbsvT9bysygfIfb+hBj6koDsu37JZG7xrCiy3fPJyNmfVtaGsgTUSEuTzcvME5YI5uyL5LD1EV5ZQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3613,8 +3483,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3626,8 +3494,6 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.24.0.tgz",
-      "integrity": "sha512-07rLuUBElvvEb1ICnafYWr4hk8/U7X9RDCOqd9JcAMtjh/9oRmcfN4yGzbPVirgMR0+HLVHehmu19CWeh7fsmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3650,8 +3516,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.24.0.tgz",
-      "integrity": "sha512-kArLq83QxGLbuHrTMoOEWO+l2MwsNS2TGISEdx8xgqpkbytB07XmlQyQdNDrCc1ecSqx0cnmhGvpX+VBwqqSkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3668,8 +3532,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3849,8 +3711,6 @@
     },
     "node_modules/acorn": {
       "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -4295,8 +4155,6 @@
     },
     "node_modules/browserslist": {
       "version": "4.24.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.2.tgz",
-      "integrity": "sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4423,8 +4281,6 @@
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001680",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz",
-      "integrity": "sha512-rPQy70G6AGUMnbwS1z6Xg+RkHYPAi18ihs47GH0jcxIG7wArmPgY3XbS2sRdBbxJljp3thdT8BIqv9ccCypiPA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4451,8 +4307,6 @@
     },
     "node_modules/chalk": {
       "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -4581,8 +4435,6 @@
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -4718,8 +4570,6 @@
     },
     "node_modules/commitizen": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.3.1.tgz",
-      "integrity": "sha512-gwAPAVTy/j5YcOOebcCRIijn+mSjWJC+IYKivTu6aG8Ei/scoXgfsMRnuAk6b0GRste2J4NGxVdMN3ZpfNaVaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4749,8 +4599,6 @@
     },
     "node_modules/commitizen/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4760,9 +4608,6 @@
     },
     "node_modules/commitizen/node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4782,8 +4627,6 @@
     },
     "node_modules/commitizen/node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4911,8 +4754,6 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5096,8 +4937,6 @@
     },
     "node_modules/debug": {
       "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5330,8 +5169,6 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.57",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.57.tgz",
-      "integrity": "sha512-xS65H/tqgOwUBa5UmOuNSLuslDo7zho0y/lgQw35pnrqiZh7UOWHCeL/Bt6noJATbA6tpQJGCifsFsIRZj1Fqg==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -5347,8 +5184,6 @@
     },
     "node_modules/emoji-regex": {
       "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5361,8 +5196,6 @@
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
-      "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -5536,8 +5369,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5609,9 +5440,8 @@
     },
     "node_modules/eslint-compat-utils": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.6.0.tgz",
-      "integrity": "sha512-1vVBdI/HLS6HTHVQCJGlN+LOF0w1Rs/WB9se23mQr84cRM0iMM8PulMFFhQdQ1BvS0cGwjpis4xziI91Rk0l6g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.5.4"
       },
@@ -5624,9 +5454,8 @@
     },
     "node_modules/eslint-compat-utils/node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -5636,8 +5465,6 @@
     },
     "node_modules/eslint-config-prettier": {
       "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.0.1.tgz",
-      "integrity": "sha512-lZBts941cyJyeaooiKxAtzoPHTN+GbQTJFAIdQbRhA4/8whaAraEh47Whw/ZFfrjNSnlAxqfm9i0XVAEkULjCw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5667,8 +5494,6 @@
     },
     "node_modules/eslint-import-resolver-typescript": {
       "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.8.0.tgz",
-      "integrity": "sha512-fItUrP/+xwpavWgadrn6lsvcMe80s08xIVFXkUXvhR4cZD2ga96kRF/z/iFGDI7ZDnvtlaZ0wGic7Tw+DhgVnA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5702,9 +5527,8 @@
     },
     "node_modules/eslint-json-compat-utils": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-json-compat-utils/-/eslint-json-compat-utils-0.2.1.tgz",
-      "integrity": "sha512-YzEodbDyW8DX8bImKhAcCeu/L31Dd/70Bidx2Qex9OFUtgzXLqtfWL4Hr5fM/aCCB8QUZLuJur0S9k6UfgFkfg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esquery": "^1.6.0"
       },
@@ -5769,8 +5593,6 @@
     },
     "node_modules/eslint-module-utils": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
-      "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5795,8 +5617,6 @@
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
-      "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5829,8 +5649,6 @@
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5840,8 +5658,6 @@
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5850,8 +5666,6 @@
     },
     "node_modules/eslint-plugin-import/node_modules/doctrine": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5863,8 +5677,6 @@
     },
     "node_modules/eslint-plugin-import/node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5876,8 +5688,6 @@
     },
     "node_modules/eslint-plugin-jest": {
       "version": "28.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz",
-      "integrity": "sha512-QAfipLcNCWLVocVbZW8GimKn5p5iiMcgGbRzz8z/P5q7xw+cNEpYqyzFMtIF/ZgF2HLOyy+dYBut+DoYolvqig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5902,8 +5712,6 @@
     },
     "node_modules/eslint-plugin-jsonc": {
       "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.19.1.tgz",
-      "integrity": "sha512-MmlAOaZK1+Lg7YoCZPGRjb88ZjT+ct/KTsvcsbZdBm+w8WMzGx+XEmexk0m40P1WV9G2rFV7X3klyRGRpFXEjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5967,8 +5775,6 @@
     },
     "node_modules/eslint-plugin-prettier": {
       "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.3.tgz",
-      "integrity": "sha512-qJ+y0FfCp/mQYQ/vWQ3s7eUlFEL4PyKfAJxsnYTJ4YT73nsJBWqmEpFryxV9OeUiqmsTsYJ5Y+KDNaeP31wrRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5998,8 +5804,6 @@
     },
     "node_modules/eslint-plugin-prettier/node_modules/synckit": {
       "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
-      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6015,8 +5819,6 @@
     },
     "node_modules/eslint-plugin-tsdoc": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.4.0.tgz",
-      "integrity": "sha512-MT/8b4aKLdDClnS8mP3R/JNjg29i0Oyqd/0ym6NnQf+gfKbJJ4ZcSh2Bs1H0YiUMTBwww5JwXGTWot/RwyJ7aQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6267,8 +6069,6 @@
     },
     "node_modules/execa": {
       "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.4.0.tgz",
-      "integrity": "sha512-yKHlle2YGxZE842MERVIplWwNH5VYmqqcPFgtnlU//K8gxuFFXu0pwd/CrfXTumFpeEiufsP7+opT/bPJa1yVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6402,8 +6202,6 @@
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -6664,21 +6462,6 @@
       "version": "1.0.0",
       "license": "ISC"
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
@@ -6794,8 +6577,6 @@
     },
     "node_modules/get-tsconfig": {
       "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.0.tgz",
-      "integrity": "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6967,8 +6748,6 @@
     },
     "node_modules/graphql": {
       "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
-      "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -6976,8 +6755,6 @@
     },
     "node_modules/graphql-config": {
       "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.1.3.tgz",
-      "integrity": "sha512-RBhejsPjrNSuwtckRlilWzLVt2j8itl74W9Gke1KejDTz7oaA5kVd6wRn9zK9TS5mcmIYGxf7zN7a1ORMdxp1Q==",
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/graphql-file-loader": "^8.0.0",
@@ -7007,8 +6784,6 @@
     },
     "node_modules/graphql-config/node_modules/cosmiconfig": {
       "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "license": "MIT",
       "dependencies": {
         "import-fresh": "^3.3.0",
@@ -7033,8 +6808,6 @@
     },
     "node_modules/graphql-config/node_modules/jiti": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.3.3.tgz",
-      "integrity": "sha512-EX4oNDwcXSivPrw2qKH2LB5PoFxEvgtv2JgwW0bU858HoLQ+kutSvjLMUqBd0PeJYEinLWhoI9Ol0eYMqj/wNQ==",
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7268,8 +7041,6 @@
     },
     "node_modules/human-signals": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.0.tgz",
-      "integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -7278,8 +7049,6 @@
     },
     "node_modules/husky": {
       "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7428,8 +7197,6 @@
     },
     "node_modules/inquirer": {
       "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
-      "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7877,8 +7644,6 @@
     },
     "node_modules/inquirer/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7894,8 +7659,6 @@
     },
     "node_modules/inquirer/node_modules/cli-width": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -7904,15 +7667,11 @@
     },
     "node_modules/inquirer/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/inquirer/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7921,8 +7680,6 @@
     },
     "node_modules/inquirer/node_modules/figures": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7937,8 +7694,6 @@
     },
     "node_modules/inquirer/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7947,15 +7702,11 @@
     },
     "node_modules/inquirer/node_modules/mute-stream": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/inquirer/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7969,8 +7720,6 @@
     },
     "node_modules/inquirer/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9656,8 +9405,6 @@
     },
     "node_modules/knip": {
       "version": "5.44.1",
-      "resolved": "https://registry.npmjs.org/knip/-/knip-5.44.1.tgz",
-      "integrity": "sha512-YJrz7K6AA3SwXJ5LL9ZlzQX9wcihMNwKoGBAaY5kUn4rLNOZ5ehsjFV+xm8gQuIJdjsFIKcFsy0K3U3yM/mabw==",
       "dev": true,
       "funding": [
         {
@@ -9706,8 +9453,6 @@
     },
     "node_modules/knip/node_modules/@nodelib/fs.scandir": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-4.0.1.tgz",
-      "integrity": "sha512-vAkI715yhnmiPupY+dq+xenu5Tdf2TBQ66jLvBIcCddtz+5Q8LbMKaf9CIJJreez8fQ8fgaY+RaywQx8RJIWpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9720,8 +9465,6 @@
     },
     "node_modules/knip/node_modules/@nodelib/fs.stat": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-4.0.0.tgz",
-      "integrity": "sha512-ctr6bByzksKRCV0bavi8WoQevU6plSp2IkllIsEqaiKe2mwNNnaluhnRhcsgGZHrrHk57B3lf95MkLMO3STYcg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9730,8 +9473,6 @@
     },
     "node_modules/knip/node_modules/@nodelib/fs.walk": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-3.0.1.tgz",
-      "integrity": "sha512-nIh/M6Kh3ZtOmlY00DaUYB4xeeV6F3/ts1l29iwl3/cfyY/OuCfUx+v08zgx8TKPTifXRcjjqVQ4KB2zOYSbyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9744,8 +9485,6 @@
     },
     "node_modules/knip/node_modules/jiti": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -9754,8 +9493,6 @@
     },
     "node_modules/knip/node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -9764,8 +9501,6 @@
     },
     "node_modules/knip/node_modules/picomatch": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9777,8 +9512,6 @@
     },
     "node_modules/knip/node_modules/strip-json-comments": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.1.tgz",
-      "integrity": "sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10667,8 +10400,6 @@
     },
     "node_modules/memfs": {
       "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.17.0.tgz",
-      "integrity": "sha512-4eirfZ7thblFmqFjywlTmuWVSvccHAJbn1r8qQLzmTO11qcqpohOjmY2mFce6x7x7WtskzRqApPD0hv+Oa74jg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11314,21 +11045,15 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/mutation-testing-elements": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.4.0.tgz",
-      "integrity": "sha512-zFJtGlobq+Fyq95JoJj0iqrmwLSLQyIJuDATLwFMDSJCxpGN8kHCA6S4LoLJnkSL6bg4Aqultp8OBSMxGbW3EA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/mutation-testing-metrics": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.3.0.tgz",
-      "integrity": "sha512-vZEJ84SpK3Rwyk7k28SORS5o6ZDtehwifLPH6fQULrozJqlz2Nj8vi52+CjA+aMZCyyKB+9eYUh1HtiWVo4o/A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11337,15 +11062,11 @@
     },
     "node_modules/mutation-testing-report-schema": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.3.0.tgz",
-      "integrity": "sha512-DF56q0sb0GYzxYUYNdzlfQzyE5oJBEasz8zL76bt3OFJU8q4iHSdUDdihPWWJD+4JLxSs3neM/R968zYdy0SWQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/mute-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -11386,8 +11107,6 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
       "license": "MIT"
     },
     "node_modules/nopt": {
@@ -11529,8 +11248,6 @@
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11546,8 +11263,6 @@
     },
     "node_modules/npm-run-path/node_modules/path-key": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11900,8 +11615,6 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -12010,8 +11723,6 @@
     },
     "node_modules/prettier": {
       "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
-      "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
@@ -12760,8 +12471,6 @@
     },
     "node_modules/run-async": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13116,8 +12825,6 @@
     },
     "node_modules/smol-toml": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.1.tgz",
-      "integrity": "sha512-tEYNll18pPKHroYSmLLrksq233j021G0giwW7P3D24jC54pQ5W5BXMsQ/Mvw1OJCmEYDgY+lrzT+3nNUtoNfXQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -13193,8 +12900,6 @@
     },
     "node_modules/stable-hash": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.4.tgz",
-      "integrity": "sha512-LjdcbuBeLcdETCrPn9i8AYAZ1eCtu4ECAWtP7UleOiZ9LzVxRzzUZEoZ8zB24nhkQnDWyET0I+3sWokSDS3E7g==",
       "dev": true,
       "license": "MIT"
     },
@@ -13656,8 +13361,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
-      "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13670,8 +13373,6 @@
     },
     "node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-      "integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -13685,8 +13386,6 @@
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13775,8 +13474,6 @@
     },
     "node_modules/ts-api-utils": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
-      "integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13876,8 +13573,6 @@
     },
     "node_modules/tslib": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "license": "0BSD"
     },
     "node_modules/tunnel": {
@@ -13997,8 +13692,6 @@
     },
     "node_modules/typed-rest-client": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
-      "integrity": "sha512-Nel9aPbgSzRxfs1+4GoSB4wexCF+4Axlk7OSGVQCMa+4fWcyxIsN/YNmkp0xTT2iQzMD98h8yFLav/cNaULmRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14019,8 +13712,6 @@
     },
     "node_modules/typedoc": {
       "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.7.tgz",
-      "integrity": "sha512-K/JaUPX18+61W3VXek1cWC5gwmuLvYTOXJzBvD9W7jFvbPnefRnCHQCEPw7MSNrP/Hj7JJrhZtDDLKdcYm6ucg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -14042,8 +13733,6 @@
     },
     "node_modules/typedoc-plugin-frontmatter": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-frontmatter/-/typedoc-plugin-frontmatter-1.2.0.tgz",
-      "integrity": "sha512-fIPUq2uryLstrSuhZpKgjMFAhYh8tN4Nv8uUTWWVINRWWeKBxj4ZnHVcMExgPznwaeQZ/ybfvP+CzAMql301FA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14055,8 +13744,6 @@
     },
     "node_modules/typedoc-plugin-markdown": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.4.2.tgz",
-      "integrity": "sha512-kJVkU2Wd+AXQpyL6DlYXXRrfNrHrEIUgiABWH8Z+2Lz5Sq6an4dQ/hfvP75bbokjNDUskOdFlEEm/0fSVyC7eg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14068,8 +13755,6 @@
     },
     "node_modules/typescript": {
       "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -14106,14 +13791,10 @@
     },
     "node_modules/undici-types": {
       "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14365,8 +14046,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "funding": [
         {
           "type": "opencollective",
@@ -14710,8 +14389,6 @@
     },
     "node_modules/webpack": {
       "version": "5.96.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
-      "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
       "license": "MIT",
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
@@ -14987,8 +14664,6 @@
     },
     "node_modules/yaml": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -15072,8 +14747,6 @@
     },
     "node_modules/yoctocolors-cjs": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
-      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15129,15 +14802,10 @@
       },
       "engines": {
         "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "@docusaurus/logger": "*"
       }
     },
     "packages/cli/node_modules/commander": {
       "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -15202,7 +14870,7 @@
       "version": "1.26.4",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/cli": "0.1.0",
+        "@docusaurus/utils": ">=3.2.0",
         "@graphql-markdown/core": "^1.12.2",
         "@graphql-markdown/logger": "^1.0.5",
         "@graphql-markdown/printer-legacy": "^1.9.1"
@@ -15270,7 +14938,6 @@
       "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/utils": ">=3.2.0",
         "@graphql-markdown/graphql": "^1.1.5",
         "@graphql-markdown/utils": "^1.7.1"
       },

--- a/packages/core/src/generator.ts
+++ b/packages/core/src/generator.ts
@@ -108,10 +108,14 @@ export const generateDocFromSchema = async ({
     {
       customDirectives,
       groups,
+      meta: {
+        generatorFrameworkName: docOptions?.generatorFrameworkName,
+        generatorFrameworkVersion: docOptions?.generatorFrameworkVersion,
+      },
+      metatags,
       onlyDocDirectives,
       printTypeOptions,
       skipDocDirectives,
-      metatags,
     },
   );
   const renderer = await getRenderer(

--- a/packages/core/tests/unit/generator.test.ts
+++ b/packages/core/tests/unit/generator.test.ts
@@ -126,6 +126,10 @@ describe("generator", () => {
         {
           customDirectives: undefined,
           groups: undefined,
+          meta: {
+            generatorFrameworkName: undefined,
+            generatorFrameworkVersion: undefined,
+          },
           metatags: [],
           printTypeOptions: options.printTypeOptions,
           onlyDocDirectives: [],

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -51,6 +51,7 @@
     "docs": "typedoc"
   },
   "dependencies": {
+    "@docusaurus/utils": ">=3.2.0",
     "@graphql-markdown/core": "^1.12.2",
     "@graphql-markdown/logger": "^1.0.5",
     "@graphql-markdown/printer-legacy": "^1.9.1"

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -5,6 +5,9 @@ import type {
   ConfigOptions,
   ExperimentalConfigOptions,
 } from "@graphql-markdown/types";
+
+import { DOCUSAURUS_VERSION } from "@docusaurus/utils";
+
 import { generateDocFromSchema, buildConfig } from "@graphql-markdown/core";
 import Logger from "@graphql-markdown/logger";
 
@@ -91,6 +94,11 @@ export default async function pluginGraphQLDocGenerator(
           const config = await buildConfig(options, cliOptions, options.id);
           await generateDocFromSchema({
             ...config,
+            docOptions: {
+              ...config.docOptions,
+              generatorFrameworkName: "docusaurus",
+              generatorFrameworkVersion: DOCUSAURUS_VERSION,
+            },
             loggerModule: LOGGER_MODULE,
           });
         });

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -56,7 +56,6 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@docusaurus/utils": ">=3.2.0",
     "@graphql-markdown/graphql": "^1.1.5",
     "@graphql-markdown/utils": "^1.7.1"
   },

--- a/packages/printer-legacy/src/common.ts
+++ b/packages/printer-legacy/src/common.ts
@@ -1,11 +1,9 @@
-import { DOCUSAURUS_VERSION } from "@docusaurus/utils";
-
 import type {
-  PrintTypeOptions,
-  MDXString,
-  Maybe,
   CustomDirectiveMap,
   CustomDirectiveMapItem,
+  Maybe,
+  MDXString,
+  PrintTypeOptions,
 } from "@graphql-markdown/types";
 
 import { isEmpty, escapeMDX } from "@graphql-markdown/utils";
@@ -64,19 +62,30 @@ export const formatDescription = (
   return `${MARKDOWN_EOP}${escapeMDX(description)}`;
 };
 
-export const printWarning = (text?: string, title?: string): string => {
+export const printWarning = (
+  text?: string,
+  title?: string,
+  options?: PrintTypeOptions,
+): string => {
   const formattedText =
     typeof text !== "string" || text.trim() === ""
       ? MARKDOWN_EOP
       : `${MARKDOWN_EOP}${text}${MARKDOWN_EOP}`;
 
-  if (DOCUSAURUS_VERSION.startsWith("2")) {
+  const isDocusaurus = options?.meta?.generatorFrameworkName === "docusaurus";
+  if (
+    isDocusaurus &&
+    options.meta?.generatorFrameworkVersion?.startsWith("2")
+  ) {
     return `${MARKDOWN_EOP}:::caution ${title}${formattedText}:::`;
   }
   return `${MARKDOWN_EOP}:::warning[${title}]${formattedText}:::`;
 };
 
-export const printDeprecation = (type: unknown): string => {
+export const printDeprecation = (
+  type: unknown,
+  options?: PrintTypeOptions,
+): string => {
   if (typeof type !== "object" || type === null || !isDeprecated(type)) {
     return "";
   }
@@ -86,7 +95,7 @@ export const printDeprecation = (type: unknown): string => {
       ? escapeMDX(type.deprecationReason)
       : "";
 
-  return printWarning(reason, DEPRECATED.toUpperCase());
+  return printWarning(reason, DEPRECATED.toUpperCase(), options);
 };
 
 export const printDescription = (
@@ -96,6 +105,6 @@ export const printDescription = (
 ): MDXString | string => {
   const description = formatDescription(type, noText);
   const customDirectives = printCustomDirectives(type, options);
-  const deprecation = printDeprecation(type);
+  const deprecation = printDeprecation(type, options);
   return `${deprecation}${description}${customDirectives}`;
 };

--- a/packages/printer-legacy/src/const/options.ts
+++ b/packages/printer-legacy/src/const/options.ts
@@ -4,7 +4,6 @@ import type {
   GraphQLDirective,
   GraphQLSchema,
   Maybe,
-  MetaOptions,
   PrintTypeOptions,
   PrinterConfigPrintTypeOptions,
   SchemaEntitiesGroupMap,

--- a/packages/printer-legacy/src/const/options.ts
+++ b/packages/printer-legacy/src/const/options.ts
@@ -4,6 +4,7 @@ import type {
   GraphQLDirective,
   GraphQLSchema,
   Maybe,
+  MetaOptions,
   PrintTypeOptions,
   PrinterConfigPrintTypeOptions,
   SchemaEntitiesGroupMap,
@@ -41,6 +42,7 @@ export const DEFAULT_OPTIONS: Required<
     | "collapsible"
     | "groups"
     | "level"
+    | "meta"
     | "onlyDocDirectives"
     | "parentType"
     | "schema"

--- a/packages/printer-legacy/src/printer.ts
+++ b/packages/printer-legacy/src/printer.ts
@@ -6,6 +6,7 @@ import type {
   IPrinter,
   MDXString,
   Maybe,
+  MetaOptions,
   PrintTypeOptions,
   PrinterConfigPrintTypeOptions,
   SchemaEntitiesGroupMap,
@@ -79,18 +80,20 @@ export class Printer implements IPrinter {
     {
       customDirectives,
       groups,
+      meta,
+      metatags,
       onlyDocDirectives,
       printTypeOptions,
       skipDocDirectives,
-      metatags,
     }: {
       customDirectives?: CustomDirectiveMap;
       deprecated?: TypeDeprecatedOption;
       groups?: SchemaEntitiesGroupMap;
+      meta?: Maybe<MetaOptions>;
+      metatags?: Record<string, string>[];
       onlyDocDirectives?: GraphQLDirective[];
       printTypeOptions?: PrinterConfigPrintTypeOptions;
       skipDocDirectives?: GraphQLDirective[];
-      metatags?: Record<string, string>[];
     } = {
       customDirectives: undefined,
       groups: undefined,
@@ -126,6 +129,7 @@ export class Printer implements IPrinter {
       metatags: metatags ?? [],
       hierarchy:
         printTypeOptions?.hierarchy ?? PRINT_TYPE_DEFAULT_OPTIONS.hierarchy,
+      meta: meta,
     };
   }
 

--- a/packages/printer-legacy/tests/unit/common.test.ts
+++ b/packages/printer-legacy/tests/unit/common.test.ts
@@ -1,3 +1,5 @@
+import type { MetaOptions, PrintTypeOptions } from "@graphql-markdown/types";
+
 import { GraphQLDirective, GraphQLScalarType } from "graphql/type";
 import { DirectiveLocation } from "graphql/language";
 
@@ -9,15 +11,6 @@ import {
 } from "../../src/common";
 
 import { DEFAULT_OPTIONS } from "../../src/const/options";
-
-import * as DocusaurusUtils from "@docusaurus/utils";
-jest.mock("@docusaurus/utils", (): unknown => {
-  return {
-    __esModule: true,
-    DOCUSAURUS_VERSION: "1.0.0",
-  };
-});
-const mockDocusaurusUtils = jest.mocked(DocusaurusUtils, { shallow: true });
 
 import * as GraphQL from "@graphql-markdown/graphql";
 jest.mock("@graphql-markdown/graphql", (): unknown => {
@@ -126,7 +119,10 @@ describe("common", () => {
     test("return DEPRECATED tag if deprecated", () => {
       expect.hasAssertions();
 
-      mockDocusaurusUtils.DOCUSAURUS_VERSION = "3.0.0";
+      const meta: MetaOptions = {
+        generatorFrameworkName: "docusaurus",
+        generatorFrameworkVersion: "3.0.0",
+      };
 
       mockGraphQL.isDeprecated.mockReturnValue(true);
 
@@ -135,7 +131,9 @@ describe("common", () => {
         isDeprecated: true,
         deprecationReason: "{ Foobar }",
       };
-      const description = printDescription(type);
+      const description = printDescription(type, {
+        meta,
+      } as unknown as PrintTypeOptions);
 
       expect(description).toMatchInlineSnapshot(`
         "
@@ -197,12 +195,10 @@ describe("common", () => {
   });
 
   describe("printDeprecation()", () => {
-    beforeEach(() => {
-      mockDocusaurusUtils.DOCUSAURUS_VERSION = "3.0.0";
-    });
-
     test("prints deprecated badge if type is deprecated", () => {
       expect.hasAssertions();
+
+      const meta: MetaOptions = {};
 
       mockGraphQL.isDeprecated.mockReturnValue(true);
 
@@ -210,7 +206,9 @@ describe("common", () => {
         name: "EntityTypeName",
         isDeprecated: true,
       };
-      const deprecation = printDeprecation(type);
+      const deprecation = printDeprecation(type, {
+        meta,
+      } as unknown as PrintTypeOptions);
 
       expect(deprecation).toMatchInlineSnapshot(`
         "
@@ -314,9 +312,16 @@ Test testDirective"
     test("prints admonition caution for Docusaurus v2", () => {
       expect.assertions(1);
 
-      mockDocusaurusUtils.DOCUSAURUS_VERSION = "2.4.2";
+      const meta: MetaOptions = {
+        generatorFrameworkName: "docusaurus",
+        generatorFrameworkVersion: "2.4.2",
+      };
 
-      expect(printWarning("test", "DEPRECATED")).toMatchInlineSnapshot(`
+      expect(
+        printWarning("test", "DEPRECATED", {
+          meta,
+        } as unknown as PrintTypeOptions),
+      ).toMatchInlineSnapshot(`
         "
 
         :::caution DEPRECATED
@@ -329,9 +334,16 @@ Test testDirective"
     test("prints admonition warning for Docusaurus v3", () => {
       expect.assertions(1);
 
-      mockDocusaurusUtils.DOCUSAURUS_VERSION = "3.0.0";
+      const meta: MetaOptions = {
+        generatorFrameworkName: "docusaurus",
+        generatorFrameworkVersion: "3.0.0",
+      };
 
-      expect(printWarning("test", "DEPRECATED")).toMatchInlineSnapshot(`
+      expect(
+        printWarning("test", "DEPRECATED", {
+          meta,
+        } as unknown as PrintTypeOptions),
+      ).toMatchInlineSnapshot(`
         "
 
         :::warning[DEPRECATED]

--- a/packages/printer-legacy/tests/unit/printer.test.ts
+++ b/packages/printer-legacy/tests/unit/printer.test.ts
@@ -47,7 +47,6 @@ import * as GraphQLPrinter from "../../src/graphql";
 jest.mock("../../src/example");
 import * as ExamplePrinter from "../../src/example";
 
-import * as Common from "../../src/common";
 import * as Link from "../../src/link";
 
 import { Printer } from "../../src/printer";
@@ -182,6 +181,7 @@ describe("Printer", () => {
             "api": {},
           },
           "level": undefined,
+          "meta": undefined,
           "metatags": [],
           "onlyDocDirectives": [],
           "parentType": undefined,
@@ -242,6 +242,7 @@ describe("Printer", () => {
             "entity": {},
           },
           "level": undefined,
+          "meta": undefined,
           "metatags": [],
           "onlyDocDirectives": [],
           "parentType": undefined,

--- a/packages/types/src/core.d.ts
+++ b/packages/types/src/core.d.ts
@@ -17,6 +17,8 @@ export interface ApiGroupOverrideType {
 export interface ConfigDocOptions {
   frontMatter?: Maybe<FrontMatterOptions>;
   index?: boolean;
+  generatorFrameworkName?: Maybe<string>;
+  generatorFrameworkVersion?: Maybe<string>;
 }
 
 export type TypeHierarchyValueType = "api" | "entity" | "flat";

--- a/packages/types/src/printer.d.ts
+++ b/packages/types/src/printer.d.ts
@@ -28,6 +28,11 @@ export type RootTypeName =
 export type TypeLocale = string | { singular: string; plural: string };
 export type RootTypeLocale = Record<RootTypeName, TypeLocale>;
 
+export interface MetaOptions {
+  generatorFrameworkName?: Maybe<string>;
+  generatorFrameworkVersion?: Maybe<string>;
+}
+
 export interface PrinterConfigPrintTypeOptions {
   codeSection?: boolean;
   deprecated?: TypeDeprecatedOption;
@@ -55,6 +60,7 @@ export interface PrintTypeOptions {
   groups?: Maybe<SchemaEntitiesGroupMap>;
   hierarchy?: Maybe<TypeHierarchyObjectType>;
   level?: Maybe<SectionLevelValue>;
+  meta?: Maybe<MetaOptions>;
   metatags?: Maybe<Record<string, string>[]>;
   onlyDocDirectives?: GraphQLDirective[];
   parentType?: Maybe<string>;
@@ -157,6 +163,7 @@ export interface PrinterOptions {
   customDirectives?: Maybe<CustomDirectiveMap>;
   deprecated?: Maybe<TypeDeprecatedOption>;
   groups?: Maybe<SchemaEntitiesGroupMap>;
+  meta?: Maybe<MetaOptions>;
   metatags?: Maybe<Record<string, string>[]>;
   onlyDocDirectives?: GraphQLDirective[];
   printTypeOptions?: Maybe<ConfigPrintTypeOptions>;


### PR DESCRIPTION
# Description

Move `@docusaurus\utils` dependency from `printer-legacy` to `docusaurus` to remove Docusaurus dependencies when using `cli`.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
