### PR TITLE
:bookmark: release 1.27.0

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -67,6 +67,7 @@ setup-cli-project:
   WORKDIR /$gqlmdCliProject
   DO +INSTALL_GRAPHQL
   DO +INSTALL_GQLMD
+  RUN npm install ./graphql-markdown-cli.tgz
   COPY --dir ./packages/cli/tests/__data__ ./data
 
 setup-docusaurus-project:
@@ -74,6 +75,7 @@ setup-docusaurus-project:
   WORKDIR /$docusaurusProject
   DO +INSTALL_GRAPHQL
   DO +INSTALL_GQLMD
+  RUN npm install ./graphql-markdown-docusaurus.tgz
   COPY --dir ./packages/docusaurus/tests/__data__ ./data
   COPY --dir ./website/static/img ./static/img
   COPY --dir ./website/src/css ./src/css
@@ -193,7 +195,9 @@ INSTALL_GQLMD:
   FUNCTION
   FOR package IN $(node /graphql-markdown/scripts/build-packages.js)
     COPY (+build-package/graphql-markdown-${package}.tgz --package=${package}) ./
-    RUN npm install ./graphql-markdown-${package}.tgz
+    IF [ "$package" != "cli" ] && [ "$package" != "docusaurus" ]
+      RUN npm install ./graphql-markdown-${package}.tgz
+    END
   END
 
 INSTALL_DOCUSAURUS:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14801,9 +14801,9 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.12.2",
+        "@graphql-markdown/core": "^1.13.0",
         "@graphql-markdown/logger": "^1.0.5",
-        "@graphql-markdown/printer-legacy": "^1.9.1",
+        "@graphql-markdown/printer-legacy": "^1.10.0",
         "commander": "^13.1.0",
         "graphql-config": "^5.1.3"
       },
@@ -14811,7 +14811,7 @@
         "gqlmd": "dist/main.js"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.4.2"
+        "@graphql-markdown/types": "^1.5.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -14819,7 +14819,7 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.12.2",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/graphql": "^1.1.5",
@@ -14827,7 +14827,7 @@
         "@graphql-markdown/utils": "^1.7.1"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.4.2"
+        "@graphql-markdown/types": "^1.5.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -14835,7 +14835,7 @@
       "peerDependencies": {
         "@graphql-markdown/diff": "^1.1.9",
         "@graphql-markdown/helpers": "^1.0.8",
-        "@graphql-markdown/printer-legacy": "^1.9.1",
+        "@graphql-markdown/printer-legacy": "^1.10.0",
         "graphql-config": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -14873,17 +14873,17 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.26.4",
+      "version": "1.27.0",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/utils": ">=3.2.0",
-        "@graphql-markdown/core": "^1.12.2",
+        "@graphql-markdown/core": "^1.13.0",
         "@graphql-markdown/logger": "^1.0.5",
-        "@graphql-markdown/printer-legacy": "^1.9.1"
+        "@graphql-markdown/printer-legacy": "^1.10.0"
       },
       "devDependencies": {
         "@docusaurus/types": "^3.5.0",
-        "@graphql-markdown/types": "^1.4.2"
+        "@graphql-markdown/types": "^1.5.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -14941,14 +14941,14 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.9.1",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/graphql": "^1.1.5",
         "@graphql-markdown/utils": "^1.7.1"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.4.2"
+        "@graphql-markdown/types": "^1.5.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -14956,7 +14956,7 @@
     },
     "packages/types": {
       "name": "@graphql-markdown/types",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "MIT",
       "devDependencies": {
         "@graphql-tools/load": "8.0.14",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,14 +53,14 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.12.2",
+    "@graphql-markdown/core": "^1.13.0",
     "@graphql-markdown/logger": "^1.0.5",
-    "@graphql-markdown/printer-legacy": "^1.9.1",
+    "@graphql-markdown/printer-legacy": "^1.10.0",
     "commander": "^13.1.0",
     "graphql-config": "^5.1.3"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.4.2"
+    "@graphql-markdown/types": "^1.5.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.12.2",
+  "version": "1.13.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -70,11 +70,11 @@
   "peerDependencies": {
     "@graphql-markdown/diff": "^1.1.9",
     "@graphql-markdown/helpers": "^1.0.8",
-    "@graphql-markdown/printer-legacy": "^1.9.1",
+    "@graphql-markdown/printer-legacy": "^1.10.0",
     "graphql-config": "^5.1.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.4.2"
+    "@graphql-markdown/types": "^1.5.0"
   },
   "peerDependenciesMeta": {
     "@graphql-markdown/printer-legacy": {

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.26.4",
+  "version": "1.27.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -52,13 +52,13 @@
   },
   "dependencies": {
     "@docusaurus/utils": ">=3.2.0",
-    "@graphql-markdown/core": "^1.12.2",
+    "@graphql-markdown/core": "^1.13.0",
     "@graphql-markdown/logger": "^1.0.5",
-    "@graphql-markdown/printer-legacy": "^1.9.1"
+    "@graphql-markdown/printer-legacy": "^1.10.0"
   },
   "devDependencies": {
     "@docusaurus/types": "^3.5.0",
-    "@graphql-markdown/types": "^1.4.2"
+    "@graphql-markdown/types": "^1.5.0"
   },
   "peerDependencies": {
     "@docusaurus/logger": "*"

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.9.1",
+  "version": "1.10.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -60,7 +60,7 @@
     "@graphql-markdown/utils": "^1.7.1"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.4.2"
+    "@graphql-markdown/types": "^1.5.0"
   },
   "resolutions": {
     "micromatch": "4.0.8"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-markdown/types",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Common types for @graphql-markdown packages",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

Release 1.27.0

🚀 This release introduces a **new NodeJS command line package** `@graphql-markdown/cli` allowing generating Markdown files without Docusaurus dependencies.
This is still an early release and it is not yet documented, but you can experiment with it and [give your feedback](https://github.com/graphql-markdown/graphql-markdown/issues) on this new package when used with other static site generators - note that you'll need MDX support.

1. Install `npm install @graphql-markdown/cli`
2. Usage `npx gqlmd graphql-to-doc`

ℹ️  The `cli` package works similarly to the Docusaurus plugin, but it relies on a [GraphQL config file](https://the-guild.dev/graphql/config/docs/user/usage) for the settings. You can find examples of settings in the [test folder of the package](https://github.com/graphql-markdown/graphql-markdown/tree/main/packages/cli/tests/__data__).

⚠️  **BREAKING CHANGES**
All previously deprecated settings have been removed:
- `docOptions.pagination` | `--noPagination` (deprecated in [release 1.22.0](https://github.com/graphql-markdown/graphql-markdown/releases/tag/1.22.0))
- `docOptions.toc` | `--noToc` (deprecated in [release 1.22.0](https://github.com/graphql-markdown/graphql-markdown/releases/tag/1.22.0))
- `printTypeOptions.useApiGroup` | `--noApiGroup` (deprecated in [release 1.26.0](https://github.com/graphql-markdown/graphql-markdown/releases/tag/1.26.0))

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
