### PR TITLE
🐛 fix(ci): restrict linter and mutation workflows to pull_request only

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,16 +6,6 @@ env:
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches:
-      - main
-    paths:
-      - "packages/**/*"
-      - "packages/tooling-config/**/*"
-      - "config/**/*"
-      - "*.json"
-      - "*.mjs"
-      - ".github/workflows/linter.yml"
 
 jobs:
   lint:
@@ -44,13 +34,7 @@ jobs:
         run: bun run knip --no-config-hints --reporter github-actions
 
       - name: Fetch base branch for fallow
-        if: github.event_name == 'pull_request'
         run: git fetch --no-tags origin "${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
 
       - name: Run fallow
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            bun run fallow -- audit --base "origin/${GITHUB_BASE_REF}"
-          else
-            bun run fallow
-          fi
+        run: bun run fallow -- audit --base "origin/${GITHUB_BASE_REF}"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -44,9 +44,13 @@ jobs:
         run: bun run knip --no-config-hints --reporter github-actions
 
       - name: Fetch base branch for fallow
-        run: |
-          BASE_REF="${GITHUB_BASE_REF:-main}"
-          git fetch --no-tags origin "${BASE_REF}:${BASE_REF}"
+        if: github.event_name == 'pull_request'
+        run: git fetch --no-tags origin "${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
 
       - name: Run fallow
-        run: bun run fallow -- audit --base "${GITHUB_BASE_REF:-main}"
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            bun run fallow -- audit --base "origin/${GITHUB_BASE_REF}"
+          else
+            bun run fallow
+          fi

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -7,18 +7,6 @@ env:
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches:
-      - main
-    paths:
-      - "packages/**/src/**/*"
-      - "packages/**/tests/**/*"
-      - "packages/**/package.json"
-      - "packages/**/stryker.conf.mjs"
-      - "packages/tooling-config/**/*"
-      - "bun.lock"
-      - "package.json"
-      - ".github/workflows/mutation.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
# Description

On `push` events to `main`, `GITHUB_BASE_REF` is empty. The `fallow audit` step defaulted to `main` as base and then tried to fetch `main:main` into the already-checked-out `main` branch — which git refuses.

The same redundancy applies to mutation tests: code only reaches `main` after passing PR checks, so re-running linting and mutation tests on every push to `main` adds no value.

Changes:
- `linter.yml`: removed `push` trigger; linter now runs on `pull_request` only. Fallow steps simplified (always PR context, `GITHUB_BASE_REF` always set).
- `mutation.yml`: removed `push` trigger; mutation tests now run on `pull_request` only.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.