### PR TITLE
:sparkles:  remove deprecated settings

### DIFF
--- a/config/.eslintrc.js
+++ b/config/.eslintrc.js
@@ -83,6 +83,7 @@ module.exports = {
         "@typescript-eslint/no-unsafe-function-type": "error",
         "@typescript-eslint/no-unsafe-return": "error",
         "@typescript-eslint/no-unused-expressions": "error",
+        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
         "@typescript-eslint/no-use-before-define": "error",
         "@typescript-eslint/no-wrapper-object-types": "error",
         "@typescript-eslint/non-nullable-type-assertion-style": "error",

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -56,15 +56,11 @@ Use these options to tweak some of the Docusaurus documentation features:
 
 - `frontMatter`: set custom front matter entries, see [Docusaurus documentation](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-docs#markdown-front-matter).
 - `index`: enable/disable the index page for categories/groups, see [Docusaurus documentation](https://docusaurus.io/docs/sidebar/items#generated-index-page).
-- `pagination`: enable/disable page buttons `Previous` and `Next` [**deprecated**, see note below].
-- `toc`: enable/disable page table of content [**deprecated**, see note below].
 
 | Setting                  | CLI flag         | Default |
 | ------------------------ | ---------------- | ------- |
 | `docOptions.frontMatter` | _not supported_  | `{}`    |
 | `docOptions.index`       | `--index`        | `false` |
-| `docOptions.pagination`  | `--noPagination` | `true`  |
-| `docOptions.toc`         | `--noToc`        | `true`  |
 
 <br/>
 
@@ -95,33 +91,6 @@ plugins: [
     ],
   ],
 ```
-
-<br/>
-
-:::warning[DEPRECATED]
-
-- **`docOptions.pagination`** (CLI flag `--noPagination`) has been replaced by `docOptions.frontMatter`:
-
-  ```js
-  docOptions: {
-   frontMatter: {
-     pagination_next: null, // disable page navigation next
-     pagination_prev: null, // disable page navigation previous
-   },
-  },
-  ```
-
-- **`docOptions.toc`** (CLI flag `--noToc`) has been replaced by `docOptions.frontMatter`:
-
-  ```js
-  docOptions: {
-   frontMatter: {
-     hide_table_of_contents: true, // disable page table of content
-   },
-  },
-  ```
-
-:::
 
 ## `force`
 
@@ -246,7 +215,6 @@ Use these options to toggle type information rendered on pages:
 - `parentTypePrefix`: prefix field names with the parent type name.
 - `relatedTypeSection`: display related type sections.
 - `typeBadges`: add field type attributes badges.
-- `useApiGroup`: split entities in `Operations` group (executable types) and `Types` group (system types) [**deprecated**, see note below].
 
 | Setting                               | CLI flag                | Default   |
 | ------------------------------------- | ----------------------- | --------- |
@@ -257,7 +225,6 @@ Use these options to toggle type information rendered on pages:
 | `printTypeOptions.parentTypePrefix`   | `--noParentType`        | `true`    |
 | `printTypeOptions.relatedTypeSection` | `--noRelatedType`       | `true`    |
 | `printTypeOptions.typeBadges`         | `--noTypeBadges`        | `true`    |
-| `printTypeOptions.useApiGroup`        | `--noApiGroup`          | `true`    |
 
 <br/>
 
@@ -337,17 +304,6 @@ plugins: [
 
 See **[customize deprecated sections](/docs/advanced/custom-deprecated-section)** to customize the rendering of `printTypeOptions.deprecated: "group"`.
 
-:::
-
-:::warning[DEPRECATED]
-
-**`printTypeOptions.useApiGroup`** (CLI flag `--noApiGroup`) has been replaced by `printTypeOptions.hierarchy`:
-
-```js
-printTypeOptions: {
-  hierarchy: "api", // use value "entity" for --noApiGroup equivalent
-},
-```
 :::
 
 ## `pretty`

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -26,8 +26,6 @@ import type {
 
 import { loadConfiguration } from "./graphql-config";
 
-import { log } from "@graphql-markdown/logger";
-
 export enum TypeHierarchy {
   API = "api",
   ENTITY = "entity",
@@ -231,60 +229,31 @@ export const getDiffMethod = (
 };
 
 export const parseDeprecatedDocOptions = (
-  cliOpts: Maybe<DeprecatedCliOptions>,
-  configOptions: Maybe<DeprecatedConfigDocOptions>,
-): Partial<{
-  pagination_next: null;
-  pagination_prev: null;
-  hide_table_of_contents: boolean;
-}> => {
-  // deprecated, replaced by frontMatter
-  let pagination: Maybe<{ pagination_next: null; pagination_prev: null }>;
-  if (
-    (typeof cliOpts?.noPagination !== "undefined" && cliOpts.noPagination) ||
-    (typeof configOptions?.pagination !== "undefined" &&
-      !configOptions.pagination)
-  ) {
-    pagination = { pagination_next: null, pagination_prev: null };
-    log(
-      "Doc option `pagination` is deprecated. Use `frontMatter: { pagination_next: null, pagination_prev: null }` instead.",
-      "warn",
-    );
-  }
-
-  // deprecated, replaced by frontMatter
-  let toc: Maybe<{ hide_table_of_contents: boolean }>;
-  if (
-    typeof cliOpts?.noToc !== "undefined" ||
-    typeof configOptions?.toc !== "undefined"
-  ) {
-    toc = {
-      hide_table_of_contents:
-        cliOpts?.noToc === true || configOptions?.toc === false,
-    };
-    log(
-      "Doc option `toc` is deprecated. Use `frontMatter: { hide_table_of_contents: true | false }` instead.",
-      "warn",
-    );
-  }
-
-  return { ...pagination, ...toc };
+  _cliOpts: Maybe<Omit<DeprecatedCliOptions, "never">>,
+  _configOptions: Maybe<Omit<DeprecatedConfigDocOptions, "never">>,
+): Record<string, never> => {
+  return {};
 };
 
 export const getDocOptions = (
-  cliOpts?: Maybe<CliOptions & DeprecatedCliOptions>,
-  configOptions?: Maybe<ConfigDocOptions & DeprecatedConfigDocOptions>,
+  cliOpts?: Maybe<CliOptions & Omit<DeprecatedCliOptions, "never">>,
+  configOptions?: Maybe<
+    ConfigDocOptions & Omit<DeprecatedConfigDocOptions, "never">
+  >,
 ): Required<ConfigDocOptions> => {
   const deprecated = parseDeprecatedDocOptions(cliOpts, configOptions);
+  const index =
+    typeof cliOpts?.index === "boolean"
+      ? cliOpts.index
+      : typeof configOptions?.index === "boolean"
+        ? configOptions.index
+        : DEFAULT_OPTIONS.docOptions!.index;
   return {
     frontMatter: {
       ...deprecated,
       ...configOptions?.frontMatter,
     },
-    index:
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      (cliOpts?.index || configOptions?.index) ??
-      DEFAULT_OPTIONS.docOptions!.index,
+    index,
   } as Required<ConfigDocOptions>;
 };
 
@@ -333,41 +302,16 @@ export const getTypeHierarchyOption = (
 };
 
 export const parseDeprecatedPrintTypeOptions = (
-  cliOpts: Maybe<DeprecatedCliOptions>,
-  configOptions: Maybe<DeprecatedConfigPrintTypeOptions>,
-): Partial<{ hierarchy: TypeHierarchyType }> => {
-  // deprecated, replaced by hierarchy
-  let option: Maybe<{ hierarchy: TypeHierarchyType }>;
-
-  if (typeof cliOpts?.noApiGroup !== "undefined" && cliOpts.noApiGroup) {
-    option = { hierarchy: TypeHierarchy.ENTITY };
-    log(
-      "Type option `noApiGroup` is deprecated. Use `hierarchy: 'entity'` instead.",
-      "warn",
-    );
-  } else if (typeof configOptions?.useApiGroup !== "undefined") {
-    if (typeof configOptions.useApiGroup === "object") {
-      option = {
-        hierarchy: { [TypeHierarchy.API]: { ...configOptions.useApiGroup } },
-      };
-    } else {
-      option = configOptions.useApiGroup
-        ? { hierarchy: TypeHierarchy.API }
-        : { hierarchy: TypeHierarchy.ENTITY };
-    }
-    log(
-      "Type option `useApiGroup` is deprecated. Use `hierarchy: 'api'` instead.",
-      "warn",
-    );
-  }
-
-  return { ...option };
+  _cliOpts: Maybe<Omit<DeprecatedCliOptions, "never">>,
+  _configOptions: Maybe<Omit<DeprecatedConfigPrintTypeOptions, "never">>,
+): Record<string, never> => {
+  return {};
 };
 
 export const getPrintTypeOptions = (
-  cliOpts: Maybe<CliOptions & DeprecatedCliOptions>,
+  cliOpts: Maybe<CliOptions & Omit<DeprecatedCliOptions, "never">>,
   configOptions: Maybe<
-    ConfigPrintTypeOptions & DeprecatedConfigPrintTypeOptions
+    ConfigPrintTypeOptions & Omit<DeprecatedConfigPrintTypeOptions, "never">
   >,
 ): Required<ConfigPrintTypeOptions> => {
   const deprecated = parseDeprecatedPrintTypeOptions(cliOpts, configOptions);

--- a/packages/core/tests/unit/config.test.ts
+++ b/packages/core/tests/unit/config.test.ts
@@ -667,7 +667,7 @@ describe("config", () => {
   });
 
   describe("parseDeprecatedPrintTypeOptions", () => {
-    test("returns empty object if no deprecated option is used", () => {
+    test("returns empty object if no deprecated option", () => {
       expect.hasAssertions();
 
       const cliOpt = {},
@@ -680,77 +680,10 @@ describe("config", () => {
       ).toStrictEqual({});
       expect(spyConsole).not.toHaveBeenCalled();
     });
-
-    test("returns hierarchy API if useApiGroup is set", () => {
-      expect.hasAssertions();
-
-      const spyConsole = jest
-        .spyOn(global.console, "warn")
-        .mockImplementation(() => {});
-
-      const cliOpt = {},
-        configOptions = { useApiGroup: true };
-
-      expect(
-        parseDeprecatedPrintTypeOptions(cliOpt, configOptions),
-      ).toStrictEqual({ hierarchy: TypeHierarchy.API });
-      expect(spyConsole).toHaveBeenCalledWith(
-        "Type option `useApiGroup` is deprecated. Use `hierarchy: 'api'` instead.",
-      );
-    });
-
-    test.each([
-      {
-        cliOpt: {},
-        configOptions: { useApiGroup: false },
-        warnMessage:
-          "Type option `useApiGroup` is deprecated. Use `hierarchy: 'api'` instead.",
-      },
-      {
-        cliOpt: { noApiGroup: true },
-        configOptions: {},
-        warnMessage:
-          "Type option `noApiGroup` is deprecated. Use `hierarchy: 'entity'` instead.",
-      },
-    ])(
-      "returns hierarchy ENTITY if --noApiGroup is set",
-      ({ cliOpt, configOptions, warnMessage }) => {
-        expect.hasAssertions();
-
-        const spyConsole = jest
-          .spyOn(global.console, "warn")
-          .mockImplementation(() => {});
-
-        expect(
-          parseDeprecatedPrintTypeOptions(cliOpt, configOptions),
-        ).toStrictEqual({ hierarchy: TypeHierarchy.ENTITY });
-        expect(spyConsole).toHaveBeenCalledWith(warnMessage);
-      },
-    );
-
-    test("returns hierarchy API object if useApiGroup is customized", () => {
-      expect.hasAssertions();
-
-      const cliOpt = {},
-        configOptions = { useApiGroup: { operations: "api" } };
-
-      const spyConsole = jest
-        .spyOn(global.console, "warn")
-        .mockImplementation(() => {});
-
-      expect(
-        parseDeprecatedPrintTypeOptions(cliOpt, configOptions),
-      ).toStrictEqual({
-        hierarchy: { [TypeHierarchy.API]: { operations: "api" } },
-      });
-      expect(spyConsole).toHaveBeenCalledWith(
-        "Type option `useApiGroup` is deprecated. Use `hierarchy: 'api'` instead.",
-      );
-    });
   });
 
   describe("parseDeprecatedDocOptions", () => {
-    test("returns empty object if no deprecated option is used", () => {
+    test("returns empty object if no deprecated option", () => {
       expect.hasAssertions();
 
       const cliOpt = {},
@@ -763,61 +696,6 @@ describe("config", () => {
       );
       expect(spyConsole).not.toHaveBeenCalled();
     });
-
-    test.each([
-      {
-        cliOpt: { noPagination: true },
-        configOptions: { frontMatter: undefined },
-      },
-      {
-        cliOpt: {},
-        configOptions: { pagination: false, frontMatter: undefined },
-      },
-    ])(
-      "returns pagination nulled if pagination option is disabled",
-      ({ cliOpt, configOptions }) => {
-        expect.assertions(2);
-
-        const spyConsole = jest
-          .spyOn(global.console, "warn")
-          .mockImplementation(() => {});
-
-        expect(parseDeprecatedDocOptions(cliOpt, configOptions)).toStrictEqual({
-          pagination_next: null,
-          pagination_prev: null,
-        });
-        expect(spyConsole).toHaveBeenCalledWith(
-          "Doc option `pagination` is deprecated. Use `frontMatter: { pagination_next: null, pagination_prev: null }` instead.",
-        );
-      },
-    );
-
-    test.each([
-      {
-        cliOpt: { noToc: true },
-        configOptions: { frontMatter: undefined },
-      },
-      {
-        cliOpt: {},
-        configOptions: { toc: false, frontMatter: undefined },
-      },
-    ])(
-      "returns hide_table_of_contents set to true if toc option is disabled",
-      ({ cliOpt, configOptions }) => {
-        expect.assertions(2);
-
-        const spyConsole = jest
-          .spyOn(global.console, "warn")
-          .mockImplementation(() => {});
-
-        expect(parseDeprecatedDocOptions(cliOpt, configOptions)).toStrictEqual({
-          hide_table_of_contents: true,
-        });
-        expect(spyConsole).toHaveBeenCalledWith(
-          "Doc option `toc` is deprecated. Use `frontMatter: { hide_table_of_contents: true | false }` instead.",
-        );
-      },
-    );
   });
 
   describe("getTypeHierarchyOption()", () => {

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -83,13 +83,6 @@ export default async function pluginGraphQLDocGenerator(
           "Option for printing deprecated entities: `default`, `group` or `skip`",
         )
         .option("--pretty", "Prettify generated files")
-        // DEPRECATED options
-        .option("--noToc", "Disable page table of content [DEPRECATED]")
-        .option(
-          "--noPagination",
-          "Disable page navigation buttons [DEPRECATED]",
-        )
-        .option("--noApiGroup", "Disable API grouping for types [DEPRECATED]")
         .action(async (cliOptions: CliOptions) => {
           const config = await buildConfig(options, cliOptions, options.id);
           await generateDocFromSchema({

--- a/packages/types/src/core.d.ts
+++ b/packages/types/src/core.d.ts
@@ -41,14 +41,13 @@ export type RendererDocOptions = ConfigDocOptions & {
 };
 
 export interface DeprecatedConfigDocOptions {
-  pagination?: boolean;
-  toc?: boolean;
+  never: never;
 }
 
 export type UseApiGroupOptionType = ApiGroupOverrideType | boolean;
 
 export interface DeprecatedConfigPrintTypeOptions {
-  useApiGroup?: UseApiGroupOptionType;
+  never: never;
 }
 
 export type TypeDeprecatedOption = "default" | "group" | "skip";
@@ -88,7 +87,9 @@ export interface ConfigOptions {
   baseURL?: Maybe<string>;
   customDirective?: Maybe<CustomDirective>;
   diffMethod?: Maybe<TypeDiffMethod>;
-  docOptions?: Maybe<ConfigDocOptions & DeprecatedConfigDocOptions>;
+  docOptions?: Maybe<
+    ConfigDocOptions & Omit<DeprecatedConfigDocOptions, "never">
+  >;
   force?: boolean;
   groupByDirective?: Maybe<GroupByDirectiveOptions>;
   homepage?: Maybe<string>;
@@ -134,9 +135,7 @@ export interface CliOptions {
 }
 
 export interface DeprecatedCliOptions {
-  noApiGroup?: boolean;
-  noPagination?: boolean;
-  noToc?: boolean;
+  never: never;
 }
 
 export type Options = Omit<


### PR DESCRIPTION
# Description

Remove support of deprecated settings:

- `docOptions.pagination` | `--noPagination`
- `docOptions.toc` | `--noToc`  
- `printTypeOptions.useApiGroup` | `--noApiGroup` 

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
