### PR TITLE
🐛 fix: remove duplicate DEFAULT_FRAMEWORK_NAME constant

### DIFF
--- a/packages/core/src/const/patterns.ts
+++ b/packages/core/src/const/patterns.ts
@@ -115,9 +115,4 @@ export const CONFIG_CONSTANTS = {
    * Items without the grouping directive are assigned to this group.
    */
   DEFAULT_GROUP: "Miscellaneous" as const,
-
-  /**
-   * Default formatter/framework name for documentation metadata.
-   */
-  DEFAULT_FRAMEWORK_NAME: "@graphql-markdown/docusaurus" as const,
 } as const;

--- a/packages/core/tests/unit/const/patterns.test.ts
+++ b/packages/core/tests/unit/const/patterns.test.ts
@@ -191,18 +191,6 @@ describe("Configuration Constants", () => {
     });
   });
 
-  describe("DEFAULT_FRAMEWORK_NAME", () => {
-    it("should have correct default framework name", () => {
-      expect(CONFIG_CONSTANTS.DEFAULT_FRAMEWORK_NAME).toBe(
-        "@graphql-markdown/docusaurus",
-      );
-    });
-
-    it("should be a constant string", () => {
-      expect(typeof CONFIG_CONSTANTS.DEFAULT_FRAMEWORK_NAME).toBe("string");
-    });
-  });
-
   describe("Constants immutability", () => {
     it("should be typed as const for compile-time immutability", () => {
       // TypeScript's 'as const' provides compile-time immutability


### PR DESCRIPTION
## Summary

Addresses post-merge Copilot code review comment from PR #2532.

## Problem

PR #2532 introduced `DEFAULT_FRAMEWORK_NAME` in `CONFIG_CONSTANTS` that duplicated the value of existing `PACKAGE_NAME` constant from `config.ts`. This violates the DRY (Don't Repeat Yourself) principle that the PR was meant to enforce.

## Solution

- Remove `DEFAULT_FRAMEWORK_NAME` from `packages/core/src/const/patterns.ts`
- Remove related tests from `packages/core/tests/unit/const/patterns.test.ts`
- `PACKAGE_NAME` in `config.ts` already serves this purpose

## Changes

- ✂️ Removed duplicate `DEFAULT_FRAMEWORK_NAME` constant
- ✂️ Removed `DEFAULT_FRAMEWORK_NAME` test cases
- ✅ All 946 tests passing
- ✅ Type checking passes
- ✅ No regressions

## Related

- Addresses comment from PR #2532: "Duplicate constant: `CONFIG_CONSTANTS.DEFAULT_FRAMEWORK_NAME`"