### PR TITLE
🐛 fix docusaurus category file not exposed

### DIFF
--- a/.knip.json
+++ b/.knip.json
@@ -39,7 +39,7 @@
   "rules": {
     "enumMembers": "warn"
   },
-  "ignoreDependencies": ["danger"],
+  "ignoreDependencies": ["danger", "commitizen", "diff", "lodash.filter"],
   "ignoreBinaries": ["danger"],
   "ignoreExportsUsedInFile": true,
   "jest": {

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -31,7 +31,11 @@ import { log, LogLevel } from "@graphql-markdown/logger";
 import { TypeHierarchy } from "./config";
 
 const DEPRECATED = "deprecated" as const;
-const CATEGORY_STYLE_CLASS = "graphql-markdown-api-section" as const;
+
+enum CATEGORY_STYLE_CLASS {
+  API = "graphql-markdown-api-section",
+  DEPRECATED = "graphql-markdown-deprecated-section",
+}
 
 enum SidebarPosition {
   FIRST = 1,
@@ -119,7 +123,7 @@ export class Renderer {
     },
   ): Promise<void> {
     if (this.mdxModuleIndexFileSupport) {
-      void (this.mdxModule as MDXSupportType).generateIndexMetafile(
+      await (this.mdxModule as MDXSupportType).generateIndexMetafile(
         dirPath,
         category,
         { ...options, index: this.options?.index },
@@ -148,7 +152,7 @@ export class Renderer {
       await this.generateIndexMetafile(dirPath, typeCat, {
         collapsible: false,
         collapsed: false,
-        styleClass: CATEGORY_STYLE_CLASS,
+        styleClass: CATEGORY_STYLE_CLASS.API,
       });
     }
 
@@ -156,7 +160,7 @@ export class Renderer {
       dirPath = join(dirPath, slugify(DEPRECATED));
       await this.generateIndexMetafile(dirPath, DEPRECATED, {
         sidebarPosition: SidebarPosition.LAST,
-        styleClass: DEPRECATED,
+        styleClass: CATEGORY_STYLE_CLASS.DEPRECATED,
       });
     }
 

--- a/packages/core/tests/unit/renderer.test.ts
+++ b/packages/core/tests/unit/renderer.test.ts
@@ -423,7 +423,7 @@ describe("renderer", () => {
 
         expect(spy).toHaveBeenCalledWith("/output/deprecated", "deprecated", {
           sidebarPosition: 999,
-          styleClass: "deprecated",
+          styleClass: "graphql-markdown-deprecated-section",
         });
         expect(spy).toHaveBeenCalledWith("/output/deprecated/baz", "Baz");
         expect(dirPath).toBe(`/output/deprecated/${root.toLowerCase()}`);

--- a/packages/docusaurus/src/mdx/category.ts
+++ b/packages/docusaurus/src/mdx/category.ts
@@ -1,19 +1,21 @@
+import { join } from "node:path";
+
 import {
   ensureDir,
   fileExists,
   saveFile,
   startCase,
 } from "@graphql-markdown/utils";
-import { join } from "node:path";
+import type { GenerateIndexMetafileType } from "@graphql-markdown/types";
 
-export const CATEGORY_YAML = "_category_.yml" as const;
+const CATEGORY_YAML = "_category_.yml" as const;
 
 enum SidebarPosition {
   FIRST = 1,
   LAST = 999,
 }
 
-export const generateIndexMetafile = async (
+export const generateIndexMetafile: GenerateIndexMetafileType = async (
   dirPath: string,
   category: string,
   options?: {

--- a/packages/docusaurus/src/mdx/index.ts
+++ b/packages/docusaurus/src/mdx/index.ts
@@ -1,6 +1,7 @@
 import type {
   AdmonitionType,
   Badge,
+  CollapsibleOption,
   Maybe,
   MDXString,
   MetaOptions,
@@ -40,10 +41,7 @@ export const formatMDXBullet = (text: string = ""): MDXString => {
 export const formatMDXDetails = ({
   dataOpen,
   dataClose,
-}: {
-  dataOpen: Maybe<string>;
-  dataClose: Maybe<string>;
-}): MDXString => {
+}: CollapsibleOption): MDXString => {
   return `${MARKDOWN_EOP}<Details dataOpen="Hide ${dataOpen}" dataClose="Show ${dataClose}">${MARKDOWN_EOP}\r${MARKDOWN_EOP}</Details>${MARKDOWN_EOP}` as MDXString;
 };
 

--- a/packages/docusaurus/src/mdx/index.ts
+++ b/packages/docusaurus/src/mdx/index.ts
@@ -13,6 +13,7 @@ const LINK_MDX_EXTENSION = ".mdx" as const;
 const DEFAULT_CSS_CLASSNAME = "badge--secondary" as const;
 
 export { mdxDeclaration } from "./components";
+export { generateIndexMetafile } from "./category";
 
 export const formatMDXBadge = ({ text, classname }: Badge): MDXString => {
   const style =

--- a/packages/docusaurus/tests/unit/mdx/index.test.ts
+++ b/packages/docusaurus/tests/unit/mdx/index.test.ts
@@ -50,7 +50,10 @@ describe("formatMDXBullet", () => {
 
 describe("formatMDXDetails", () => {
   test("returns a formatted MDX details string", () => {
-    const details = { dataOpen: "Open", dataClose: "Close" };
+    const details = {
+      dataOpen: "Open",
+      dataClose: "Close",
+    };
     const result = formatMDXDetails(details);
     expect(result).toBe(
       '\n\n<Details dataOpen="Hide Open" dataClose="Show Close">\n\n\r\n\n</Details>\n\n',

--- a/packages/printer-legacy/src/badge.ts
+++ b/packages/printer-legacy/src/badge.ts
@@ -19,10 +19,12 @@ import {
 
 import { getCategoryLocale } from "./link";
 import { getGroup } from "./group";
+import { DEPRECATED, NON_NULL } from "./const/strings";
 
 export const CSS_BADGE_CLASSNAME = {
   DEPRECATED: "DEPRECATED",
   RELATION: "RELATION",
+  NON_NULL: "NON_NULL",
 };
 
 export const getTypeBadges = (
@@ -39,14 +41,15 @@ export const getTypeBadges = (
 
   if (isDeprecated(type)) {
     badges.push({
-      text: "deprecated",
+      text: DEPRECATED,
       classname: CSS_BADGE_CLASSNAME.DEPRECATED,
     } as Badge);
   }
 
   if (isNonNullType(rootType)) {
     badges.push({
-      text: "non-null",
+      text: NON_NULL,
+      classname: CSS_BADGE_CLASSNAME.NON_NULL,
     } as Badge);
   }
 

--- a/packages/printer-legacy/src/const/strings.ts
+++ b/packages/printer-legacy/src/const/strings.ts
@@ -15,6 +15,7 @@ export const ROOT_TYPE_LOCALE: RootTypeLocale = {
 } as const;
 
 export const DEPRECATED = "deprecated" as const;
+export const NON_NULL = "non-null" as const;
 export const GRAPHQL = "graphql" as const;
 export const NO_DESCRIPTION_TEXT = "No description" as const;
 export const MARKDOWN_CODE_SNIPPET = "```" as const;

--- a/packages/printer-legacy/src/mdx/index.ts
+++ b/packages/printer-legacy/src/mdx/index.ts
@@ -1,6 +1,7 @@
 import type {
   AdmonitionType,
   Badge,
+  CollapsibleOption,
   FrontMatterOptions,
   Maybe,
   MDXString,
@@ -30,13 +31,8 @@ const formatMDXBullet = (text: string = ""): MDXString => {
   return `<span class="gqlmd-mdx-bullet">&nbsp;●&nbsp;</span>${text}` as MDXString;
 };
 
-const formatMDXDetails = ({
-  dataOpen,
-}: {
-  dataOpen: Maybe<string>;
-  dataClose: Maybe<string>;
-}): MDXString => {
-  return `${MARKDOWN_EOP}<details class="gqlmd-mdx-details">${MARKDOWN_EOL}<summary class="gqlmd-mdx-details-summary"><span className="gqlmd-mdx-details-summary-open">${dataOpen?.toUpperCase()}</span></summary>${MARKDOWN_EOP}\r${MARKDOWN_EOP}</details>${MARKDOWN_EOP}` as MDXString;
+const formatMDXDetails = ({ dataOpen }: CollapsibleOption): MDXString => {
+  return `${MARKDOWN_EOP}<details class="gqlmd-mdx-details">${MARKDOWN_EOL}<summary class="gqlmd-mdx-details-summary"><span className="gqlmd-mdx-details-summary-open">${dataOpen.toUpperCase()}</span></summary>${MARKDOWN_EOP}\r${MARKDOWN_EOP}</details>${MARKDOWN_EOP}` as MDXString;
 };
 
 const formatMDXSpecifiedByLink = (url: string): MDXString => {

--- a/packages/printer-legacy/tests/unit/badge.test.ts
+++ b/packages/printer-legacy/tests/unit/badge.test.ts
@@ -115,7 +115,9 @@ describe("badge", () => {
 
       const badges = Badge.getTypeBadges(type);
 
-      expect(badges).toStrictEqual([{ text: "non-null" }]);
+      expect(badges).toStrictEqual([
+        { classname: "NON_NULL", text: "non-null" },
+      ]);
     });
 
     test("return list badge is type is list", () => {

--- a/packages/types/src/core.d.ts
+++ b/packages/types/src/core.d.ts
@@ -9,12 +9,14 @@ import type { Maybe } from "./utils";
 
 export type FrontMatterOptions = Record<string, unknown> | false;
 
+export type GenerateIndexMetafileType = (
+  dirPath: string,
+  category: string,
+  options?: Record<string, unknown>,
+) => Promise<void> | void;
+
 export interface MDXSupportType {
-  generateIndexMetafile: (
-    dirPath: string,
-    category: string,
-    ...args: unknown[]
-  ) => Promise<void> | void;
+  generateIndexMetafile: GenerateIndexMetafileType;
   formatMDXAdmonition: (
     { text, title, type, icon }: AdmonitionType,
     meta: Maybe<MetaOptions>,

--- a/packages/types/src/core.d.ts
+++ b/packages/types/src/core.d.ts
@@ -15,6 +15,11 @@ export type GenerateIndexMetafileType = (
   options?: Record<string, unknown>,
 ) => Promise<void> | void;
 
+export interface CollapsibleOption {
+  dataOpen: string;
+  dataClose: string;
+}
+
 export interface MDXSupportType {
   generateIndexMetafile: GenerateIndexMetafileType;
   formatMDXAdmonition: (
@@ -23,13 +28,7 @@ export interface MDXSupportType {
   ) => MDXString;
   formatMDXBadge: ({ text, classname }: Badge) => MDXString;
   formatMDXBullet: (text?: string) => MDXString;
-  formatMDXDetails: ({
-    dataOpen,
-    dataClose,
-  }: {
-    dataOpen?: Maybe<string>;
-    dataClose?: Maybe<string>;
-  }) => MDXString;
+  formatMDXDetails: (option: CollapsibleOption) => MDXString;
   formatMDXLink: (link: TypeLink) => TypeLink;
   formatMDXNameEntity: (name: string, parentType?: Maybe<string>) => MDXString;
   formatMDXSpecifiedByLink: (url: string) => MDXString;

--- a/packages/types/src/printer.d.ts
+++ b/packages/types/src/printer.d.ts
@@ -1,4 +1,5 @@
 import type {
+  CollapsibleOption,
   ConfigPrintTypeOptions,
   FrontMatterOptions,
   MDXSupportType,
@@ -50,11 +51,6 @@ export interface PrinterConfigPrintTypeOptions {
   parentTypePrefix?: boolean;
   relatedTypeSection?: boolean;
   typeBadges?: boolean;
-}
-
-export interface CollapsibleOption {
-  dataOpen: string;
-  dataClose: string;
 }
 
 export type PrintTypeOptions = Partial<MDXSupportType> & {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -75,10 +75,11 @@ main code {
     no-repeat;
 }
 
-.deprecated {
+.deprecated, .graphql-markdown-deprecated-section {
   padding-top: 1rem;
 }
 
+.graphql-markdown-deprecated-section a::after,
 .deprecated a::after,
 span.deprecated::after {
   content: "⚠️";


### PR DESCRIPTION
# Description

fix missing export for generateIndexMetafile in docusaurus mdx](https://github.com/graphql-markdown/graphql-markdown/commit/27f50856fd9993faf41fbd0f6a4510ad17b61fe8)

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
