### PR TITLE
:recycle: make core printer static and align dependency wiring

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -61,7 +61,6 @@
       "dependencies": {
         "@graphql-markdown/core": "workspace:^",
         "@graphql-markdown/logger": "workspace:^",
-        "@graphql-markdown/printer-legacy": "workspace:^",
         "@graphql-markdown/types": "workspace:^",
         "commander": "^5.1.0",
         "graphql-config": "catalog:",
@@ -77,6 +76,7 @@
         "@fastify/deepmerge": "^3.2.1",
         "@graphql-markdown/graphql": "workspace:^",
         "@graphql-markdown/logger": "workspace:^",
+        "@graphql-markdown/printer-legacy": "workspace:^",
         "@graphql-markdown/types": "workspace:^",
         "@graphql-markdown/utils": "workspace:^",
       },
@@ -86,13 +86,11 @@
       "peerDependencies": {
         "@graphql-markdown/diff": "workspace:^",
         "@graphql-markdown/helpers": "workspace:^",
-        "@graphql-markdown/printer-legacy": "workspace:^",
         "graphql-config": "catalog:",
       },
       "optionalPeers": [
         "@graphql-markdown/diff",
         "@graphql-markdown/helpers",
-        "@graphql-markdown/printer-legacy",
         "graphql-config",
       ],
     },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,6 @@
   "dependencies": {
     "@graphql-markdown/core": "workspace:^",
     "@graphql-markdown/logger": "workspace:^",
-    "@graphql-markdown/printer-legacy": "workspace:^",
     "@graphql-markdown/types": "workspace:^",
     "commander": "^5.1.0",
     "graphql-config": "catalog:"

--- a/packages/cli/tsconfig.test.json
+++ b/packages/cli/tsconfig.test.json
@@ -16,8 +16,8 @@
     "types": ["node", "@types/jest"],
 
     "paths": {
-      "@graphql-markdown/types": ["./packages/types/src/index.d.ts"],
-      "@graphql-markdown/*": ["./packages/*/src/index.ts"]
+      "@graphql-markdown/types": ["../types/src/index.d.ts"],
+      "@graphql-markdown/*": ["../*/src/index.ts"]
     }
   },
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,6 +75,7 @@
     "@fastify/deepmerge": "^3.2.1",
     "@graphql-markdown/graphql": "workspace:^",
     "@graphql-markdown/logger": "workspace:^",
+    "@graphql-markdown/printer-legacy": "workspace:^",
     "@graphql-markdown/types": "workspace:^",
     "@graphql-markdown/utils": "workspace:^"
   },
