### PR TITLE
:bug:  fix badge classname linked to docusaurus css

### DIFF
--- a/packages/docusaurus/src/mdx/index.ts
+++ b/packages/docusaurus/src/mdx/index.ts
@@ -10,11 +10,14 @@ import type {
 const MARKDOWN_EOL = "\n" as const;
 const MARKDOWN_EOP = `${MARKDOWN_EOL.repeat(2)}` as const;
 const LINK_MDX_EXTENSION = ".mdx" as const;
+const DEFAULT_CSS_CLASSNAME = "badge--secondary" as const;
 
 export { mdxDeclaration } from "./components";
 
 export const formatMDXBadge = ({ text, classname }: Badge): MDXString => {
-  return `<Badge class="badge ${classname}" text="${text as string}"/>` as MDXString;
+  const style =
+    typeof classname === "string" ? `badge--${classname.toLowerCase()}` : "";
+  return `<Badge class="badge ${DEFAULT_CSS_CLASSNAME} ${style}" text="${text as string}"/>` as MDXString;
 };
 
 export const formatMDXAdmonition = (

--- a/packages/docusaurus/tests/unit/mdx/index.test.ts
+++ b/packages/docusaurus/tests/unit/mdx/index.test.ts
@@ -12,7 +12,9 @@ describe("formatMDXBadge", () => {
   test("returns a formatted MDX badge string", () => {
     const badge = { text: "Test Badge", classname: "test-class" };
     const result = formatMDXBadge(badge);
-    expect(result).toBe('<Badge class="badge test-class" text="Test Badge"/>');
+    expect(result).toBe(
+      '<Badge class="badge badge--secondary badge--test-class" text="Test Badge"/>',
+    );
   });
 });
 

--- a/packages/printer-legacy/src/badge.ts
+++ b/packages/printer-legacy/src/badge.ts
@@ -20,7 +20,10 @@ import {
 import { getCategoryLocale } from "./link";
 import { getGroup } from "./group";
 
-export const DEFAULT_CSS_CLASSNAME = "badge--secondary" as const;
+export const CSS_BADGE_CLASSNAME = {
+  DEPRECATED: "DEPRECATED",
+  RELATION: "RELATION",
+};
 
 export const getTypeBadges = (
   type: unknown,
@@ -37,24 +40,23 @@ export const getTypeBadges = (
   if (isDeprecated(type)) {
     badges.push({
       text: "deprecated",
-      classname: "badge--deprecated badge--secondary",
+      classname: CSS_BADGE_CLASSNAME.DEPRECATED,
     } as Badge);
   }
 
   if (isNonNullType(rootType)) {
     badges.push({
       text: "non-null",
-      classname: DEFAULT_CSS_CLASSNAME,
     } as Badge);
   }
 
   if (isListType(rootType)) {
-    badges.push({ text: "list", classname: DEFAULT_CSS_CLASSNAME } as Badge);
+    badges.push({ text: "list" } as Badge);
   }
 
   const category = getCategoryLocale(getNamedType(rootType));
   if (category) {
-    badges.push({ text: category, classname: DEFAULT_CSS_CLASSNAME } as Badge);
+    badges.push({ text: category } as Badge);
   }
 
   if (groups) {
@@ -63,7 +65,7 @@ export const getTypeBadges = (
     ) as SchemaEntity;
     const group = getGroup(rootType, groups, typeCategory);
     if (group && group !== "") {
-      badges.push({ text: group, classname: DEFAULT_CSS_CLASSNAME } as Badge);
+      badges.push({ text: group } as Badge);
     }
   }
 

--- a/packages/printer-legacy/src/relation.ts
+++ b/packages/printer-legacy/src/relation.ts
@@ -18,7 +18,7 @@ import {
 } from "@graphql-markdown/graphql";
 
 import { getRelationLink } from "./link";
-import { DEFAULT_CSS_CLASSNAME, printBadge } from "./badge";
+import { CSS_BADGE_CLASSNAME, printBadge } from "./badge";
 import { MARKDOWN_EOP, ROOT_TYPE_LOCALE } from "./const/strings";
 import { SectionLevels } from "./const/options";
 
@@ -66,7 +66,7 @@ export const printRelationOf = <T>(
     const badge = printBadge(
       {
         text: category,
-        classname: DEFAULT_CSS_CLASSNAME,
+        classname: CSS_BADGE_CLASSNAME.RELATION,
       },
       options,
     );

--- a/packages/printer-legacy/tests/unit/badge.test.ts
+++ b/packages/printer-legacy/tests/unit/badge.test.ts
@@ -115,9 +115,7 @@ describe("badge", () => {
 
       const badges = Badge.getTypeBadges(type);
 
-      expect(badges).toStrictEqual([
-        { text: "non-null", classname: "badge--secondary" },
-      ]);
+      expect(badges).toStrictEqual([{ text: "non-null" }]);
     });
 
     test("return list badge is type is list", () => {
@@ -129,9 +127,7 @@ describe("badge", () => {
 
       const badges = Badge.getTypeBadges(type);
 
-      expect(badges).toStrictEqual([
-        { text: "list", classname: "badge--secondary" },
-      ]);
+      expect(badges).toStrictEqual([{ text: "list" }]);
     });
 
     test("return category name as badge is type is subtype", () => {
@@ -143,9 +139,7 @@ describe("badge", () => {
 
       const badges = Badge.getTypeBadges(type);
 
-      expect(badges).toStrictEqual([
-        { text: "foobar", classname: "badge--secondary" },
-      ]);
+      expect(badges).toStrictEqual([{ text: "foobar" }]);
     });
 
     test("return group name as badge is type has group", () => {
@@ -157,9 +151,7 @@ describe("badge", () => {
 
       const badges = Badge.getTypeBadges(type, { queries: {} });
 
-      expect(badges).toStrictEqual([
-        { text: "foobaz", classname: "badge--secondary" },
-      ]);
+      expect(badges).toStrictEqual([{ text: "foobaz" }]);
     });
   });
 });

--- a/packages/types/src/printer.d.ts
+++ b/packages/types/src/printer.d.ts
@@ -87,7 +87,7 @@ declare const SECTION_LEVEL_VALUE: unique symbol;
 
 export interface Badge {
   text: TypeLocale | string;
-  classname: string;
+  classname?: string[] | string;
 }
 
 export interface TypeLink {


### PR DESCRIPTION
# Description

Remove docusaurus css classname specific constants from default badge handling.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
