### PR TITLE
:bug: fix issue with default values for object type fields

### DIFF
--- a/packages/docusaurus/tests/__data__/schema_with_grouping.graphql
+++ b/packages/docusaurus/tests/__data__/schema_with_grouping.graphql
@@ -94,6 +94,21 @@ enum Roles {
   USER
 }
 
+enum SortField {
+  SOME_FIELD
+  SOME_FIELD2
+}
+
+enum SortDirection {
+  ASC
+  DESC
+}
+
+input EntitySort {
+  field: SortField!
+  direction: SortDirection!
+}
+
 type Query {
   GPA(skip: Int = 0): Int @doc(category: "Grade") @beta
   WeightedGPA(input: String, skip: Int!): Int
@@ -112,7 +127,10 @@ type Query {
   allCourses: [Course] @doc(category: "Course")
   mathCourses: [Course] @doc(category: "Course") @deprecated
   scienceCourses: [Course] @doc(category: "Course") @deprecated
-  searchRole(roles: [Roles!]! = [ADMIN]): Int!
+  searchRole(
+    roles: [Roles!]! = [ADMIN]
+    sort: EntitySort = { field: SOME_FIELD, direction: ASC }
+  ): Int!
     @beta
     @auth
     @complexity(value: 2, multipliers: ["roles"])

--- a/packages/graphql/tests/unit/formatter.test.ts
+++ b/packages/graphql/tests/unit/formatter.test.ts
@@ -3,6 +3,7 @@ import {
   GraphQLEnumType,
   GraphQLFloat,
   GraphQLID,
+  GraphQLInputObjectType,
   GraphQLInt,
   GraphQLList,
   GraphQLString,
@@ -139,6 +140,36 @@ describe("formatter", () => {
       };
 
       expect(getFormattedDefaultValue(argument)).toBe("[RED]");
+    });
+
+    test("returns object default value unformatted for type InputObject", () => {
+      expect.hasAssertions();
+
+      const enumType = new GraphQLEnumType({
+        name: "RGB",
+        values: {
+          RED: { value: "RED" },
+          GREEN: { value: "GREEN" },
+          BLUE: { value: "BLUE" },
+        },
+      });
+
+      const input = new GraphQLInputObjectType({
+        name: "TestInput",
+        fields: {
+          foo: { type: enumType },
+        },
+      });
+
+      const argument = {
+        name: "color",
+        description: undefined,
+        type: input,
+        defaultValue: { foo: "RED" },
+        extensions: undefined,
+      };
+
+      expect(getFormattedDefaultValue(argument)).toBe("{ foo: RED }");
     });
   });
 });

--- a/packages/printer-legacy/tests/unit/graphql/operation.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/operation.test.ts
@@ -218,7 +218,7 @@ undefined### Type
 
     expect(code).toMatchInlineSnapshot(`
         "TestQuery(
-          ArgFooBar: TestInput = { foo: \\"bar\\" }
+          ArgFooBar: TestInput = { foo: "bar" }
         ): ID
         "
       `);

--- a/packages/printer-legacy/tests/unit/graphql/operation.test.ts
+++ b/packages/printer-legacy/tests/unit/graphql/operation.test.ts
@@ -1,5 +1,10 @@
 import type { GraphQLSchema } from "@graphql-markdown/types";
-import { GraphQLID, GraphQLObjectType, GraphQLString } from "graphql/type";
+import {
+  GraphQLID,
+  GraphQLInputObjectType,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql/type";
 
 jest.mock("@graphql-markdown/graphql", (): unknown => {
   return {
@@ -185,5 +190,37 @@ undefined### Type
         "
       `);
     });
+  });
+
+  test("returns an operation with fields and default values", () => {
+    expect.hasAssertions();
+
+    const input = new GraphQLInputObjectType({
+      name: "TestInput",
+      fields: {
+        foo: { type: GraphQLString },
+      },
+    });
+
+    const operation = {
+      name: "TestQuery",
+      type: GraphQLID,
+      args: [
+        {
+          name: "ArgFooBar",
+          type: input,
+          defaultValue: { foo: "bar" },
+        },
+      ],
+    };
+
+    const code = printCodeOperation(operation);
+
+    expect(code).toMatchInlineSnapshot(`
+        "TestQuery(
+          ArgFooBar: TestInput = { foo: \\"bar\\" }
+        ): ID
+        "
+      `);
   });
 });


### PR DESCRIPTION
# Description

Fix issue with `InputObject` fields with default value

```graphql
type Query {
  searchRole(
    roles: [Roles!]! = [ADMIN]
    sort: EntitySort = { field: SOME_FIELD, direction: ASC }
  ): Int!
}
```

| Before fix | After fix |
|---|---|
| <img width="1000" height="133" alt="Screenshot 2025-08-27 at 18 59 55" src="https://github.com/user-attachments/assets/3be1d8ed-218c-4065-8ca4-be0dd6c62c1a" /> |  <img width="1014" height="152" alt="Screenshot 2025-08-27 at 18 51 16" src="https://github.com/user-attachments/assets/dd23a82b-7659-4c6e-acab-26bc8d9d836a" /> |

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
