### PR TITLE
:bug:  fix mdx compilation error when underscore used with entity name

### DIFF
--- a/packages/docusaurus/src/mdx/index.ts
+++ b/packages/docusaurus/src/mdx/index.ts
@@ -16,6 +16,7 @@ import type {
   MetaOptions,
   TypeLink,
 } from "@graphql-markdown/types";
+import { escapeMDX } from "@graphql-markdown/utils";
 
 const MARKDOWN_EOL = "\n" as const;
 const MARKDOWN_EOP = `${MARKDOWN_EOL.repeat(2)}` as const;
@@ -90,7 +91,7 @@ export const formatMDXNameEntity = (
   parentType?: Maybe<string>,
 ): MDXString => {
   const parentName = parentType ? `${parentType}.` : "";
-  return `<code style={{ fontWeight: 'normal' }}>${parentName}<b>${name}</b></code>` as MDXString;
+  return `<code style={{ fontWeight: 'normal' }}>${escapeMDX(parentName)}<b>${escapeMDX(name)}</b></code>` as MDXString;
 };
 
 export const formatMDXLink = ({ text, url }: TypeLink): TypeLink => {

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -176,7 +176,7 @@ export const toHTMLUnicode = (char: Maybe<string>): string => {
  */
 export const escapeMDX = (str: unknown): string => {
   return `${String(str)}`.replace(
-    /(?<!`)([{<>}])(?=(?:[^`]*`[^`]*`)*[^`]*$)/g,
+    /(?<!`)([{<_*>}])(?=(?:[^`]*`[^`]*`)*[^`]*$)/g,
     toHTMLUnicode,
   );
 };

--- a/packages/utils/tests/unit/string.test.ts
+++ b/packages/utils/tests/unit/string.test.ts
@@ -133,16 +133,18 @@ describe("string", () => {
     test("returns string with HTML &#x0000; format for MDX special characters", () => {
       expect.hasAssertions();
 
-      expect(escapeMDX("{MDX} <special> characters")).toBe(
-        "&#x007B;MDX&#x007D; &#x003C;special&#x003E; characters",
+      expect(
+        escapeMDX("{MDX} <special> characters and formatting _test_"),
+      ).toBe(
+        "&#x007B;MDX&#x007D; &#x003C;special&#x003E; characters and formatting &#x005F;test&#x005F;",
       );
     });
 
     test("does not transform MDX special characters enclosed as code", () => {
       expect.hasAssertions();
 
-      expect(escapeMDX(">`{MDX}` `<special>` characters")).toBe(
-        "&#x003E;`{MDX}` `<special>` characters",
+      expect(escapeMDX(">`{MDX}` `<special>` characters `_test_`")).toBe(
+        "&#x003E;`{MDX}` `<special>` characters `_test_`",
       );
     });
 


### PR DESCRIPTION
# Description

Add missing support for escaping special MDX characters when rendering links.

This should fix #2214 

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
