### PR TITLE
:bookmark:  release 1.30.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -944,37 +944,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
-      "integrity": "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.0.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
-      "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz",
-      "integrity": "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
       "dev": true,
@@ -2618,18 +2587,6 @@
         "resolve": "~1.22.2"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
-      "integrity": "sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.9.0"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "license": "MIT",
@@ -2906,165 +2863,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-darwin-x64": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.2.0.tgz",
-      "integrity": "sha512-0zhgNUm5bYezdSFOg3FYhtVP83bAq7FTV/3suGQDl/43MixfQG7+bl+hlrP4mz6WlD2SUb2u9BomnJWl1uey9w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-freebsd-x64": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.2.0.tgz",
-      "integrity": "sha512-SHOxfCcZV1axeIGfyeD1BkdLvfQgjmPy18tO0OUXGElcdScxD6MqU5rj/AVtiuBT+51GtFfOKlwl1+BdVwhD1A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.2.0.tgz",
-      "integrity": "sha512-mgEkYrJ+N90sgEDqEZ07zH+4I1D28WjqAhdzfW3aS2x2vynVpoY9jWfHuH8S62vZt3uATJrTKTRa8CjPWEsrdw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.2.0.tgz",
-      "integrity": "sha512-BhEzNLjn4HjP8+Q18D3/jeIDBxW7OgoJYIjw2CaaysnYneoTlij8hPTKxHfyqq4IGM3fFs9TLR/k338M3zkQ7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.2.0.tgz",
-      "integrity": "sha512-yxbMYUgRmN2V8x8XoxmD/Qq6aG7YIW3ToMDILfmcfeeRRVieEJ3DOWBT0JSE+YgrOy79OyFDH/1lO8VnqLmDQQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.2.0.tgz",
-      "integrity": "sha512-QG1UfgC2N2qhW1tOnDCgB/26vn1RCshR5sYPhMeaxO1gMQ3kEKbZ3QyBXxrG1IX5qsXYj5hPDJLDYNYUjRcOpg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.2.0.tgz",
-      "integrity": "sha512-uqTDsQdi6mrkSV1gvwbuT8jf/WFl6qVDVjNlx7IPSaAByrNiJfPrhTmH8b+Do58Dylz7QIRZgxQ8CHIZSyBUdg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.2.0.tgz",
-      "integrity": "sha512-GZdHXhJ7p6GaQg9MjRqLebwBf8BLvGIagccI6z5yMj4fV3LU4QuDfwSEERG+R6oQ/Su9672MBqWwncvKcKT68w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.2.0.tgz",
-      "integrity": "sha512-YBAC3GOicYznReG2twE7oFPSeK9Z1f507z1EYWKg6HpGYRYRlJyszViu7PrhMT85r/MumDTs429zm+CNqpFWOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.2.0.tgz",
-      "integrity": "sha512-+qlIg45CPVPy+Jn3vqU1zkxA/AAv6e/2Ax/ImX8usZa8Tr2JmQn/93bmSOOOnr9fXRV9d0n4JyqYzSWxWPYDEw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.11"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.2.0.tgz",
-      "integrity": "sha512-AI4KIpS8Zf6vwfOPk0uQPSC0pQ1m5HU4hCbtrgL21JgJSlnJaeEu3/aoOBB45AXKiExBU9R+CDR7aSnW7uhc5A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.2.0.tgz",
-      "integrity": "sha512-r19cQc7HaEJ76HFsMsbiKMTIV2YqFGSof8H5hB7e5Jkb/23Y8Isv1YrSzkDaGhcw02I/COsrPo+eEmjy35eFuA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@pkgjs/parseargs": {
@@ -3377,16 +3175,6 @@
       "version": "1.0.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@tybys/wasm-util": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
-      "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
@@ -15310,12 +15098,12 @@
     },
     "packages/cli": {
       "name": "@graphql-markdown/cli",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.15.1",
+        "@graphql-markdown/core": "^1.16.0",
         "@graphql-markdown/logger": "^1.0.5",
-        "@graphql-markdown/printer-legacy": "^1.12.1",
+        "@graphql-markdown/printer-legacy": "^1.12.2",
         "commander": "^5.1.0",
         "graphql-config": "^5.1.3"
       },
@@ -15323,7 +15111,7 @@
         "gqlmd": "dist/main.js"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.7.0"
+        "@graphql-markdown/types": "^1.8.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15338,23 +15126,23 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.15.1",
+      "version": "1.16.0",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/graphql": "^1.1.7",
+        "@graphql-markdown/graphql": "^1.1.8",
         "@graphql-markdown/logger": "^1.0.5",
