### PR TITLE
fix: resolve SonarQube issues (S4325, S2699, S1135)

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -28,7 +28,6 @@ import type {
   ConfigPrintTypeOptions,
   CustomDirective,
   DirectiveName,
-  FrontMatterOptions,
   GroupByDirectiveOptions,
   Maybe,
   Options,
@@ -161,14 +160,13 @@ export const DEFAULT_OPTIONS: Readonly<
   id: "default" as const,
   baseURL: "schema" as const,
   customDirective: undefined,
-  diffMethod: DiffMethod.NONE as TypeDiffMethod,
+  diffMethod: DiffMethod.NONE,
   docOptions: {
     categorySort: undefined,
-    frontMatter: {} as FrontMatterOptions,
+    frontMatter: {},
     index: false as const,
     sectionHeaderId: true as const,
-  } as Pick<ConfigDocOptions, "categorySort"> &
-    Required<Pick<ConfigDocOptions, "frontMatter" | "index">>,
+  },
   force: false as const,
   groupByDirective: undefined,
   homepage: ASSET_HOMEPAGE_LOCATION,
@@ -177,7 +175,7 @@ export const DEFAULT_OPTIONS: Readonly<
   metatags: [] as Record<string, string>[],
   pretty: false as const,
   printTypeOptions: {
-    deprecated: DeprecatedOption.DEFAULT as TypeDeprecatedOption,
+    deprecated: DeprecatedOption.DEFAULT,
     exampleSection: undefined,
     parentTypePrefix: true as const,
     typeBadges: true as const,
@@ -188,7 +186,7 @@ export const DEFAULT_OPTIONS: Readonly<
     hierarchy: Required<Pick<TypeHierarchyObjectType, TypeHierarchy.API>>;
   },
   rootPath: "./docs" as const,
-  schema: "./schema.graphql" as Pointer,
+  schema: "./schema.graphql",
   tmpDir: join(tmpdir(), PACKAGE_NAME),
   skipDocDirective: [] as DirectiveName[],
   onlyDocDirective: [] as DirectiveName[],
@@ -845,5 +843,5 @@ export const buildConfig = async (
     schemaLocation,
     skipDocDirective,
     tmpDir,
-  } as Options;
+  };
 };

