### PR TITLE
:bug:  fix prettier support for mdx with config

### DIFF
--- a/packages/utils/src/prettier.ts
+++ b/packages/utils/src/prettier.ts
@@ -37,7 +37,7 @@ export const prettify = async (
       options = (await resolveConfig(file)) ?? {};
     }
 
-    return await format(content, { parser, ...options });
+    return await format(content, { ...options, parser });
   } catch {
     const message = `Prettier is not found or not configured. Please install it or disable the "pretty" option.`;
     if ("logger" in global && global.logger) {

--- a/packages/utils/src/prettier.ts
+++ b/packages/utils/src/prettier.ts
@@ -27,13 +27,23 @@ export const prettify = async (
   parser: string,
 ): Promise<string | undefined> => {
   try {
-    const { format } = await import("prettier");
-    return await format(content, { parser });
+    const { resolveConfigFile, resolveConfig, format } = await import(
+      "prettier"
+    );
+    const file = await resolveConfigFile();
+
+    let options: Record<string, unknown> = {};
+    if (file) {
+      options = (await resolveConfig(file)) ?? {};
+    }
+
+    return await format(content, { parser, ...options });
   } catch {
+    const message = `Prettier is not found or not configured. Please install it or disable the "pretty" option.`;
     if ("logger" in global && global.logger) {
-      (global.logger as LoggerType)._log("Prettier is not found");
+      (global.logger as LoggerType)._log(message);
     } else {
-      global.console.log("Prettier is not found");
+      global.console.log(message);
     }
     return undefined;
   }
@@ -57,5 +67,5 @@ export const prettify = async (
 export const prettifyMarkdown = async (
   content: string,
 ): Promise<string | undefined> => {
-  return prettify(content, "markdown");
+  return prettify(content, "mdx");
 };


### PR DESCRIPTION
# Description

User `mdx` parser instead of `markdown` when calling prettier, and add support for local config file.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
