### PR TITLE
:wrench:  update jest config related to deprecation of isolatedModules

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -11,7 +11,6 @@ const projectConfig = (name) => ({
       "ts-jest",
       {
         tsconfig: "<rootDir>/tsconfig.test.json",
-        isolatedModules: true,
       },
     ],
   },

--- a/packages/cli/tsconfig.test.json
+++ b/packages/cli/tsconfig.test.json
@@ -6,6 +6,8 @@
 
     "noEmit": true,
 
+    "isolatedModules": true,
+
     "types": ["node", "@types/jest"],
 
     "paths": {

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -6,6 +6,8 @@
 
     "noEmit": true,
 
+    "isolatedModules": true,
+
     "types": ["node", "@types/jest"],
 
     "paths": {

--- a/packages/diff/tsconfig.test.json
+++ b/packages/diff/tsconfig.test.json
@@ -6,6 +6,8 @@
 
     "noEmit": true,
 
+    "isolatedModules": true,
+
     "types": ["node", "@types/jest"],
 
     "paths": {

--- a/packages/docusaurus/tsconfig.test.json
+++ b/packages/docusaurus/tsconfig.test.json
@@ -6,6 +6,8 @@
 
     "noEmit": true,
 
+    "isolatedModules": true,
+
     "types": ["node", "@types/jest"],
 
     "paths": {

--- a/packages/graphql/tsconfig.test.json
+++ b/packages/graphql/tsconfig.test.json
@@ -6,6 +6,8 @@
 
     "noEmit": true,
 
+    "isolatedModules": true,
+
     "types": ["node", "@types/jest"],
 
     "paths": {

--- a/packages/helpers/tsconfig.test.json
+++ b/packages/helpers/tsconfig.test.json
@@ -6,6 +6,8 @@
 
     "noEmit": true,
 
+    "isolatedModules": true,
+
     "types": ["node", "@types/jest"],
 
     "paths": {

--- a/packages/logger/tsconfig.test.json
+++ b/packages/logger/tsconfig.test.json
@@ -6,6 +6,8 @@
 
     "noEmit": true,
 
+    "isolatedModules": true,
+
     "types": ["node", "@types/jest"],
 
     "paths": {

--- a/packages/printer-legacy/tsconfig.test.json
+++ b/packages/printer-legacy/tsconfig.test.json
@@ -6,6 +6,8 @@
 
     "noEmit": true,
 
+    "isolatedModules": true,
+
     "types": ["node", "@types/jest"],
 
     "paths": {

--- a/packages/utils/tsconfig.test.json
+++ b/packages/utils/tsconfig.test.json
@@ -6,6 +6,8 @@
 
     "noEmit": true,
 
+    "isolatedModules": true,
+
     "types": ["node", "@types/jest"],
 
     "paths": {


### PR DESCRIPTION
# Description

Jest `ts-jest` config `isolatedModules` is deprecated in favor of  `isolatedModules` in tsconfig.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
