### PR TITLE
docs: document code-first TS/JS schema support

### DIFF
--- a/docs/advanced/schema-loading.md
+++ b/docs/advanced/schema-loading.md
@@ -99,3 +99,31 @@ plugins: [
 See our [Troubleshooting section](/docs/troubleshooting) in case of error ['UrlLoader' does not exist in type 'LoaderOption'.ts](/docs/troubleshooting#urlloader-does-not-exist-in-type-loaderoptionts).
 
 :::
+
+## Code-first schema (TypeScript/JavaScript)
+
+For teams using a code-first approach, use `@graphql-tools/code-file-loader` to load a schema exported directly from a TypeScript or JavaScript file:
+
+```shell title="shell"
+npm install @graphql-tools/code-file-loader
+```
+
+Once done, you can declare the loader in `@graphql-markdown/docusaurus` configuration:
+
+```js title="docusaurus.config.js"
+plugins: [
+  [
+    "@graphql-markdown/docusaurus",
+    /** @type {import('@graphql-markdown/types').ConfigOptions} */
+    {
+      // ... other options
+      schema: "./src/**/graphql/*.ts",
+      loaders: {
+        CodeFileLoader: "@graphql-tools/code-file-loader"
+      }
+    },
+  ],
+],
+```
+
+The schema file must export a `GraphQLSchema` instance as its default or named export. This works with any code-first library that produces a `GraphQLSchema` — including `makeExecutableSchema` (graphql-tools), [Pothos](https://pothos-graphql.dev/), [TypeGraphQL](https://typegraphql.com/), and [NestJS](https://docs.nestjs.com/graphql/quick-start).

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -31,7 +31,7 @@ Managing API documentation can be time-consuming and prone to becoming outdated.
 - Full cross-linking between types with visual relationship hierarchy
 - MDX output fully customizable using your own components
 - Extensible lifecycle hooks and events system
-- Any schema loader compatible with `@graphql-tools/load` (local files, remote endpoints)
+- Any schema loader compatible with `@graphql-tools/load` — SDL files, remote endpoints, or code-first TS/JS schemas
 - Group types into categories using directives
 - Namespaced operations (nested query/mutation/subscription objects)
 - GraphQL config support

--- a/website/src/components/HomepageFeatures/index.js
+++ b/website/src/components/HomepageFeatures/index.js
@@ -17,7 +17,7 @@ const HowItWorksSteps = [
     title: "Configure",
     description: (
       <>
-        Point it at your schema — SDL file, introspection endpoint, or GraphQL config.
+        Point it at your schema — SDL file, introspection endpoint, GraphQL config, or code-first TS/JS schema.
       </>
     ),
   },
@@ -39,7 +39,7 @@ const FeatureList = [
     Svg: require("@site/static/img/website.svg").default,
     description: (
       <>
-        Supports SDL files, introspection endpoints, and GraphQL config. Type
+        Supports SDL files, introspection endpoints, GraphQL config, and code-first TS/JS schemas. Type
         cross-linking, deprecation notices, and custom directive badges —
         included out of the box.{" "}
         <Link to="/docs/get-started" className={styles.inlineCta}>


### PR DESCRIPTION
# Description

GraphQL-Markdown supports any `@graphql-tools/load`-compatible loader, including `@graphql-tools/code-file-loader`, which lets TypeScript/JavaScript teams using a code-first approach point the tool directly at their schema files. This was not documented anywhere — TS/JS teams had no way to discover this without already knowing the `@graphql-tools` loader ecosystem.

Changes:
- **`docs/advanced/schema-loading.md`**: New "Code-first schema (TypeScript/JavaScript)" section with install instructions, a config example, and a note listing compatible libraries (Pothos, TypeGraphQL, NestJS, makeExecutableSchema)
- **`docs/intro.md`**: Updated the schema loader feature bullet to explicitly name SDL files, remote endpoints, and code-first TS/JS schemas
- **`website/src/components/HomepageFeatures/index.js`**: Updated the "Configure" step and "Schema-to-docs in seconds" feature card copy to mention code-first TS/JS schemas

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.