### PR TITLE
:construction_worker:  remove unused postCreateCommand from devContainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -56,5 +56,5 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "/bin/sh -c ./.devcontainer/postCreateCommand.sh",
+  // "postCreateCommand": "/bin/sh -c ./.devcontainer/postCreateCommand.sh",
 }


### PR DESCRIPTION
# Description

remove unused postCreateCommand from devContainer

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