@@ -84,13 +85,9 @@
   "peerDependencies": {
     "@graphql-markdown/diff": "workspace:^",
     "@graphql-markdown/helpers": "workspace:^",
-    "@graphql-markdown/printer-legacy": "workspace:^",
     "graphql-config": "catalog:"
   },
   "peerDependenciesMeta": {
-    "@graphql-markdown/printer-legacy": {
-      "optional": true
-    },
     "@graphql-markdown/diff": {
       "optional": true
     },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -35,7 +35,6 @@ import type {
   GroupByDirectiveOptions,
   Maybe,
   Options,
-  PackageName,
   Pointer,
   TypeDeprecatedOption,
   TypeDiffMethod,
@@ -180,7 +179,6 @@ export const DEFAULT_OPTIONS: Readonly<
   loaders: undefined,
   metatags: [] as Record<string, string>[],
   pretty: false as const,
-  printer: "@graphql-markdown/printer-legacy" as PackageName,
   printTypeOptions: {
     codeSection: true as const,
     deprecated: DeprecatedOption.DEFAULT as TypeDeprecatedOption,
@@ -900,7 +898,6 @@ export const buildConfig = async (
     onlyDocDirective,
     outputDir: join(rootPath, baseURL),
     prettify,
-    printer: (config.printer ?? DEFAULT_OPTIONS.printer)!,
     printTypeOptions: getPrintTypeOptions(cliOpts, config.printTypeOptions),
     schemaLocation,
     skipDocDirective,

--- a/packages/core/src/generator.ts
+++ b/packages/core/src/generator.ts
@@ -349,7 +349,6 @@ export const generateDocFromSchema = async ({
   onlyDocDirective,
   outputDir,
   prettify,
-  printer: printerModule,
   printTypeOptions,
   schemaLocation,
   skipDocDirective,
@@ -433,9 +432,6 @@ export const generateDocFromSchema = async ({
   );
 
   const printer = await getPrinter(
-    // module mandatory
-    printerModule,
-
     // config mandatory
     {
       baseURL,

--- a/packages/core/src/printer.ts
+++ b/packages/core/src/printer.ts
@@ -7,11 +7,10 @@
  * @module printer
  *
  * This module provides the functionality to load and initialize a printer for GraphQL schema documentation.
- * It dynamically imports a printer module and configures it with the provided schema and options.
+ * It resolves a supported printer module and configures it with the provided schema and options.
  */
 import type {
   Formatter,
-  IPrinter,
   Maybe,
   PackageName,
   Printer,
@@ -19,11 +18,14 @@ import type {
   PrinterEventEmitter,
   PrinterOptions,
 } from "@graphql-markdown/types";
+import { Printer as LegacyPrinter } from "@graphql-markdown/printer-legacy";
+
+const PRINTER_LEGACY_PACKAGE = "@graphql-markdown/printer-legacy";
 
 /**
  * Loads and initializes a printer module for GraphQL schema documentation.
  *
- * This function dynamically imports the specified printer module and initializes it
+ * This function resolves the specified printer module and initializes it
  * with the provided configuration and options. The printer is responsible for rendering
  * GraphQL schema documentation in the desired format.
  *
@@ -36,7 +38,7 @@ import type {
  *
  * @throws Will throw an error if printerModule is not a string
  * @throws Will throw an error if config is not provided
- * @throws Will throw an error if the module specified by printerModule cannot be found
+ * @throws Will throw an error if printerModule is not supported
  *
  * @example
  * ```typescript
@@ -80,24 +82,23 @@ export const getPrinter = async (
     throw new Error("Invalid printer config.");
   }
 
-  try {
-    const { Printer }: { Printer: typeof IPrinter } = await import(
-      printerModule
-    );
-
-    const { schema, baseURL, linkRoot } = config;
-    await Printer.init(
-      schema,
-      baseURL,
-      linkRoot,
-      { ...options },
-      formatter,
-      mdxDeclaration,
-      eventEmitter,
-    );
-
-    return Printer;
-  } catch {
-    throw new Error(`Cannot find module '${printerModule}'.`);
+  if (printerModule !== PRINTER_LEGACY_PACKAGE) {
+    throw new Error(`Unsupported printer module '${printerModule}'.`);
   }
+
+  const printer = LegacyPrinter as unknown as Printer;
+  const normalizedOptions = options ?? undefined;
+
+  const { schema, baseURL, linkRoot } = config;
+  await printer.init(
+    schema,
+    baseURL,
+    linkRoot,
+    normalizedOptions,
+    formatter,
+    mdxDeclaration,
+    eventEmitter,
+  );
+
+  return printer;
 };

--- a/packages/core/src/printer.ts
+++ b/packages/core/src/printer.ts
@@ -11,16 +11,35 @@
  */
 import type {
   Formatter,
+  IPrinter,
   Maybe,
-  PackageName,
-  Printer,
   PrinterConfig,
   PrinterEventEmitter,
+  PrinterInitOptions,
   PrinterOptions,
 } from "@graphql-markdown/types";
-import { Printer as LegacyPrinter } from "@graphql-markdown/printer-legacy";
+import { Printer } from "@graphql-markdown/printer-legacy";
 
-const PRINTER_LEGACY_PACKAGE = "@graphql-markdown/printer-legacy";
+const normalizePrinterOptions = (
+  options?: Maybe<PrinterOptions>,
+): PrinterInitOptions | undefined => {
+  if (!options) {
+    return undefined;
+  }
+
+  return {
+    customDirectives: options.customDirectives ?? undefined,
+    deprecated: options.deprecated ?? undefined,
+    groups: options.groups ?? undefined,
+    meta: options.meta ?? undefined,
+    metatags: options.metatags ?? undefined,
+    onlyDocDirectives: options.onlyDocDirectives ?? undefined,
+    printTypeOptions:
+      options.printTypeOptions as NonNullable<PrinterInitOptions>["printTypeOptions"],
+    skipDocDirectives: options.skipDocDirectives ?? undefined,
+    sectionHeaderId: options.sectionHeaderId,
+  };
+};
 
 /**
  * Loads and initializes a printer module for GraphQL schema documentation.
@@ -29,16 +48,13 @@ const PRINTER_LEGACY_PACKAGE = "@graphql-markdown/printer-legacy";
  * with the provided configuration and options. The printer is responsible for rendering
  * GraphQL schema documentation in the desired format.
  *
- * @param printerModule - The name/path of the printer module to load
  * @param config - Configuration for the printer including schema, baseURL, and linkRoot
  * @param options - Additional options for customizing the printer's behavior
  * @param formatter - Optional formatter functions for customizing output format (e.g., MDX)
  *
  * @returns A promise that resolves to the initialized Printer instance
  *
- * @throws Will throw an error if printerModule is not a string
  * @throws Will throw an error if config is not provided
- * @throws Will throw an error if printerModule is not supported
  *
  * @example
  * ```typescript
@@ -52,7 +68,6 @@ const PRINTER_LEGACY_PACKAGE = "@graphql-markdown/printer-legacy";
  * `);
  *
  * const printer = await getPrinter(
- *   '@graphql-markdown/printer-legacy',
  *   {
  *     schema,
  *     baseURL: '/docs',
@@ -67,30 +82,20 @@ const PRINTER_LEGACY_PACKAGE = "@graphql-markdown/printer-legacy";
  * ```
  */
 export const getPrinter = async (
-  printerModule?: Maybe<PackageName>,
   config?: Maybe<PrinterConfig>,
   options?: Maybe<PrinterOptions>,
   formatter?: Partial<Formatter>,
   mdxDeclaration?: Maybe<string>,
   eventEmitter?: Maybe<PrinterEventEmitter>,
-): Promise<Printer> => {
-  if (typeof printerModule !== "string") {
-    throw new TypeError("Invalid printer module name.");
-  }
-
+): Promise<typeof IPrinter> => {
   if (!config) {
     throw new Error("Invalid printer config.");
   }
 
-  if (printerModule !== PRINTER_LEGACY_PACKAGE) {
-    throw new Error(`Unsupported printer module '${printerModule}'.`);
-  }
-
-  const printer = LegacyPrinter as unknown as Printer;
-  const normalizedOptions = options ?? undefined;
+  const normalizedOptions = normalizePrinterOptions(options);
 
   const { schema, baseURL, linkRoot } = config;
-  await printer.init(
+  await Printer.init(
     schema,
     baseURL,
     linkRoot,
@@ -100,5 +105,5 @@ export const getPrinter = async (
     eventEmitter,
   );
 
-  return printer;
+  return Printer;
 };

--- a/packages/core/src/printer.ts
+++ b/packages/core/src/printer.ts
@@ -15,31 +15,9 @@ import type {
   Maybe,
   PrinterConfig,
   PrinterEventEmitter,
-  PrinterInitOptions,
   PrinterOptions,
 } from "@graphql-markdown/types";
 import { Printer } from "@graphql-markdown/printer-legacy";
-
-const normalizePrinterOptions = (
-  options?: Maybe<PrinterOptions>,
-): PrinterInitOptions | undefined => {
-  if (!options) {
-    return undefined;
-  }
-
-  return {
-    customDirectives: options.customDirectives ?? undefined,
-    deprecated: options.deprecated ?? undefined,
-    groups: options.groups ?? undefined,
-    meta: options.meta ?? undefined,
-    metatags: options.metatags ?? undefined,
-    onlyDocDirectives: options.onlyDocDirectives ?? undefined,
-    printTypeOptions:
-      options.printTypeOptions as NonNullable<PrinterInitOptions>["printTypeOptions"],
-    skipDocDirectives: options.skipDocDirectives ?? undefined,
-    sectionHeaderId: options.sectionHeaderId,
-  };
-};
 
 /**
  * Loads and initializes a printer module for GraphQL schema documentation.
@@ -74,11 +52,14 @@ const normalizePrinterOptions = (
  *     linkRoot: 'graphql'
  *   },
  *   {
- *     printTypeOptions: { includeDeprecationReasons: true }
+ *     printTypeOptions: { deprecated: 'group' }
  *   }
  * );
  *
- * const output = printer.printSchema();
+ * const queryType = schema.getQueryType();
+ * if (queryType) {
+ *   const output = await printer.printType('Query', queryType);
+ * }
  * ```
  */
 export const getPrinter = async (
@@ -92,14 +73,12 @@ export const getPrinter = async (
     throw new Error("Invalid printer config.");
   }
 
-  const normalizedOptions = normalizePrinterOptions(options);
-
   const { schema, baseURL, linkRoot } = config;
   await Printer.init(
     schema,
     baseURL,
     linkRoot,
-    normalizedOptions,
+    options ?? undefined,
     formatter,
     mdxDeclaration,
     eventEmitter,

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -4,7 +4,7 @@ import type {
   CategorySortFn,
   Maybe,
   MDXString,
-  Printer,
+  IPrinter,
   RendererDocOptions,
   SchemaEntitiesGroupMap,
   SchemaEntity,
@@ -340,8 +340,7 @@ export class Renderer {
   readonly options: Maybe<RendererDocOptions>;
   readonly mdxExtension: string;
   // mdxModuleIndexFileSupport: boolean;
-
-  private readonly printer: Printer;
+  private readonly printer: typeof IPrinter;
   private readonly rootLevelPositionManager: CategoryPositionManager;
   private readonly categoryPositionManager: CategoryPositionManager;
 
@@ -358,7 +357,7 @@ export class Renderer {
    * @example
    */
   constructor(
-    printer: Printer,
+    printer: typeof IPrinter,
     outputDir: string,
     baseURL: string,
     group: Maybe<SchemaEntitiesGroupMap>,
@@ -1033,7 +1032,7 @@ export class Renderer {
  * ```
  */
 export const getRenderer = async (
-  printer: Printer,
+  printer: typeof IPrinter,
   outputDir: string,
   baseURL: string,
   group: Maybe<SchemaEntitiesGroupMap>,

--- a/packages/core/tests/unit/config.test.ts
+++ b/packages/core/tests/unit/config.test.ts
@@ -255,7 +255,6 @@ describe("config", () => {
           outputDir: join(DEFAULT_OPTIONS.rootPath!, DEFAULT_OPTIONS.baseURL!),
           onlyDocDirective: DEFAULT_OPTIONS.onlyDocDirective,
           prettify: DEFAULT_OPTIONS.pretty,
-          printer: DEFAULT_OPTIONS.printer,
           printTypeOptions: {
             ...DEFAULT_OPTIONS.printTypeOptions,
             hierarchy: DEFAULT_HIERARCHY,
@@ -337,7 +336,6 @@ describe("config", () => {
         outputDir: join(configFileOpts.rootPath!, configFileOpts.baseURL!),
         onlyDocDirective: DEFAULT_OPTIONS.onlyDocDirective,
         prettify: configFileOpts.pretty,
-        printer: DEFAULT_OPTIONS.printer,
         printTypeOptions: {
           ...configFileOpts.printTypeOptions,
           hierarchy: { entity: {} },
@@ -430,7 +428,6 @@ describe("config", () => {
           hierarchy: { entity: {} },
           exampleSection: false,
         },
-        printer: DEFAULT_OPTIONS.printer,
         skipDocDirective: ["noDoc"],
         onlyDocDirective: ["public"],
         customDirective: DEFAULT_OPTIONS.customDirective,
@@ -508,7 +505,6 @@ describe("config", () => {
           hierarchy: { entity: {} },
           exampleSection: true,
         },
-        printer: DEFAULT_OPTIONS.printer,
         skipDocDirective: [],
         onlyDocDirective: [],
         customDirective: DEFAULT_OPTIONS.customDirective,
@@ -546,7 +542,6 @@ describe("config", () => {
         onlyDocDirective: DEFAULT_OPTIONS.onlyDocDirective,
         outputDir: join(DEFAULT_OPTIONS.rootPath!, configFileOpts.baseURL!),
         prettify: cliOpts.pretty,
-        printer: DEFAULT_OPTIONS.printer,
         printTypeOptions: {
           ...DEFAULT_OPTIONS.printTypeOptions,
           hierarchy: DEFAULT_HIERARCHY,
@@ -580,7 +575,6 @@ describe("config", () => {
         onlyDocDirective: DEFAULT_OPTIONS.onlyDocDirective,
         outputDir: join(DEFAULT_OPTIONS.rootPath!, DEFAULT_OPTIONS.baseURL!),
         prettify: DEFAULT_OPTIONS.pretty,
-        printer: DEFAULT_OPTIONS.printer,
         printTypeOptions: {
           ...DEFAULT_OPTIONS.printTypeOptions,
           hierarchy: DEFAULT_HIERARCHY,
@@ -618,7 +612,6 @@ describe("config", () => {
         onlyDocDirective: DEFAULT_OPTIONS.onlyDocDirective,
         outputDir: join(DEFAULT_OPTIONS.rootPath!, DEFAULT_OPTIONS.baseURL!),
         prettify: DEFAULT_OPTIONS.pretty,
-        printer: DEFAULT_OPTIONS.printer,
         printTypeOptions: {
           ...DEFAULT_OPTIONS.printTypeOptions,
           hierarchy: DEFAULT_HIERARCHY,

--- a/packages/core/tests/unit/generator.test.ts
+++ b/packages/core/tests/unit/generator.test.ts
@@ -73,7 +73,6 @@ describe("generator", () => {
       metatags: [],
       onlyDocDirective: [],
       prettify: true,
-      printer: "printer module" as PackageName,
       printTypeOptions: {
         codeSection: true,
         deprecated: "skip",
@@ -157,7 +156,6 @@ describe("generator", () => {
         await generateDocFromSchema({ ...options, mdxParser });
 
         expect(getPrinterSpy).toHaveBeenCalledWith(
-          options.printer,
           {
             baseURL: options.baseURL,
             linkRoot: options.linkRoot,
@@ -404,7 +402,6 @@ describe("generator", () => {
 
       // Verify object literals are passed correctly with all expected properties
       expect(getPrinterSpy).toHaveBeenCalledWith(
-        expect.any(String),
         expect.objectContaining({
           baseURL: options.baseURL,
           linkRoot: options.linkRoot,
@@ -425,13 +422,13 @@ describe("generator", () => {
       );
 
       // Verify that the meta object contains expected properties
-      expect(getPrinterSpy.mock.calls[0][2]?.meta).toEqual({
+      expect(getPrinterSpy.mock.calls[0][1]?.meta).toEqual({
         generatorFrameworkName: undefined,
         generatorFrameworkVersion: undefined,
       });
 
       // Verify printTypeOptions are passed intact
-      expect(getPrinterSpy.mock.calls[0][2]?.printTypeOptions).toEqual(
+      expect(getPrinterSpy.mock.calls[0][1]?.printTypeOptions).toEqual(
         options.printTypeOptions,
       );
     });
@@ -472,7 +469,6 @@ describe("generator", () => {
       });
 
       expect(getPrinterSpy).toHaveBeenCalledWith(
-        expect.any(String),
         expect.any(Object),
         expect.objectContaining({
           sectionHeaderId: false,

--- a/packages/core/tests/unit/graphql-config.test.ts
+++ b/packages/core/tests/unit/graphql-config.test.ts
@@ -377,7 +377,6 @@ describe("config", () => {
             graphqlConfig.extensions["graphql-markdown"].baseURL,
           ),
           prettify: DEFAULT_OPTIONS.pretty,
-          printer: DEFAULT_OPTIONS.printer,
           printTypeOptions: {
             ...DEFAULT_OPTIONS.printTypeOptions,
             hierarchy: DEFAULT_HIERARCHY,

--- a/packages/core/tests/unit/printer.test.ts
+++ b/packages/core/tests/unit/printer.test.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema } from "graphql/type";
 
-import type { Formatter, PackageName } from "@graphql-markdown/types";
+import type { Formatter } from "@graphql-markdown/types";
 
 import { getPrinter } from "../../src/printer";
 
@@ -25,7 +25,6 @@ describe("generator", () => {
         printTypeOptions: {},
       };
       const printer = await getPrinter(
-        "@graphql-markdown/printer-legacy" as PackageName,
         printerConfig,
         printerOptions,
         undefined,
@@ -45,60 +44,15 @@ describe("generator", () => {
       );
     });
 
-    test.each([[undefined], [null]])(
-      "throws exception if printer module is %s",
-      async (value) => {
-        expect.assertions(1);
-
-        await expect(
-          getPrinter(
-            value,
-            {
-              schema: new GraphQLSchema({}),
-              baseURL: "/",
-              linkRoot: "root",
-            },
-            {
-              groups: {},
-              printTypeOptions: {},
-            },
-          ),
-        ).rejects.toThrow("Invalid printer module name.");
-      },
-    );
-
     test("throws exception if no printer config set", async () => {
       expect.assertions(1);
 
       await expect(
-        getPrinter(
-          "@graphql-markdown/printer-legacy" as PackageName,
-          undefined,
-          {
-            groups: {},
-            printTypeOptions: {},
-          },
-        ),
+        getPrinter(undefined, {
+          groups: {},
+          printTypeOptions: {},
+        }),
       ).rejects.toThrow("Invalid printer config.");
-    });
-
-    test("throws exception if no printer module not found", async () => {
-      expect.assertions(1);
-
-      await expect(
-        getPrinter(
-          "foobar" as PackageName,
-          {
-            schema: new GraphQLSchema({}),
-            baseURL: "/",
-            linkRoot: "root",
-          },
-          {
-            groups: {},
-            printTypeOptions: {},
-          },
-        ),
-      ).rejects.toThrow("Unsupported printer module 'foobar'.");
     });
 
     test("throws error if printer initialization fails", async () => {
@@ -110,7 +64,6 @@ describe("generator", () => {
 
       await expect(
         getPrinter(
-          "@graphql-markdown/printer-legacy" as PackageName,
           {
             schema: new GraphQLSchema({}),
             baseURL: "/",
@@ -131,7 +84,6 @@ describe("generator", () => {
       const mdxModule = { test: true } as Partial<Formatter>;
 
       await getPrinter(
-        "@graphql-markdown/printer-legacy" as PackageName,
         {
           schema: new GraphQLSchema({}),
           baseURL: "/",
@@ -162,7 +114,6 @@ describe("generator", () => {
       const mdxModule = { test: true } as Partial<Formatter>;
 
       await getPrinter(
-        "@graphql-markdown/printer-legacy" as PackageName,
         {
           schema: new GraphQLSchema({}),
           baseURL: "/",

--- a/packages/core/tests/unit/printer.test.ts
+++ b/packages/core/tests/unit/printer.test.ts
@@ -98,10 +98,10 @@ describe("generator", () => {
             printTypeOptions: {},
           },
         ),
-      ).rejects.toThrow("Cannot find module 'foobar'.");
+      ).rejects.toThrow("Unsupported printer module 'foobar'.");
     });
 
-    test("throws error if printer module initialization fails", async () => {
+    test("throws error if printer initialization fails", async () => {
       expect.assertions(1);
 
       jest
@@ -121,9 +121,7 @@ describe("generator", () => {
             printTypeOptions: {},
           },
         ),
-      ).rejects.toThrow(
-        "Cannot find module '@graphql-markdown/printer-legacy'",
-      );
+      ).rejects.toThrow("Init error");
     });
 
     test("passes mdxModule to printer initialization", async () => {

--- a/packages/core/tests/unit/printer.test.ts
+++ b/packages/core/tests/unit/printer.test.ts
@@ -44,7 +44,7 @@ describe("generator", () => {
       );
     });
 
-    test("normalizes nullable printer options before initialization", async () => {
+    test("passes nullable printer options through to initialization", async () => {
       expect.assertions(1);
 
       const spy = jest.spyOn(Printer, "init");
@@ -75,17 +75,86 @@ describe("generator", () => {
         "/",
         "root",
         {
-          customDirectives: undefined,
-          deprecated: undefined,
-          groups: undefined,
-          meta: undefined,
-          metatags: undefined,
+          customDirectives: null,
+          deprecated: null,
+          groups: null,
+          meta: null,
+          metatags: null,
           onlyDocDirectives: [],
           printTypeOptions: {
             deprecated: "group",
           },
           skipDocDirectives: [],
           sectionHeaderId: false,
+        },
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    test("passes null printTypeOptions through to initialization", async () => {
+      expect.assertions(1);
+
+      const spy = jest.spyOn(Printer, "init");
+
+      await getPrinter(
+        {
+          schema: new GraphQLSchema({}),
+          baseURL: "/",
+          linkRoot: "root",
+        },
+        {
+          groups: {},
+          printTypeOptions: null,
+        },
+      );
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.any(GraphQLSchema),
+        "/",
+        "root",
+        {
+          groups: {},
+          printTypeOptions: null,
+        },
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
+    test("passes string hierarchy through to initialization", async () => {
+      expect.assertions(1);
+
+      const spy = jest.spyOn(Printer, "init");
+
+      await getPrinter(
+        {
+          schema: new GraphQLSchema({}),
+          baseURL: "/",
+          linkRoot: "root",
+        },
+        {
+          groups: {},
+          printTypeOptions: {
+            hierarchy: "flat",
+          },
+        },
+        undefined,
+        undefined,
+        undefined,
+      );
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.any(GraphQLSchema),
+        "/",
+        "root",
+        {
+          groups: {},
+          printTypeOptions: {
+            hierarchy: "flat",
+          },
         },
         undefined,
         undefined,

--- a/packages/core/tests/unit/printer.test.ts
+++ b/packages/core/tests/unit/printer.test.ts
@@ -44,6 +44,55 @@ describe("generator", () => {
       );
     });
 
+    test("normalizes nullable printer options before initialization", async () => {
+      expect.assertions(1);
+
+      const spy = jest.spyOn(Printer, "init");
+
+      await getPrinter(
+        {
+          schema: new GraphQLSchema({}),
+          baseURL: "/",
+          linkRoot: "root",
+        },
+        {
+          customDirectives: null,
+          deprecated: null,
+          groups: null,
+          meta: null,
+          metatags: null,
+          onlyDocDirectives: [],
+          printTypeOptions: {
+            deprecated: "group",
+          },
+          skipDocDirectives: [],
+          sectionHeaderId: false,
+        },
+      );
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.any(GraphQLSchema),
+        "/",
+        "root",
+        {
+          customDirectives: undefined,
+          deprecated: undefined,
+          groups: undefined,
+          meta: undefined,
+          metatags: undefined,
+          onlyDocDirectives: [],
+          printTypeOptions: {
+            deprecated: "group",
+          },
+          skipDocDirectives: [],
+          sectionHeaderId: false,
+        },
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
     test("throws exception if no printer config set", async () => {
       expect.assertions(1);
 

--- a/packages/core/tests/unit/printer.test.ts
+++ b/packages/core/tests/unit/printer.test.ts
@@ -124,6 +124,31 @@ describe("generator", () => {
       );
     });
 
+    test("passes undefined to initialization when printer options are null", async () => {
+      expect.assertions(1);
+
+      const spy = jest.spyOn(Printer, "init");
+
+      await getPrinter(
+        {
+          schema: new GraphQLSchema({}),
+          baseURL: "/",
+          linkRoot: "root",
+        },
+        null,
+      );
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.any(GraphQLSchema),
+        "/",
+        "root",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
+
     test("passes string hierarchy through to initialization", async () => {
       expect.assertions(1);
 

--- a/packages/docusaurus/tsconfig.test.json
+++ b/packages/docusaurus/tsconfig.test.json
@@ -16,8 +16,8 @@
     "types": ["node", "@types/jest"],
 
     "paths": {
-      "@graphql-markdown/types": ["./packages/types/src/index.d.ts"],
-      "@graphql-markdown/*": ["./packages/*/src/index.ts"]
+      "@graphql-markdown/types": ["../types/src/index.d.ts"],
+      "@graphql-markdown/*": ["../*/src/index.ts"]
     }
   },
 

--- a/packages/printer-legacy/src/printer.ts
+++ b/packages/printer-legacy/src/printer.ts
@@ -9,6 +9,7 @@
  */
 
 import type {
+  ConfigPrintTypeOptions,
   DeprecatedPrintTypeOptions,
   Formatter,
   GraphQLField,
@@ -22,6 +23,8 @@ import type {
   PrinterEventEmitter,
   PrinterInitOptions,
   PrintTypeOptions,
+  TypeHierarchyObjectType,
+  TypeHierarchyValueType,
 } from "@graphql-markdown/types";
 
 /**
@@ -122,6 +125,29 @@ const DEFAULT_INIT_OPTIONS = {
   customDirectives: undefined,
   groups: undefined,
   sectionHeaderId: true,
+};
+
+const normalizeHierarchy = (
+  hierarchy?: Maybe<ConfigPrintTypeOptions["hierarchy"]>,
+): TypeHierarchyObjectType | undefined => {
+  if (!hierarchy) {
+    return undefined;
+  }
+
+  if (typeof hierarchy !== "string") {
+    return hierarchy;
+  }
+
+  switch (hierarchy.toLowerCase() as TypeHierarchyValueType) {
+    case "entity":
+      return { entity: {} };
+    case "flat":
+      return { flat: {} };
+    case "api":
+      return { api: {} };
+    default:
+      return undefined;
+  }
 };
 
 /**
@@ -229,6 +255,7 @@ export class Printer implements IPrinter {
     linkRoot: Maybe<string> = "/",
     {
       customDirectives,
+      deprecated,
       groups,
       meta,
       metatags,
@@ -258,7 +285,9 @@ export class Printer implements IPrinter {
           printTypeOptions?.parentTypePrefix ??
           PRINT_TYPE_DEFAULT_OPTIONS.parentTypePrefix,
         deprecated:
-          printTypeOptions?.deprecated ?? PRINT_TYPE_DEFAULT_OPTIONS.deprecated,
+          printTypeOptions?.deprecated ??
+          deprecated ??
+          PRINT_TYPE_DEFAULT_OPTIONS.deprecated,
         schema,
         onlyDocDirectives: onlyDocDirectives ?? [],
         skipDocDirectives: skipDocDirectives ?? [],
@@ -267,7 +296,8 @@ export class Printer implements IPrinter {
           printTypeOptions?.typeBadges ?? PRINT_TYPE_DEFAULT_OPTIONS.typeBadges,
         metatags: metatags ?? [],
         hierarchy:
-          printTypeOptions?.hierarchy ?? PRINT_TYPE_DEFAULT_OPTIONS.hierarchy,
+          normalizeHierarchy(printTypeOptions?.hierarchy) ??
+          PRINT_TYPE_DEFAULT_OPTIONS.hierarchy,
         meta: meta,
         // Merge formatter functions: default formatter with any overrides
         ...createDefaultFormatter(),

--- a/packages/printer-legacy/src/printer.ts
+++ b/packages/printer-legacy/src/printer.ts
@@ -9,24 +9,19 @@
  */
 
 import type {
-  CustomDirectiveMap,
   DeprecatedPrintTypeOptions,
   Formatter,
-  GraphQLDirective,
   GraphQLField,
   GraphQLSchema,
   IPrinter,
   Maybe,
   MDXString,
-  MetaInfo,
   PageHeader,
   PageSection,
   PageSections,
-  PrinterConfigPrintTypeOptions,
   PrinterEventEmitter,
+  PrinterInitOptions,
   PrintTypeOptions,
-  SchemaEntitiesGroupMap,
-  TypeDeprecatedOption,
 } from "@graphql-markdown/types";
 
 /**
@@ -128,13 +123,6 @@ const DEFAULT_INIT_OPTIONS = {
   groups: undefined,
   sectionHeaderId: true,
 };
-
-type InitPrintTypeOptions = DeprecatedPrintTypeOptions &
-  Omit<PrinterConfigPrintTypeOptions, "exampleSection"> & {
-    exampleSection?:
-      | DeprecatedPrintTypeOptions["exampleSection"]
-      | PrinterConfigPrintTypeOptions["exampleSection"];
-  };
 
 /**
  * The Printer class implements the core functionality for generating Markdown documentation
@@ -248,17 +236,7 @@ export class Printer implements IPrinter {
       printTypeOptions,
       skipDocDirectives,
       sectionHeaderId,
-    }: {
-      customDirectives?: CustomDirectiveMap;
-      deprecated?: TypeDeprecatedOption;
-      groups?: SchemaEntitiesGroupMap;
-      meta?: Maybe<MetaInfo>;
-      metatags?: Record<string, string>[];
-      onlyDocDirectives?: GraphQLDirective[];
-      printTypeOptions?: InitPrintTypeOptions;
-      skipDocDirectives?: GraphQLDirective[];
-      sectionHeaderId?: boolean;
-    } = DEFAULT_INIT_OPTIONS,
+    }: PrinterInitOptions = DEFAULT_INIT_OPTIONS,
     formatter?: Partial<Formatter>,
     mdxDeclaration?: Maybe<string>,
     eventEmitter?: Maybe<PrinterEventEmitter>,

--- a/packages/printer-legacy/tests/unit/printer.test.ts
+++ b/packages/printer-legacy/tests/unit/printer.test.ts
@@ -322,6 +322,28 @@ describe("Printer", () => {
       expect(Printer.options!.sectionHeaderId).toBe(false);
     });
 
+    test.each([
+      ["entity", { entity: {} }],
+      ["flat", { flat: {} }],
+      ["api", { api: {} }],
+      ["unknown", DEFAULT_OPTIONS.hierarchy],
+    ])(
+      "normalizes hierarchy value %s during initialization",
+      async (hierarchy, expectedHierarchy) => {
+        expect.hasAssertions();
+
+        Printer.options = undefined;
+
+        await Printer.init(undefined, undefined, undefined, {
+          printTypeOptions: {
+            hierarchy: hierarchy as "api",
+          },
+        });
+
+        expect(Printer.options!.hierarchy).toEqual(expectedHierarchy);
+      },
+    );
+
     test("uses top-level deprecated option when printTypeOptions.deprecated is unset", async () => {
       expect.hasAssertions();
 

--- a/packages/printer-legacy/tests/unit/printer.test.ts
+++ b/packages/printer-legacy/tests/unit/printer.test.ts
@@ -321,6 +321,33 @@ describe("Printer", () => {
 
       expect(Printer.options!.sectionHeaderId).toBe(false);
     });
+
+    test("uses top-level deprecated option when printTypeOptions.deprecated is unset", async () => {
+      expect.hasAssertions();
+
+      Printer.options = undefined;
+
+      await Printer.init(undefined, undefined, undefined, {
+        deprecated: "group",
+      });
+
+      expect(Printer.options!.deprecated).toBe("group");
+    });
+
+    test("prefers printTypeOptions.deprecated over top-level deprecated option", async () => {
+      expect.hasAssertions();
+
+      Printer.options = undefined;
+
+      await Printer.init(undefined, undefined, undefined, {
+        deprecated: "group",
+        printTypeOptions: {
+          deprecated: "skip",
+        },
+      });
+
+      expect(Printer.options!.deprecated).toBe("skip");
+    });
   });
 
   describe("printHeader()", () => {

--- a/packages/printer-legacy/tsconfig.json
+++ b/packages/printer-legacy/tsconfig.json
@@ -15,7 +15,6 @@
   },
 
   "references": [
-    { "path": "../core" },
     { "path": "../graphql" },
     { "path": "../utils" }
   ]

--- a/packages/types/src/core.d.ts
+++ b/packages/types/src/core.d.ts
@@ -253,8 +253,6 @@ export interface ConfigOptions {
   onlyDocDirective?: Maybe<DirectiveName | DirectiveName[]>;
   /** Use prettier to make the output pretty */
   pretty?: Maybe<boolean>;
-  /** Printer module to use for generating output */
-  printer?: Maybe<PackageName>;
   /** Options for printing GraphQL types */
   printTypeOptions?: Maybe<ConfigPrintTypeOptions>;
   /** Root path for the project */
@@ -376,7 +374,6 @@ export type Options = Omit<
       | "docOptions"
       | "metatags"
       | "onlyDocDirective"
-      | "printer"
       | "printTypeOptions"
       | "skipDocDirective"
     > & {

--- a/packages/types/src/printer.d.ts
+++ b/packages/types/src/printer.d.ts
@@ -316,6 +316,26 @@ export type PrintDirectiveOptions = Partial<PrintTypeOptions> &
   Pick<PrintTypeOptions, "basePath" | "deprecated" | "parentTypePrefix">;
 
 /**
+ * Options accepted by printer initialization.
+ */
+export type PrinterInitOptions = {
+  customDirectives?: CustomDirectiveMap;
+  deprecated?: TypeDeprecatedOption;
+  groups?: SchemaEntitiesGroupMap;
+  meta?: Maybe<MetaInfo>;
+  metatags?: Record<string, string>[];
+  onlyDocDirectives?: GraphQLDirective[];
+  printTypeOptions?: DeprecatedPrintTypeOptions &
+    Omit<PrinterConfigPrintTypeOptions, "exampleSection"> & {
+      exampleSection?:
+        | DeprecatedPrintTypeOptions["exampleSection"]
+        | PrinterConfigPrintTypeOptions["exampleSection"];
+    };
+  skipDocDirectives?: GraphQLDirective[];
+  sectionHeaderId?: boolean;
+};
+
+/**
  * Abstract printer class that handles the generation of markdown documentation
  * from GraphQL schema components.
  * @public
@@ -334,9 +354,9 @@ export abstract class IPrinter {
    */
   static init(
     schema: Maybe<GraphQLSchema>,
-    baseURL: string,
-    linkRoot: string,
-    options: Maybe<PrinterOptions>,
+    baseURL?: Maybe<string>,
+    linkRoot?: Maybe<string>,
+    options?: PrinterInitOptions,
     mdxModule?: Partial<Formatter>,
     mdxDeclaration?: Maybe<string>,
     eventEmitter?: Maybe<PrinterEventEmitter>,
@@ -352,7 +372,7 @@ export abstract class IPrinter {
   static printHeader(
     id: string,
     title: string,
-    options: PrinterConfig & PrinterOptions,
+    options: PrintTypeOptions,
   ): string;
 
   /**
@@ -364,9 +384,9 @@ export abstract class IPrinter {
    */
   static printDescription(
     type: unknown,
-    options: PrinterConfig & PrinterOptions,
-    noText: string,
-  ): string;
+    options: PrintTypeOptions,
+    noText?: string,
+  ): MDXString | string;
 
   /**
    * Prints the code representation of a GraphQL type
@@ -376,7 +396,7 @@ export abstract class IPrinter {
    */
   static printCode(
     type: unknown,
-    options: PrinterConfig & PrinterOptions,
+    options: PrintTypeOptions,
   ): string;
 
   /**
@@ -387,8 +407,8 @@ export abstract class IPrinter {
    */
   static printCustomDirectives(
     type: unknown,
-    options: PrinterConfig & PrinterOptions,
-  ): MDXString;
+    options: PrintTypeOptions,
+  ): Maybe<PageSection>;
 
   /**
    * Prints custom tags associated with a type
@@ -398,8 +418,8 @@ export abstract class IPrinter {
    */
   static printCustomTags(
     type: unknown,
-    options: PrinterConfig & PrinterOptions,
-  ): MDXString;
+    options: PrintTypeOptions,
+  ): MDXString | string;
 
   /**
    * Prints metadata information for a type
@@ -409,8 +429,8 @@ export abstract class IPrinter {
    */
   static printTypeMetadata(
     type: unknown,
-    options: PrinterConfig & PrinterOptions,
-  ): MDXString;
+    options: PrintTypeOptions,
+  ): Maybe<PageSection | PageSection[]>;
 
   /**
    * Prints related types and their relationships
@@ -420,8 +440,8 @@ export abstract class IPrinter {
    */
   static printRelations(
     type: unknown,
-    options: PrinterConfig & PrinterOptions,
-  ): MDXString;
+    options: PrintTypeOptions,
+  ): MDXString | string;
 
   /**
    * Prints complete documentation for a GraphQL type
@@ -431,17 +451,11 @@ export abstract class IPrinter {
    * @returns Promise resolving to MDX string containing complete type documentation
    */
   static printType(
-    name: string,
+    name: Maybe<string>,
     type: unknown,
     options?: Maybe<Partial<PrintTypeOptions>>,
   ): Promise<Maybe<MDXString>>;
 }
-
-/**
- * Type representing the static side of IPrinter class
- * Used for type-safe access to static printer methods
- */
-export type Printer = typeof IPrinter;
 
 /**
  * Basic printer configuration

--- a/packages/types/src/printer.d.ts
+++ b/packages/types/src/printer.d.ts
@@ -319,20 +319,15 @@ export type PrintDirectiveOptions = Partial<PrintTypeOptions> &
  * Options accepted by printer initialization.
  */
 export type PrinterInitOptions = {
-  customDirectives?: CustomDirectiveMap;
-  deprecated?: TypeDeprecatedOption;
-  groups?: SchemaEntitiesGroupMap;
+  customDirectives?: Maybe<CustomDirectiveMap>;
+  deprecated?: Maybe<TypeDeprecatedOption>;
+  groups?: Maybe<SchemaEntitiesGroupMap>;
   meta?: Maybe<MetaInfo>;
-  metatags?: Record<string, string>[];
-  onlyDocDirectives?: GraphQLDirective[];
-  printTypeOptions?: DeprecatedPrintTypeOptions &
-    Omit<PrinterConfigPrintTypeOptions, "exampleSection"> & {
-      exampleSection?:
-        | DeprecatedPrintTypeOptions["exampleSection"]
-        | PrinterConfigPrintTypeOptions["exampleSection"];
-    };
-  skipDocDirectives?: GraphQLDirective[];
-  sectionHeaderId?: boolean;
+  metatags?: Maybe<Record<string, string>[]>;
+  onlyDocDirectives?: Maybe<GraphQLDirective[]>;
+  printTypeOptions?: Maybe<ConfigPrintTypeOptions>;
+  skipDocDirectives?: Maybe<GraphQLDirective[]>;
+  sectionHeaderId?: Maybe<boolean>;
 };
 
 /**


### PR DESCRIPTION
# Description

Now that event hooks are available, there's no need for a dynamic printer module.

This PR removes dynamic printer loading in core and makes printer wiring explicit and type-aligned.

- `@graphql-markdown/core` now statically uses `@graphql-markdown/printer-legacy` in `getPrinter`.
- `@graphql-markdown/printer-legacy` is now a direct dependency of `@graphql-markdown/core`.
- Redundant direct `@graphql-markdown/printer-legacy` dependency was removed from `@graphql-markdown/cli`.
- `tsconfig.test.json` path mappings were corrected in CLI and Docusaurus packages.
- Core printer initialization flow was simplified and normalized for options handling.
- Printer contracts in `@graphql-markdown/types` were aligned with the concrete `Printer` implementation (Printer is the source of truth).
- Core/generator/config/renderer and related unit tests were updated to match the static printer flow and updated typing.

No issue is linked from this PR.

Dependencies required for this change:
- `@graphql-markdown/printer-legacy` as a fixed/direct dependency of `@graphql-markdown/core`.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
