### PR TITLE
fix(cli): initialize logger before buildConfig

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,6 +49,7 @@ export const runGraphQLMarkdown = async (
   cliOptions: CliOptions,
   loggerModule?: string,
 ): Promise<void> => {
+  await Logger(loggerModule);
   const config = await buildConfig(options, cliOptions, options.id);
 
   if (cliOptions.config) {

--- a/packages/cli/tests/unit/index.test.ts
+++ b/packages/cli/tests/unit/index.test.ts
@@ -552,6 +552,26 @@ describe("CLI Module", () => {
       ).toHaveBeenCalled();
     });
 
+    test("initializes logger before buildConfig", async () => {
+      expect.assertions(2);
+
+      const callOrder: string[] = [];
+      require("@graphql-markdown/logger").mockImplementationOnce(async () => {
+        callOrder.push("Logger");
+      });
+      require("@graphql-markdown/core").buildConfig.mockImplementationOnce(
+        async (config: Options) => {
+          callOrder.push("buildConfig");
+          return config;
+        },
+      );
+
+      await runGraphQLMarkdown({ schema: "./schema.graphql" }, {});
+
+      expect(callOrder[0]).toBe("Logger");
+      expect(callOrder[1]).toBe("buildConfig");
+    });
+
     test("handles errors during documentation generation", async () => {
       expect.assertions(1);
 


### PR DESCRIPTION
# Description

Ensures the logger is initialized before `buildConfig()` runs in `runGraphQLMarkdown`. Without this, any `log()` calls inside `buildConfig` (e.g. deprecation warnings introduced by `feat/rename-mdxparser-to-formatter`) are silently dropped because `globalThis.logger` is not yet set at that point.

The second `Logger()` call inside `generateDocFromSchema` is a no-op since the guard `if (globalThis.logger?.instance && moduleName === undefined)` returns early once the logger is already initialized.

**Prerequisite for:** `feat/rename-mdxparser-to-formatter`

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.