### PR TITLE
improve: centralise CI setup in composite action and pin Bun version

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,28 @@
+name: Setup environment
+description: Checkout repository, install Node.js, Bun 1.3.2, and project dependencies
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout Code Base
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Setup NodeJS LTS
+      uses: actions/setup-node@v6
+      with:
+        node-version: "lts/*"
+
+    - name: Install safe-chain
+      shell: bash
+      run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: "1.3.2"
+
+    - name: Install modules
+      shell: bash
+      run: bun ci

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,14 +1,9 @@
 name: Setup environment
-description: Checkout repository, install Node.js, Bun 1.3.2, and project dependencies
+description: Install Node.js, Bun 1.3.2, and project dependencies
 
 runs:
   using: composite
   steps:
-    - name: Checkout Code Base
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-
     - name: Setup NodeJS LTS
       uses: actions/setup-node@v6
       with:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -11,7 +11,7 @@ runs:
 
     - name: Install safe-chain
       shell: bash
-      run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+      run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh | sh -s -- --ci
 
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout Code Base
+        uses: actions/checkout@v6
+
       - name: Setup environment
         uses: ./.github/actions/setup
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,22 +23,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Code Base
-        uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "lts/*"
-
-      - name: Install safe-chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "latest"
-
-      - name: Install modules
-        run: bun ci
+      - name: Setup environment
+        uses: ./.github/actions/setup
 
       - name: Run TS Check
         run: bun run ts:check

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -47,22 +47,8 @@ jobs:
           ]
 
     steps:
-      - name: Checkout Code Base
-        uses: actions/checkout@v6
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "lts/*"
-
-      - name: Install safe-chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "latest"
-
-      - name: Install modules
-        run: bun ci
+      - name: Setup environment
+        uses: ./.github/actions/setup
 
       - name: Cache turbo build setup
         uses: actions/cache@v5

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -47,6 +47,9 @@ jobs:
           ]
 
     steps:
+      - name: Checkout Code Base
+        uses: actions/checkout@v6
+
       - name: Setup environment
         uses: ./.github/actions/setup
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,11 @@ jobs:
           ]
 
     steps:
+      - name: Checkout Code Base
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Setup environment
         uses: ./.github/actions/setup
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,26 +39,8 @@ jobs:
           ]
 
     steps:
-      - name: Checkout Code Base
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup NodeJS LTS
-        uses: actions/setup-node@v6
-        with:
-          node-version: "lts/*"
-
-      - name: Install safe-chain
-        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "latest"
-
-      - name: Install modules
-        run: bun ci
+      - name: Setup environment
+        uses: ./.github/actions/setup
 
       - name: Cache turbo build setup
         uses: actions/cache@v5

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "docs": "turbo run docs",
     "docs:api": "turbo run docs:api:root",
     "docs:api:root": "node ./packages/tooling-config/scripts/docs-api.mjs",
-    "fallow": "fallow",
+    "fallow": "bunx fallow",
     "knip": "knip --strict",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "docs": "turbo run docs",
     "docs:api": "turbo run docs:api:root",
     "docs:api:root": "node ./packages/tooling-config/scripts/docs-api.mjs",
+    "fallow": "fallow",
     "knip": "knip --strict",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint:fix",


### PR DESCRIPTION
## Summary

Three related CI/DX improvements grouped by their shared theme: reducing duplication and increasing reliability in the CI setup.

## Changes

### 1. Reusable composite action (`.github/actions/setup/action.yml`)

The same 5-step setup sequence (checkout, Node LTS, safe-chain, Bun, `bun ci`) was repeated verbatim in `test.yml`, `mutation.yml`, and `linter.yml`. Extracted into a composite action — each workflow now uses a single `uses: ./.github/actions/setup` step.

**Benefit:** CI setup is maintained in one place. Updating the Node version, Bun version, or safe-chain install command requires changing a single file.

### 2. Pin Bun version to 1.3.2

All three workflows used `bun-version: "latest"` while `package.json` declares `"packageManager": "bun@1.3.2"`. A silent Bun upgrade in CI could break `bun.lock` resolution or introduce unexpected runtime behaviour. The composite action now pins to `1.3.2`.

### 3. Add `fallow` npm script

The repo has a maintained `.fallowrc.jsonc` config for `fallow` (unused import analysis) but no npm script. Added `"fallow": "fallow"` to root `package.json` so it can be run locally with `bun run fallow`.

## Files changed

| File | Change |
|------|--------|
| `.github/actions/setup/action.yml` | new composite action |
| `.github/workflows/test.yml` | use composite action |
| `.github/workflows/mutation.yml` | use composite action |
| `.github/workflows/linter.yml` | use composite action |
| `package.json` | add `fallow` script |