### PR TITLE
🏷️ release 1.31.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15110,10 +15110,10 @@
     },
     "packages/cli": {
       "name": "@graphql-markdown/cli",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@graphql-markdown/core": "^1.16.0",
+        "@graphql-markdown/core": "^1.16.1",
         "@graphql-markdown/logger": "^1.0.5",
         "@graphql-markdown/printer-legacy": "^1.12.2",
         "commander": "^5.1.0",
@@ -15138,7 +15138,7 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.16.0",
+      "version": "1.16.1",
       "license": "MIT",
       "dependencies": {
         "@graphql-markdown/graphql": "^1.1.8",
@@ -15192,11 +15192,11 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.30.0",
+      "version": "1.30.1",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/utils": ">=3.2.0",
-        "@graphql-markdown/cli": "^0.4.0",
+        "@graphql-markdown/cli": "^0.4.1",
         "@graphql-markdown/logger": "^1.0.5",
         "@graphql-markdown/utils": "^1.9.0"
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -53,7 +53,7 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/core": "^1.16.0",
+    "@graphql-markdown/core": "^1.16.1",
     "@graphql-markdown/logger": "^1.0.5",
     "@graphql-markdown/printer-legacy": "^1.12.2",
     "commander": "^5.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.16.0",
+  "version": "1.16.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.30.0",
+  "version": "1.30.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -65,7 +65,7 @@
     "docs": "typedoc"
   },
   "dependencies": {
-    "@graphql-markdown/cli": "^0.4.0",
+    "@graphql-markdown/cli": "^0.4.1",
     "@graphql-markdown/logger": "^1.0.5",
     "@graphql-markdown/utils": "^1.9.0",
     "@docusaurus/utils": ">=3.2.0"


### PR DESCRIPTION
# Description

Version bump to release a new package `core` to fix the "magic" warning.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