--- a/packages/core/src/generator.ts
+++ b/packages/core/src/generator.ts
@@ -96,11 +96,11 @@ export const loadMDXModule = async (
   mdxParser: Maybe<PackageName | string>,
 ): Promise<unknown> => {
   return mdxParser !== undefined && mdxParser !== null
-    ? import(mdxParser as string).catch((error: unknown) => {
+    ? import(mdxParser).catch((error: unknown) => {
         const errorMessage =
           error instanceof Error ? error.message : String(error);
         log(
-          `An error occurred while loading MDX formatter "${mdxParser as string}": ${errorMessage}`,
+          `An error occurred while loading MDX formatter "${mdxParser}": ${errorMessage}`,
           LogLevel.warn,
         );
         return undefined;

--- a/packages/core/src/graphql-config.ts
+++ b/packages/core/src/graphql-config.ts
@@ -192,7 +192,7 @@ export const loadConfiguration = async (
       }
     }
 
-    return projectConfig as Readonly<ExtensionProjectConfig>;
+    return projectConfig;
   } catch {
     return undefined;
   }

--- a/packages/core/src/options/builder.ts
+++ b/packages/core/src/options/builder.ts
@@ -165,7 +165,7 @@ export class OptionBuilder<T extends Record<string, unknown>> {
    * @returns The current value for the key, or `undefined` if not set
    */
   get<K extends keyof T>(key: K): T[K] | undefined {
-    const value = this.merged[key] as T[K] | undefined;
+    const value = this.merged[key];
     if (Array.isArray(value)) {
       return [...value] as T[K];
     }

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -728,7 +728,7 @@ export class Renderer {
       category,
       filePath,
       name,
-    } as Category;
+    };
   }
 
   /**

--- a/packages/core/tests/unit/config.test.ts
+++ b/packages/core/tests/unit/config.test.ts
@@ -1517,17 +1517,12 @@ describe("getVisibilityDirectives additional validation", () => {
   });
 
   test("error message exact format must be validated", () => {
-    expect.assertions(2);
-
-    const thrown = expect(() => {
+    expect(() => {
       getVisibilityDirectives(
         { only: ["@deprecated" as DirectiveName] },
         { skipDocDirective: ["@deprecated" as DirectiveName] },
       );
-    });
-
-    thrown.toThrow();
-    thrown.toThrow(
+    }).toThrow(
       "The same directive cannot be declared in 'onlyDocDirective' and 'skipDocDirective'.",
     );
   });

--- a/packages/graphql/src/introspection.ts
+++ b/packages/graphql/src/introspection.ts
@@ -74,9 +74,7 @@ export const getTypeFromSchema = <T>(
 
   const operationKinds: string[] = [];
   Object.values(OperationTypeNode).forEach((operationTypeNode) => {
-    const operationType = schema.getRootType(
-      operationTypeNode as OperationTypeNode,
-    );
+    const operationType = schema.getRootType(operationTypeNode);
     if (operationType) {
       operationKinds.push(operationType.name);
     }
@@ -256,14 +254,14 @@ export const getTypeDirectiveValues = (
 ): Maybe<Record<string, unknown>> => {
   if (hasAstNode(type)) {
     return getDirectiveValues(
-      directive as never,
+      directive,
       (type as GraphQLNamedType).astNode as {
         readonly directives?: readonly DirectiveNode[];
       },
     );
   }
   return getDirectiveValues(
-    directive as never,
+    directive,
     type as ASTNode as {
       readonly directives?: readonly DirectiveNode[];
     },

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -128,7 +128,7 @@ export const Logger = async (moduleName?: string): Promise<void> => {
     requestedLevel: LogLevel | keyof typeof LogLevel,
   ): ((...args: unknown[]) => unknown) | undefined => {
     if (hasLogMethod(instanceObj, requestedLevel)) {
-      return instanceObj[requestedLevel] as (...args: unknown[]) => unknown;
+      return instanceObj[requestedLevel];
     }
     if (hasLogMethod(instanceObj, LogLevel.info)) {
       return instanceObj[LogLevel.info] as (...args: unknown[]) => unknown;

--- a/packages/printer-legacy/src/badge.ts
+++ b/packages/printer-legacy/src/badge.ts
@@ -56,23 +56,23 @@ export const getTypeBadges = (
     badges.push({
       text: DEPRECATED,
       classname: CSS_BADGE_CLASSNAME.DEPRECATED,
-    } as Badge);
+    });
   }
 
   if (isNonNullType(rootType)) {
     badges.push({
       text: NON_NULL,
       classname: CSS_BADGE_CLASSNAME.NON_NULL,
-    } as Badge);
+    });
   }
 
   if (isListType(rootType)) {
-    badges.push({ text: "list" } as Badge);
+    badges.push({ text: "list" });
   }
 
   const category = getCategoryLocale(getNamedType(rootType));
   if (category) {
-    badges.push({ text: category } as Badge);
+    badges.push({ text: category });
   }
 
   if (groups) {
@@ -81,7 +81,7 @@ export const getTypeBadges = (
     ) as SchemaEntity;
     const group = getGroup(rootType, groups, typeCategory);
     if (group && group !== "") {
-      badges.push({ text: group } as Badge);
+      badges.push({ text: group });
     }
   }
 
@@ -127,7 +127,7 @@ export const formatBadges = (
     .map((badge) => {
       return printBadge(badge, options);
     })
-    .join(" ") as MDXString;
+    .join(" ");
 };
 
 /**

--- a/packages/printer-legacy/src/common.ts
+++ b/packages/printer-legacy/src/common.ts
@@ -102,7 +102,7 @@ export const printWarning = (
   return options.formatMDXAdmonition!(
     { text: formattedText, type: "warning", icon: "⚠️", title },
     options.meta,
-  ) as string;
+  );
 };
 
 /**

--- a/packages/printer-legacy/src/const/options.ts
+++ b/packages/printer-legacy/src/const/options.ts
@@ -1,6 +1,5 @@
 import type {
   CollapsibleOption,
-  FrontMatterOptions,
   GraphQLDirective,
   GraphQLSchema,
   Maybe,
@@ -97,7 +96,7 @@ export const DEFAULT_OPTIONS: Required<
   customDirectives: {} as const,
   exampleSection: undefined,
   groups: undefined,
-  frontMatter: {} as FrontMatterOptions,
+  frontMatter: {},
   level: undefined,
   metatags: PRINT_TYPE_DEFAULT_OPTIONS.metatags,
   onlyDocDirectives: [] as const,

--- a/packages/printer-legacy/src/example.ts
+++ b/packages/printer-legacy/src/example.ts
@@ -72,7 +72,7 @@ export const getDirectiveExampleOption = ({
     directive,
     field: argName,
     parser: parserFunc,
-  } as TypeDirectiveExample;
+  };
 };
 
 /**

--- a/packages/printer-legacy/src/frontmatter.ts
+++ b/packages/printer-legacy/src/frontmatter.ts
@@ -29,5 +29,5 @@ export const printFrontMatter = (
     return "";
   }
 
-  return options.formatMDXFrontmatter(props, frontMatter) as string;
+  return options.formatMDXFrontmatter(props, frontMatter);
 };

--- a/packages/printer-legacy/src/link.ts
+++ b/packages/printer-legacy/src/link.ts
@@ -6,7 +6,6 @@
 
 import type {
   ApiGroupOverrideType,
-  GraphQLNamedType,
   MDXString,
   Maybe,
   PrintLinkOptions,
@@ -356,7 +355,7 @@ export const printLinkAttributes = (
   }
 
   if (!isLeafType(type) && "ofType" in type && type.ofType !== undefined) {
-    text = printLinkAttributes(type.ofType as GraphQLNamedType, text);
+    text = printLinkAttributes(type.ofType, text);
   }
 
   if (isListType(type)) {

--- a/packages/printer-legacy/src/printer.ts
+++ b/packages/printer-legacy/src/printer.ts
@@ -11,12 +11,10 @@
 import type {
   ConfigPrintTypeOptions,
   Formatter,
-  GraphQLField,
   GraphQLSchema,
   IPrinter,
   Maybe,
   MDXString,
-  PageHeader,
   PageSection,
   PageSections,
   PrinterEventEmitter,
@@ -466,10 +464,7 @@ export class Printer implements IPrinter {
       case isDirectiveType(type):
         return printDirectiveMetadata(type, options);
       case isOperation(type):
-        return printOperationMetadata(
-          type as unknown as GraphQLField<unknown, unknown, unknown>,
-          options,
-        );
+        return printOperationMetadata(type, options);
       default:
         return undefined;
     }
@@ -589,8 +584,7 @@ export class Printer implements IPrinter {
 
     // Generate all sections unconditionally so that BEFORE_COMPOSE_PAGE_TYPE hooks
     // can add, remove, or reorder them at will.
-    // TODO(perf): Implement lazy section generation when no BEFORE_COMPOSE_PAGE_TYPE
-    // listeners are registered.
+    // See: https://github.com/graphql-markdown/graphql-markdown/issues/2954
     const code = await Printer.printCodeAsync(type, name, printTypeOptions);
 
     const customDirectives = Printer.printCustomDirectives(
@@ -604,9 +598,9 @@ export class Printer implements IPrinter {
 
     // Create sections map for composition events
     const sections: PageSections = {
-      header: { content: header } as PageHeader,
-      metatags: { content: metatags } as PageHeader,
-      mdxDeclaration: { content: Printer.mdxDeclaration ?? "" } as PageHeader,
+      header: { content: header },
+      metatags: { content: metatags },
+      mdxDeclaration: { content: Printer.mdxDeclaration ?? "" },
       tags: Printer.normalizePageSection(tags),
       description: Printer.normalizePageSection(description),
       code: Printer.normalizePageSection(code),
@@ -779,7 +773,7 @@ export class Printer implements IPrinter {
     }
 
     if (typeof section === "string" || Array.isArray(section)) {
-      return { content: section } as PageSection;
+      return { content: section };
     }
 
     return section;

--- a/packages/printer-legacy/src/relation.ts
+++ b/packages/printer-legacy/src/relation.ts
@@ -117,7 +117,7 @@ export const printRelationOf = <T>(
     })
     .join(options.formatMDXBullet!()) as MDXString;
 
-  return `${SectionLevels.LEVEL.repeat(3)} ${section}${MARKDOWN_EOP}${content}${MARKDOWN_EOP}` as MDXString;
+  return `${SectionLevels.LEVEL.repeat(3)} ${section}${MARKDOWN_EOP}${content}${MARKDOWN_EOP}`;
 };
 
 /**
@@ -149,5 +149,5 @@ export const printRelations = (
       return printRelationOf(type, section, getRelation, options);
     },
   );
-  return relationResults.join("") as MDXString;
+  return relationResults.join("");
 };

--- a/packages/printer-legacy/src/section.ts
+++ b/packages/printer-legacy/src/section.ts
@@ -93,7 +93,7 @@ export const printSectionItem = <T>(
     });
   }
 
-  return section as MDXString;
+  return section;
 };
 
 /**
@@ -124,7 +124,7 @@ export const printSectionItems = <V>(
     });
   });
 
-  return items.join(MARKDOWN_EOP) as MDXString;
+  return items.join(MARKDOWN_EOP);
 };
 
 /**
@@ -155,9 +155,7 @@ export const printSection = <V>(
       typeof options.collapsible?.dataOpen === "string" &&
       typeof options.collapsible.dataClose === "string"
     ) {
-      return options.formatMDXDetails!(options.collapsible).split(
-        `\r`,
-      ) as MDXString[];
+      return options.formatMDXDetails!(options.collapsible).split(`\r`);
     }
     return ["", MARKDOWN_EOP];
   })();


### PR DESCRIPTION
# Description

Fix all 38 open SonarQube issues reported at https://sonarcloud.io/organizations/graphql-markdown/projects across 4 packages.

## Changes

**typescript:S2699 — Test with no assertion (BLOCKER, 1 occurrence)**
- `packages/core/tests/unit/config.test.ts`: Inline `expect(() => {...}).toThrow()` chain directly instead of storing the `expect(fn)` call in a variable, which SonarQube did not recognize as an assertion.

**typescript:S4325 — Unnecessary type assertions (MINOR, 36 occurrences)**
Remove redundant casts where the receiver already accepts the original type:
- `packages/core`: config.ts, generator.ts, graphql-config.ts, options/builder.ts, renderer.ts
- `packages/graphql`: introspection.ts (incl. obsolete `as never` hacks for older graphql-js API)
- `packages/logger`: index.ts
- `packages/printer-legacy`: badge.ts, common.ts, const/options.ts, example.ts, frontmatter.ts, link.ts, printer.ts, relation.ts, section.ts

**typescript:S1135 — TODO comment (INFO, 1 occurrence)**
- `packages/printer-legacy/src/printer.ts`: Replace TODO with reference to tracking issue #2954.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.