### PR TITLE
:bug: fix overwritten docOptions

### DIFF
--- a/packages/core/tests/unit/config.test.ts
+++ b/packages/core/tests/unit/config.test.ts
@@ -283,6 +283,7 @@ describe("config", () => {
         pretty: true,
         docOptions: {
           index: false,
+          frontMatter: { draft: true },
         },
         printTypeOptions: {
           codeSection: false,
@@ -312,7 +313,10 @@ describe("config", () => {
         baseURL: configFileOpts.baseURL,
         customDirective: configFileOpts.customDirective,
         diffMethod: configFileOpts.diffMethod,
-        docOptions: { ...configFileOpts.docOptions, frontMatter: {} },
+        docOptions: {
+          ...configFileOpts.docOptions,
+          frontMatter: { draft: true },
+        },
         groupByDirective: configFileOpts.groupByDirective,
         force: DEFAULT_OPTIONS.force,
         homepageLocation: configFileOpts.homepage,

--- a/packages/core/tests/unit/renderer.test.ts
+++ b/packages/core/tests/unit/renderer.test.ts
@@ -242,19 +242,25 @@ describe("renderer", () => {
         jest
           .spyOn(Printer, "printType")
           .mockReturnValue("Lorem ipsum" as MDXString);
-        const spy = jest.spyOn(Utils, "saveFile");
+        const spy = jest.spyOn(Printer, "printType");
 
-        jest.replaceProperty(rendererInstance, "options", {
+        const optionsWithFrontMatter: RendererDocOptions = {
           frontMatter: { custom: "value" },
-        });
+        };
+
+        jest.replaceProperty(
+          rendererInstance,
+          "options",
+          optionsWithFrontMatter,
+        );
 
         const output = "/output/foobar";
         await rendererInstance.renderTypeEntities(output, "FooBar", "FooBar");
 
         expect(spy).toHaveBeenCalledWith(
-          `${output}/foo-bar.mdx`,
-          "Lorem ipsum",
-          undefined,
+          "foo-bar",
+          "FooBar",
+          optionsWithFrontMatter,
         );
       });
 

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -52,6 +52,7 @@ export default async function pluginGraphQLDocGenerator(
             docOptions: {
               generatorFrameworkName: "docusaurus",
               generatorFrameworkVersion: DOCUSAURUS_VERSION,
+              ...options.docOptions,
             },
           },
           LOGGER_MODULE,

--- a/packages/docusaurus/tests/unit/index.test.ts
+++ b/packages/docusaurus/tests/unit/index.test.ts
@@ -27,6 +27,7 @@ describe("pluginGraphQLDocGenerator", () => {
   const mockOptions = {
     runOnBuild: true,
     someOtherOption: "value",
+    docOptions: { frontMatter: { draft: true } },
   };
 
   beforeEach(() => {
@@ -80,6 +81,7 @@ describe("pluginGraphQLDocGenerator", () => {
       expect(getGraphQLMarkdownCli).toHaveBeenCalledWith(
         expect.objectContaining({
           docOptions: {
+            frontMatter: { draft: true },
             generatorFrameworkName: "docusaurus",
             generatorFrameworkVersion: expect.any(String),
           },


### PR DESCRIPTION
# Description

This PR fix `docOptions` being overwritten when Docusaurus plugin calls the GQLMD cli.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
