### PR TITLE
:bug: hide details open label when collapsed in Docusaurus

### DIFF
--- a/packages/docusaurus/src/mdx/index.ts
+++ b/packages/docusaurus/src/mdx/index.ts
@@ -81,7 +81,7 @@ export const formatMDXDetails = ({
 }: CollapsibleOption): MDXString => {
   const openLabel = escapeMDX(`Hide ${dataOpen}`);
   const closeLabel = escapeMDX(`Show ${dataClose}`);
-  return `${MARKDOWN_EOP}<details class="graphql-markdown-details">${MARKDOWN_EOL}<summary>${MARKDOWN_EOL}<span class="graphql-markdown-details-label-closed">${closeLabel}</span>${MARKDOWN_EOL}<span class="graphql-markdown-details-label-open">${openLabel}</span>${MARKDOWN_EOL}</summary>${MARKDOWN_EOP}\r${MARKDOWN_EOP}</details>${MARKDOWN_EOP}` as MDXString;
+  return `${MARKDOWN_EOP}<details class="graphql-markdown-details">${MARKDOWN_EOL}<summary>${MARKDOWN_EOL}<span class="graphql-markdown-details-label-closed">${closeLabel}</span>${MARKDOWN_EOL}<span class="graphql-markdown-details-label-open" hidden>${openLabel}</span>${MARKDOWN_EOL}</summary>${MARKDOWN_EOP}\r${MARKDOWN_EOP}</details>${MARKDOWN_EOP}` as MDXString;
 };
 
 /**

--- a/packages/docusaurus/tests/unit/mdx/index.test.ts
+++ b/packages/docusaurus/tests/unit/mdx/index.test.ts
@@ -58,7 +58,7 @@ describe("formatMDXDetails", () => {
     };
     const result = formatMDXDetails(details);
     expect(result).toBe(
-      '\n\n<details class="graphql-markdown-details">\n<summary>\n<span class="graphql-markdown-details-label-closed">Show Close</span>\n<span class="graphql-markdown-details-label-open">Hide Open</span>\n</summary>\n\n\r\n\n</details>\n\n',
+      '\n\n<details class="graphql-markdown-details">\n<summary>\n<span class="graphql-markdown-details-label-closed">Show Close</span>\n<span class="graphql-markdown-details-label-open" hidden>Hide Open</span>\n</summary>\n\n\r\n\n</details>\n\n',
     );
   });
 });


### PR DESCRIPTION
## Summary

Fixes a visual issue where the details/collapsible element open label remains visible even when the details are collapsed in Docusaurus-generated documentation.

## Changes

- Updates CSS to properly hide the open label state when details are in collapsed state

## Test plan

- [x] Visually verified that the open label is hidden when details are collapsed
- [x] Existing tests pass

## Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] New and existing unit tests pass locally with my changes.