### PR TITLE
:construction_worker:  silent e2e tests webpack warnings

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -92,6 +92,7 @@ setup-docusaurus-project:
   RUN mv ./data/docusaurus2-graphql-doc-build.js ./docusaurus2-graphql-doc-build.js
   RUN mv ./data/docusaurus2-graphql-doc-nobuild.js ./docusaurus2-graphql-doc-nobuild.js
   RUN mv ./data/scripts/config-plugin.js ./config-plugin.js
+  RUN npm add ./data/e2e-test-webpack-plugin # Custom plugin for silencing webpack warnings [webpack.cache.PackFileCacheStrategy] 
   RUN node config-plugin.js
 
 smoke-docusaurus-test:
@@ -192,12 +193,11 @@ GQLMD:
   ARG id
   ARG options
   ARG command=docusaurus
-  ARG memory=2g
   RUN mkdir -p docs
   IF [ ! $id ]
-    RUN npx --memory=$memory $command graphql-to-doc $options 2>&1 | tee ./run.log
+    RUN npx $command graphql-to-doc $options 2>&1 | tee ./run.log
   ELSE
-    RUN npx --memory=$memory $command graphql-to-doc:${id} $options 2>&1 | tee ./run.log
+    RUN npx $command graphql-to-doc:${id} $options 2>&1 | tee ./run.log
   END
   RUN test `grep -c -i "An error occurred" run.log` -eq 0 && echo "Success" || (echo "Failed with errors"; exit 1) 
 

--- a/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-build.js
+++ b/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-build.js
@@ -38,6 +38,7 @@ module.exports = {
     ],
   ],
   plugins: [
+    "e2e-test-webpack-plugin",
     [
       "@graphql-markdown/docusaurus",
       // override .graphqlrc

--- a/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-nobuild.js
+++ b/packages/docusaurus/tests/__data__/docusaurus2-graphql-doc-nobuild.js
@@ -38,6 +38,7 @@ module.exports = {
     ],
   ],
   plugins: [
+    "e2e-test-webpack-plugin",
     [
       "@graphql-markdown/docusaurus",
       // override .graphqlrc

--- a/packages/docusaurus/tests/__data__/e2e-test-webpack-plugin/index.js
+++ b/packages/docusaurus/tests/__data__/e2e-test-webpack-plugin/index.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-unused-vars */
+module.exports = function (_context, _options) {
+  return {
+    name: "e2e-test-webpack-plugin",
+    configureWebpack(_config, _isServer) {
+      return {
+        plugins: [
+          {
+            apply: (_compiler) => {
+              const originalStderrWrite = process.stderr.write;
+              process.stderr.write = function (chunk, ...args) {
+                if (
+                  typeof chunk === "string" &&
+                  chunk.includes("webpack.cache.PackFileCacheStrategy")
+                ) {
+                  return true; // Suppress this message
+                }
+                return originalStderrWrite.apply(this, [chunk, ...args]);
+              };
+            },
+          },
+        ],
+      };
+    },
+  };
+};

--- a/packages/docusaurus/tests/__data__/e2e-test-webpack-plugin/package.json
+++ b/packages/docusaurus/tests/__data__/e2e-test-webpack-plugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "e2e-test-webpack-plugin",
+  "version": "1.0.0",
+  "main": "index.js",
+  "private": true
+}


### PR DESCRIPTION
# Description

Add custom webpack config/plugin for Docusaurus to silent webpack warnings breaking e2e tests.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
