### PR TITLE
:sparkles:  add support for disabling homepage

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -134,6 +134,12 @@ The plugin provides a default page in `assets/generated`.
 | ---------- | --------------------------- | -------------- |
 | `homepage` | `-h, --homepage <homepage>` | `generated.md` |
 
+:::tip
+
+Set `homepage: false` to disable the homepage generation.
+
+:::
+
 <br/>
 
 :::info

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -703,6 +703,25 @@ export const parseGroupByOption = (
   return { directive, field, fallback } as GroupByDirectiveOptions;
 };
 
+export const parseHomepageOption = (
+  cliHomepage: Maybe<string>,
+  configHomepage: Maybe<string | false>,
+): Maybe<string> => {
+  if (typeof cliHomepage === "string") {
+    return cliHomepage;
+  }
+
+  if (configHomepage === false) {
+    return undefined;
+  }
+
+  if (typeof configHomepage === "string") {
+    return configHomepage;
+  }
+
+  return DEFAULT_OPTIONS.homepage;
+};
+
 /**
  * Builds the complete configuration object by merging options from multiple sources
  * in order of precedence:
@@ -770,8 +789,7 @@ export const buildConfig = async (
     force,
     groupByDirective:
       parseGroupByOption(cliOpts.groupByDirective) ?? config.groupByDirective,
-    homepageLocation:
-      cliOpts.homepage ?? config.homepage ?? DEFAULT_OPTIONS.homepage,
+    homepageLocation: parseHomepageOption(cliOpts.homepage, config.homepage),
     id: id ?? DEFAULT_OPTIONS.id,
     linkRoot: cliOpts.link ?? config.linkRoot ?? DEFAULT_OPTIONS.linkRoot,
     loaders: config.loaders,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -704,7 +704,7 @@ export const parseGroupByOption = (
 };
 
 export const parseHomepageOption = (
-  cliHomepage: Maybe<string>,
+  cliHomepage: Maybe<string | false>,
   configHomepage: Maybe<string | false>,
 ): Maybe<string> => {
   if (typeof cliHomepage === "string") {
@@ -719,7 +719,7 @@ export const parseHomepageOption = (
     return configHomepage;
   }
 
-  return DEFAULT_OPTIONS.homepage;
+  return DEFAULT_OPTIONS.homepage as string;
 };
 
 /**

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -491,9 +491,8 @@ export class Renderer {
    * @useDeclaredType
    * @example
    */
-  async renderHomepage(homepageLocation: string): Promise<void> {
+  async renderHomepage(homepageLocation: Maybe<string>): Promise<void> {
     if (typeof homepageLocation !== "string") {
-      log("Homepage location is not a valid string", LogLevel.warn);
       return;
     }
 

--- a/packages/core/tests/unit/config.test.ts
+++ b/packages/core/tests/unit/config.test.ts
@@ -30,6 +30,7 @@ import {
   parseDeprecatedDocOptions,
   parseDeprecatedPrintTypeOptions,
   parseGroupByOption,
+  parseHomepageOption,
   TypeHierarchy,
 } from "../../src/config";
 
@@ -948,6 +949,42 @@ describe("config", () => {
       // Test with undefined/null values
       expect(getTypeHierarchyOption(cliOption, configOption)).toStrictEqual(
         DEFAULT_HIERARCHY,
+      );
+    });
+  });
+
+  describe("parseHomepageOption", () => {
+    test("returns default homepage no option passed", () => {
+      expect.hasAssertions();
+
+      expect(parseHomepageOption(undefined, undefined)).toStrictEqual(
+        DEFAULT_OPTIONS.homepage,
+      );
+    });
+
+    test("returns cli homepage if set", () => {
+      expect.hasAssertions();
+
+      expect(parseHomepageOption("homepage.md", undefined)).toBe("homepage.md");
+    });
+
+    test("returns config homepage if set", () => {
+      expect.hasAssertions();
+
+      expect(parseHomepageOption(undefined, "config.md")).toBe("config.md");
+    });
+
+    test("returns undefined if config homepage is false", () => {
+      expect.hasAssertions();
+
+      expect(parseHomepageOption(undefined, false)).toBeUndefined();
+    });
+
+    test("returns cli homepage override config homepage", () => {
+      expect.hasAssertions();
+
+      expect(parseHomepageOption("homepage.md", "config.md")).toBe(
+        "homepage.md",
       );
     });
   });

--- a/packages/core/tests/unit/renderer.test.ts
+++ b/packages/core/tests/unit/renderer.test.ts
@@ -505,17 +505,15 @@ describe("renderer", () => {
         ).rejects.toThrow("Output directory is empty or not specified");
       });
 
-      test("logs warning when homepage location is not a valid string", async () => {
+      test("do not generated homepage if undefined", async () => {
         expect.assertions(1);
 
-        // Pass undefined as the homepage location
-        const consoleSpy = jest.spyOn(global.console, "warn");
-        // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-        await rendererInstance.renderHomepage(undefined as unknown as string);
+        const spy = jest.spyOn(Utils, "copyFile");
 
-        expect(consoleSpy).toHaveBeenCalledWith(
-          "Homepage location is not a valid string",
-        );
+        // Pass undefined as the homepage location
+        await rendererInstance.renderHomepage(undefined);
+
+        expect(spy).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/types/src/core.d.ts
+++ b/packages/types/src/core.d.ts
@@ -208,7 +208,7 @@ export interface ConfigOptions {
   /** Directives used to group schema types */
   groupByDirective?: Maybe<GroupByDirectiveOptions>;
   /** Location of the homepage content */
-  homepage?: Maybe<string>;
+  homepage?: Maybe<string | false>;
   /** Identifier for the project */
   id?: Maybe<string>;
   /** Root path for generating links */
@@ -285,7 +285,7 @@ export interface CliOptions {
   /** Directive for grouping */
   groupByDirective?: string;
   /** Homepage location */
-  homepage?: string;
+  homepage?: string | false;
   /** Generate index files flag */
   index?: boolean;
   /** Root for documentation links */
@@ -348,7 +348,7 @@ export type Options = Omit<
       /** Base URL for documentation */
       baseURL: string;
       /** Homepage file location */
-      homepageLocation: string;
+      homepageLocation: Maybe<string>;
       /** Root for documentation links */
       linkRoot: string;
       /** Directives to only document */


### PR DESCRIPTION
# Description

Add support for disabling homepage generation (#2233 and #2234).

`homepage: false` will now prevent the generation of the homepage.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