-        "@graphql-markdown/utils": "^1.8.1"
+        "@graphql-markdown/utils": "^1.9.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.7.0"
+        "@graphql-markdown/types": "^1.8.0"
       },
       "engines": {
         "node": ">=16.14"
       },
       "peerDependencies": {
-        "@graphql-markdown/diff": "^1.1.11",
-        "@graphql-markdown/helpers": "^1.0.10",
-        "@graphql-markdown/printer-legacy": "^1.12.1",
+        "@graphql-markdown/diff": "^1.1.12",
+        "@graphql-markdown/helpers": "^1.0.11",
+        "@graphql-markdown/printer-legacy": "^1.12.2",
         "graphql-config": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -15374,17 +15162,17 @@
     },
     "packages/diff": {
       "name": "@graphql-markdown/diff",
-      "version": "1.1.11",
+      "version": "1.1.12",
       "license": "MIT",
       "dependencies": {
         "@graphql-inspector/core": "^6.1.0",
-        "@graphql-markdown/graphql": "^1.1.7",
-        "@graphql-markdown/utils": "^1.8.1",
+        "@graphql-markdown/graphql": "^1.1.8",
+        "@graphql-markdown/utils": "^1.9.0",
         "@graphql-tools/graphql-file-loader": "^8.0.1",
         "@graphql-tools/load": "^8.0.2"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.7.0"
+        "@graphql-markdown/types": "^1.8.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15392,17 +15180,17 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.29.1",
+      "version": "1.30.0",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/utils": ">=3.2.0",
-        "@graphql-markdown/cli": "^0.3.1",
+        "@graphql-markdown/cli": "^0.4.0",
         "@graphql-markdown/logger": "^1.0.5",
-        "@graphql-markdown/utils": "^1.8.1"
+        "@graphql-markdown/utils": "^1.9.0"
       },
       "devDependencies": {
         "@docusaurus/types": "^3.7.0",
-        "@graphql-markdown/types": "^1.7.0"
+        "@graphql-markdown/types": "^1.8.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15413,14 +15201,14 @@
     },
     "packages/graphql": {
       "name": "@graphql-markdown/graphql",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/utils": "^1.8.1",
+        "@graphql-markdown/utils": "^1.9.0",
         "@graphql-tools/load": "^8.1.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.7.0"
+        "@graphql-markdown/types": "^1.8.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15431,14 +15219,14 @@
     },
     "packages/helpers": {
       "name": "@graphql-markdown/helpers",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/graphql": "^1.1.7",
-        "@graphql-markdown/utils": "^1.8.1"
+        "@graphql-markdown/graphql": "^1.1.8",
+        "@graphql-markdown/utils": "^1.9.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.7.0"
+        "@graphql-markdown/types": "^1.8.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15452,7 +15240,7 @@
       "version": "1.0.5",
       "license": "MIT",
       "devDependencies": {
-        "@graphql-markdown/types": "^1.4.0"
+        "@graphql-markdown/types": "^1.8.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15460,14 +15248,14 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/graphql": "^1.1.7",
-        "@graphql-markdown/utils": "^1.8.1"
+        "@graphql-markdown/graphql": "^1.1.8",
+        "@graphql-markdown/utils": "^1.9.0"
       },
       "devDependencies": {
-        "@graphql-markdown/types": "^1.7.0"
+        "@graphql-markdown/types": "^1.8.0"
       },
       "engines": {
         "node": ">=16.14"
@@ -15475,7 +15263,7 @@
     },
     "packages/types": {
       "name": "@graphql-markdown/types",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "devDependencies": {
         "@graphql-tools/load": "8.1.0",
@@ -15486,10 +15274,10 @@
     },
     "packages/utils": {
       "name": "@graphql-markdown/utils",
-      "version": "1.8.1",
+      "version": "1.9.0",
       "license": "MIT",
       "devDependencies": {
-        "@graphql-markdown/types": "^1.7.0"
+        "@graphql-markdown/types": "^1.8.0"
       },
       "engines": {
         "node": ">=16.14"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "0.3.1",
+  "version": "0.4.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -53,14 +53,14 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.15.1",
+    "@graphql-markdown/core": "^1.16.0",
     "@graphql-markdown/logger": "^1.0.5",
-    "@graphql-markdown/printer-legacy": "^1.12.1",
+    "@graphql-markdown/printer-legacy": "^1.12.2",
     "commander": "^5.1.0",
     "graphql-config": "^5.1.3"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.7.0"
+    "@graphql-markdown/types": "^1.8.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.15.1",
+  "version": "1.16.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -64,18 +64,18 @@
     "suggest:tests": "ts-node ../../scripts/test-suggestions.ts"
   },
   "dependencies": {
-    "@graphql-markdown/graphql": "^1.1.7",
+    "@graphql-markdown/graphql": "^1.1.8",
     "@graphql-markdown/logger": "^1.0.5",
-    "@graphql-markdown/utils": "^1.8.1"
+    "@graphql-markdown/utils": "^1.9.0"
   },
   "peerDependencies": {
-    "@graphql-markdown/diff": "^1.1.11",
-    "@graphql-markdown/helpers": "^1.0.10",
-    "@graphql-markdown/printer-legacy": "^1.12.1",
+    "@graphql-markdown/diff": "^1.1.12",
+    "@graphql-markdown/helpers": "^1.0.11",
+    "@graphql-markdown/printer-legacy": "^1.12.2",
     "graphql-config": "^5.1.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.7.0"
+    "@graphql-markdown/types": "^1.8.0"
   },
   "peerDependenciesMeta": {
     "@graphql-markdown/printer-legacy": {

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.11",
+  "version": "1.1.12",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -57,13 +57,13 @@
   },
   "dependencies": {
     "@graphql-inspector/core": "^6.1.0",
-    "@graphql-markdown/graphql": "^1.1.7",
-    "@graphql-markdown/utils": "^1.8.1",
+    "@graphql-markdown/graphql": "^1.1.8",
+    "@graphql-markdown/utils": "^1.9.0",
     "@graphql-tools/graphql-file-loader": "^8.0.1",
     "@graphql-tools/load": "^8.0.2"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.7.0"
+    "@graphql-markdown/types": "^1.8.0"
   },
   "resolutions": {
     "braces": "3.0.3"

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.29.1",
+  "version": "1.30.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -65,14 +65,14 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/cli": "^0.3.1",
+    "@graphql-markdown/cli": "^0.4.0",
     "@graphql-markdown/logger": "^1.0.5",
-    "@graphql-markdown/utils": "^1.8.1",
+    "@graphql-markdown/utils": "^1.9.0",
     "@docusaurus/utils": ">=3.2.0"
   },
   "devDependencies": {
     "@docusaurus/types": "^3.7.0",
-    "@graphql-markdown/types": "^1.7.0"
+    "@graphql-markdown/types": "^1.8.0"
   },
   "peerDependencies": {
     "@docusaurus/logger": "*"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.7",
+  "version": "1.1.8",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -57,13 +57,13 @@
   },
   "dependencies": {
     "@graphql-tools/load": "^8.1.0",
-    "@graphql-markdown/utils": "^1.8.1"
+    "@graphql-markdown/utils": "^1.9.0"
   },
   "peerDependencies": {
     "graphql": "^16.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.7.0"
+    "@graphql-markdown/types": "^1.8.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.10",
+  "version": "1.0.11",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,14 +56,14 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/graphql": "^1.1.7",
-    "@graphql-markdown/utils": "^1.8.1"
+    "@graphql-markdown/graphql": "^1.1.8",
+    "@graphql-markdown/utils": "^1.9.0"
   },
   "peerDependencies": {
     "graphql": "^16.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.7.0"
+    "@graphql-markdown/types": "^1.8.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -42,7 +42,7 @@
     "docs": "typedoc"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.4.0"
+    "@graphql-markdown/types": "^1.8.0"
   },
   "directories": {
     "test": "tests"

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.12.1",
+  "version": "1.12.2",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,11 +56,11 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/graphql": "^1.1.7",
-    "@graphql-markdown/utils": "^1.8.1"
+    "@graphql-markdown/graphql": "^1.1.8",
+    "@graphql-markdown/utils": "^1.9.0"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.7.0"
+    "@graphql-markdown/types": "^1.8.0"
   },
   "resolutions": {
     "micromatch": "4.0.8"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-markdown/types",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Common types for @graphql-markdown packages",
   "repository": {
     "type": "git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.8.1",
+  "version": "1.9.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,7 +56,7 @@
     "docs": "typedoc"
   },
   "devDependencies": {
-    "@graphql-markdown/types": "^1.7.0"
+    "@graphql-markdown/types": "^1.8.0"
   },
   "peerDependencies": {
     "prettier": "^2.8 || ^3.0"


### PR DESCRIPTION
# Description

This release improves prettier support config file and now uses `mdx` parser instead of `markdown`. It also comes with a new configuration option for `homepage` that you can now set to `false` to disable its generation.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
