### PR TITLE
fix: add missing formatters package to tsconfig.json references

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "packages/core" },
     { "path": "packages/diff" },
     { "path": "packages/docusaurus" },
+    { "path": "packages/formatters" },
     { "path": "packages/graphql" },
     { "path": "packages/helpers" },
     { "path": "packages/logger" },


### PR DESCRIPTION
## Summary

`packages/formatters` was absent from the root `tsconfig.json` project references array, causing `bun run ts:check` to silently skip type-checking the formatters package from the repository root.

## Change

- `tsconfig.json`: add `{ "path": "packages/formatters" }` in alphabetical position

## Why it matters

TypeScript project references define the build and type-check graph. Missing a package means CI has a blind spot on all type errors in `@graphql-markdown/formatters`.