### PR TITLE
🗒️  remove page id reference from homepage.md

### DIFF
--- a/docs/advanced/homepage.md
+++ b/docs/advanced/homepage.md
@@ -5,9 +5,9 @@ pagination_next: null
 
 # Homepage
 
-If you decide to use your homepage for the GraphQL-generated documentation, then set the page ID to `id: schema` and the sidebar position to `sidebar_position: 1`:
+If you decide to use a custom homepage for the GraphQL-generated documentation, then set the sidebar position to `sidebar_position: 1` to ensure it shows first:
 
-```markdown {2,5} title="schema.md"
+```markdown title="schema.md"
 ---
 id: schema
 slug: /schema


### PR DESCRIPTION
# Description

`id :schema` had been deprecated, there's no reason to have set with a specific value for the homepage.

Closes #2229

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
