### PR TITLE
:computer: resolve typedoc plugin path and printLink param docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   "scripts": {
     "build": "turbo build",
     "clean": "turbo clean",
+    "docs": "turbo run docs",
     "docs:api": "turbo run docs:api:root",
     "docs:api:root": "node ./packages/tooling-config/scripts/docs-api.mjs",
     "knip": "knip --strict",

--- a/packages/printer-legacy/src/link.ts
+++ b/packages/printer-legacy/src/link.ts
@@ -391,7 +391,7 @@ const isLinkType = (arg: unknown): arg is TypeLink => {
 /**
  * Prints a link for a GraphQL type based on the provided options.
  *
- * @param type - The GraphQL type to print a link for
+ * @param arg - The GraphQL type or link object to print a link for
  * @param options - Configuration options for link generation
  * @returns The formatted link as a string
  */

--- a/packages/tooling-config/typedoc/base.mjs
+++ b/packages/tooling-config/typedoc/base.mjs
@@ -39,9 +39,9 @@ export const createPackageTypedocConfig = (overrides = {}) => {
     ...typedocBaseOptions,
     plugin: [
       "typedoc-plugin-markdown",
-      "../../tooling-config/typedoc/no-media-plugin.mjs",
+      "../tooling-config/typedoc/no-media-plugin.mjs",
     ],
-    prettierConfigFile: "../../tooling-config/prettier/index.mjs",
+    prettierConfigFile: "../tooling-config/prettier/index.mjs",
     entryPoints: ["./src"],
     entryPointStrategy: "expand",
     out: "./docs",

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,7 @@
     },
     "docs": {
       "dependsOn": ["^build"],
-      "outputs": ["api/**"]
+      "outputs": ["docs/**"]
     },
     "lint": {
       "dependsOn": ["^build"]
@@ -55,6 +55,6 @@
     "//#docs:api:root": {
       "dependsOn": ["^build"],
       "outputs": ["api/**", "!api/@@graphql-markdown/**"]
-    },
+    }
   }
 }


### PR DESCRIPTION
- Fix TypeDoc package config path to `no-media-plugin.mjs` and prettier config after tooling-config relocation.
- Fix JSDoc `@param` name for `printLink` (`arg` instead of `type`) to remove TypeDoc warning.
- Verified by running docs for `@graphql-markdown/graphql`, `@graphql-markdown/logger`, `@graphql-markdown/utils`, and `@graphql-markdown/printer-legacy`.
