### PR TITLE
improve: optimize turbo task dependencies and cache inputs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "packages/core" },
     { "path": "packages/diff" },
     { "path": "packages/docusaurus" },
+    { "path": "packages/formatters" },
     { "path": "packages/graphql" },
     { "path": "packages/helpers" },
     { "path": "packages/logger" },

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://turborepo.org/schema.json",
+  "globalDependencies": [
+    "bun.lock",
+    "tsconfig.base.json",
+    "package.json"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
@@ -42,17 +47,38 @@
     "test:unit": {
       "dependsOn": ["^build"],
       "outputs": ["coverage/**"],
-      "inputs": ["src/**/*.ts", "tests/unit/**/*.ts", "tests/__mocks__/**/*.ts", "tsconfig*.json"]
+      "inputs": [
+        "src/**/*.ts",
+        "tests/unit/**/*.ts",
+        "tests/__mocks__/**/*.ts",
+        "tsconfig*.json",
+        "jest.config.mjs",
+        "package.json"
+      ]
     },
     "test:integration": {
       "dependsOn": ["^build"],
       "outputs": ["coverage/**"],
-      "inputs": ["src/**/*.ts", "tests/integration/**/*.ts", "tests/__mocks__/**/*.ts", "tsconfig*.json"]
+      "inputs": [
+        "src/**/*.ts",
+        "tests/integration/**/*.ts",
+        "tests/__mocks__/**/*.ts",
+        "tsconfig*.json",
+        "jest.config.mjs",
+        "package.json"
+      ]
     },
     "test:ci": {
       "dependsOn": ["^build"],
       "outputs": ["coverage/**"],
-      "inputs": ["src/**/*.ts", "tests/**/*.ts", "tests/__mocks__/**/*.ts", "tsconfig*.json"]
+      "inputs": [
+        "src/**/*.ts",
+        "tests/**/*.ts",
+        "tests/__mocks__/**/*.ts",
+        "tsconfig*.json",
+        "jest.config.mjs",
+        "package.json"
+      ]
     },
     "test:watch": {
       "cache": false,

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,8 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "inputs": ["src/**/*.ts", "tsconfig*.json", "package.json"]
     },
     "clean": {
       "cache": false
@@ -18,7 +19,8 @@
       "outputs": ["docs/**"]
     },
     "lint": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "inputs": ["src/**/*.ts", "tests/**/*.ts", "package.json"]
     },
     "lint:fix": {
       "dependsOn": ["^build"],
@@ -29,24 +31,28 @@
       "cache": false
     },
     "ts:check": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "inputs": ["src/**/*.ts", "tests/**/*.ts", "tsconfig*.json"]
     },
     "test": {
-      "dependsOn": ["lint"],
+      "dependsOn": ["^build"],
       "outputs": ["coverage/**"],
       "cache": false
     },
     "test:unit": {
-      "dependsOn": ["lint"],
-      "outputs": ["coverage/**"]
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"],
+      "inputs": ["src/**/*.ts", "tests/unit/**/*.ts", "tests/__mocks__/**/*.ts", "tsconfig*.json"]
     },
     "test:integration": {
-      "dependsOn": ["lint"],
-      "outputs": ["coverage/**"]
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"],
+      "inputs": ["src/**/*.ts", "tests/integration/**/*.ts", "tests/__mocks__/**/*.ts", "tsconfig*.json"]
     },
     "test:ci": {
-      "dependsOn": ["lint"],
-      "outputs": ["coverage/**"]
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"],
+      "inputs": ["src/**/*.ts", "tests/**/*.ts", "tests/__mocks__/**/*.ts", "tsconfig*.json"]
     },
     "test:watch": {
       "cache": false,


### PR DESCRIPTION
## Summary

Two independent Turbo configuration improvements for better parallelism and caching.

## Changes

### 1. Decouple tests from lint

Test tasks (`test`, `test:unit`, `test:integration`, `test:ci`) previously depended on `lint`, which itself depends on `^build`. This forced a fully sequential chain: **build → lint → tests**.

Tests only need upstream packages to be built (`^build`), not a passing lint result.

**Before:** `turbo run test lint` → build, then lint, then test (sequential)
**After:** `turbo run test lint` → build, then lint **and** tests in parallel

### 2. Add precise cache inputs

Without explicit `inputs`, Turbo hashes all workspace files for cache validity. Adding per-task input lists means:
- Changing integration tests no longer invalidates the unit test cache
- Changing only source files doesn't bust test caches unless those files are in scope

| Task | Changes |
|------|---------|
| `build` | + inputs |
| `lint` | + inputs |
| `ts:check` | + inputs |
| `test` | `dependsOn`: lint → ^build |
| `test:unit` | `dependsOn`: lint → ^build, + inputs |
| `test:integration` | `dependsOn`: lint → ^build, + inputs |
| `test:ci` | `dependsOn`: lint → ^build, + inputs |