### PR TITLE
📝 docs: clarify formatter entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,23 @@
 
 # GraphQL-Markdown
 
-Generate **Markdown documentation** from **GraphQL schemas** for static site generators.
+Generate **Markdown and MDX documentation** from **GraphQL schemas** for Docusaurus and other supported documentation ecosystems.
 
 ## Installation
 
-Choose your preferred package based on your static site generator:
+GraphQL-Markdown supports two main setup paths:
+
+- use the official Docusaurus integration for Docusaurus sites
+- use the CLI with formatter presets for other supported ecosystems such as Hugo, MkDocs, DocFX, and mdBook
+
+Choose your preferred package based on your documentation stack:
 
 ```shell
-# For Docusaurus
+# For Docusaurus sites
 npm install @graphql-markdown/docusaurus graphql
 
-# For other static site generators
-npm install @graphql-markdown/cli graphql
+# For formatter-based setups
+npm install @graphql-markdown/cli @graphql-markdown/formatters graphql
 ```
 
 ## Usage
@@ -45,13 +50,27 @@ npx docusaurus graphql-to-doc
 
 ### CLI Usage
 
+Use the CLI directly for custom workflows, or pair it with `@graphql-markdown/formatters` to adapt the generated output for supported frameworks.
+
 ```shell
 npx gqlmd graphql-to-doc --schema ./schema.graphql --output ./docs
+```
+
+For formatter-based setups:
+
+```yaml
+schema: ./schema.graphql
+extensions:
+  graphql-markdown:
+    rootPath: ./docs
+    baseURL: api
+    formatter: "@graphql-markdown/formatters/hugo"
 ```
 
 ### API Usage
 
 For programmatic usage, you can use the CLI package:
+
 ```typescript
 import { runGraphQLMarkdown } from '@graphql-markdown/cli';
 
@@ -63,7 +82,7 @@ const config = {
 await runGraphQLMarkdown(config);
 ```
 
-See [API documentation](https://graphql-markdown.dev/api/) and our [Framework Integration page](https://graphql-markdown.dev/docs/advanced/integration-with-frameworks) for more details.
+See [API documentation](https://graphql-markdown.dev/api/) and our [Framework Integration page](https://graphql-markdown.dev/docs/advanced/integration-with-frameworks) for the full list of supported formatter presets.
 
 ## Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,7 +11,7 @@ keywords:
 
 # Configuration
 
-GraphQL-Markdown supports three configuration methods. Later entries in this list take precedence over earlier ones.
+GraphQL-Markdown supports three configuration methods. Use GraphQL Config for framework-agnostic setups, use Docusaurus plugin options for Docusaurus sites, and use CLI flags when you need temporary overrides. Later entries in this list take precedence over earlier ones.
 
 ## Framework-agnostic Configuration
 
@@ -30,6 +30,7 @@ extensions:
     linkRoot: "/examples/default"
     baseURL: "."
     homepage: "data/anilist.md"
+    formatter: "@graphql-markdown/formatters/hugo"
     loaders:
       UrlLoader:
         module: "@graphql-tools/url-loader"
@@ -38,6 +39,8 @@ extensions:
     printTypeOptions:
       deprecated: "group"
 ```
+
+For supported formatter presets, see [Integration with Frameworks](/docs/advanced/integration-with-frameworks).
 
 ## Docusaurus Integration
 
@@ -111,5 +114,6 @@ For any framework, you can use CLI flags to temporarily override settings withou
 :::
 
 **Current limitations:**
+
 - Single schema only, no schema stitching
 - `include`, `exclude`, `documents` and glob pattern are not supported

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 30
-description: Quick start guide for installing and configuring GraphQL-Markdown with Docusaurus. Generate documentation from your GraphQL schema in minutes.
+description: Quick start guide for installing and configuring GraphQL-Markdown with Docusaurus, plus the right entry point for formatter-based setups.
 keywords:
   - GraphQL-Markdown installation
   - Docusaurus setup
@@ -13,13 +13,26 @@ keywords:
 
 :::info
 
-While GraphQL-Markdown was initially developed as a Docusaurus plugin, it now supports various MDX documentation generators. This guide focuses on the Docusaurus integration - for other frameworks, please see our [Framework Integration Guide](/docs/advanced/integration-with-frameworks).
+GraphQL-Markdown supports two main setup paths:
+
+- the official Docusaurus integration for Docusaurus sites
+- the CLI with formatter presets for other supported documentation ecosystems
+
+This guide focuses on the Docusaurus path. If you are using Hugo, MkDocs, DocFX, mdBook, or another supported formatter-based setup, start with our [Framework Integration Guide](/docs/advanced/integration-with-frameworks).
 
 :::
 
-Get started by [creating a new site](#new-docusaurus-site).
+If you are setting up Docusaurus, get started by [creating a new site](#new-docusaurus-site).
 
 Or try GraphQL-Markdown immediately with our [demo](/docs/try-it).
+
+If you are not using Docusaurus, install the CLI and formatter presets:
+
+```shell title="shell"
+npm install @graphql-markdown/cli @graphql-markdown/formatters graphql
+```
+
+Then continue with [Integration with Frameworks](/docs/advanced/integration-with-frameworks) to choose the preset for your documentation stack.
 
 ## New Docusaurus site
 
@@ -84,7 +97,7 @@ The `npm run start` command builds your website locally and serves it through a 
 
 :::note
 
-These requirements are specific to Docusaurus integration. See our [Framework Integration Guide](/docs/advanced/integration-with-frameworks) for other frameworks' requirements.
+These requirements are specific to Docusaurus integration. See our [Framework Integration Guide](/docs/advanced/integration-with-frameworks) for formatter-based setups and their requirements.
 
 :::
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -2,7 +2,7 @@
 sidebar_position: 10
 pagination_next: try-it
 hide_table_of_contents: true
-description: Generate human-friendly Markdown/MDX documentation from GraphQL schemas. Easy setup, customizable output, and seamless Docusaurus integration.
+description: Generate human-friendly Markdown and MDX documentation from GraphQL schemas for Docusaurus and supported formatter-based documentation ecosystems.
 keywords:
   - GraphQL
   - documentation generator
@@ -14,7 +14,7 @@ keywords:
 
 # Introduction
 
-The `@graphql-markdown/cli` package adds a CLI with commands for generating MDX using a GraphQL schema as the source. It simplifies creating and maintaining GraphQL API documentation by automatically generating well-structured documentation from your schema.
+GraphQL-Markdown generates Markdown and MDX documentation from a GraphQL schema. You can use the official Docusaurus integration for Docusaurus sites, or use the CLI with formatter presets for other supported documentation ecosystems such as Hugo, MkDocs, DocFX, and mdBook.
 
 ## Why GraphQL Markdown?
 
@@ -23,7 +23,7 @@ Managing API documentation can be time-consuming and prone to becoming outdated.
 - Automatically generating documentation from your schema
 - Keeping documentation in sync with your API
 - Providing a consistent documentation structure
-- Integrating seamlessly with most of the MDX documentation frameworks
+- Integrating with Docusaurus and supported formatter-based documentation ecosystems
 
 ## Features
 
@@ -44,8 +44,10 @@ For **Docusaurus** projects:
 npm install @graphql-markdown/docusaurus graphql
 ```
 
-For **other MDX frameworks** (Astro, Next.js, etc.):
+For **formatter-based setups** (Hugo, MkDocs, DocFX, mdBook, Astro, Next.js, etc.):
 
 ```bash
-npm install @graphql-markdown/cli graphql
+npm install @graphql-markdown/cli @graphql-markdown/formatters graphql
 ```
+
+For the full list of supported formatter presets, see [Integration with Frameworks](/docs/advanced/integration-with-frameworks).

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -11,7 +11,7 @@ keywords:
 
 # Settings
 
-All settings can be set via plugin options in your config file and overridden with CLI flags. See [configuration](/docs/configuration) for the different config methods.
+All settings can be set via plugin options in your config file and overridden with CLI flags. Use `formatter` when you want GraphQL-Markdown to target a supported formatter-based documentation ecosystem, and see [configuration](/docs/configuration) for the different config methods.
 
 ## `--config`
 
@@ -203,7 +203,6 @@ GraphQL schema loaders to use (see [schema loading](/docs/advanced/schema-loadin
 ## `formatter`
 
 Provide a custom module for formatting output content. You can also use built-in formatter presets from [`@graphql-markdown/formatters`](https://github.com/graphql-markdown/graphql-markdown/tree/main/packages/formatters).
-
 
 | Setting     | CLI flag      | Default                            |
 | ----------- | ------------- | ---------------------------------- |

--- a/packages/formatters/README.md
+++ b/packages/formatters/README.md
@@ -2,7 +2,7 @@
 
 Framework formatter presets for GraphQL-Markdown.
 
-This package provides ready-to-use `mdxParser` modules for popular documentation frameworks, with each formatter in its own package subpath.
+This package provides ready-to-use formatter presets for popular documentation frameworks, with each formatter in its own package subpath.
 
 ## Installation
 
@@ -20,7 +20,7 @@ extensions:
   graphql-markdown:
     rootPath: ./docs
     baseURL: api
-    mdxParser: "@graphql-markdown/formatters/docusaurus"
+    formatter: "@graphql-markdown/formatters/docusaurus"
 ```
 
 Or programmatically:
@@ -32,16 +32,18 @@ await runGraphQLMarkdown({
   schema: "./schema.graphql",
   rootPath: "./docs",
   baseURL: "api",
-  mdxParser: "@graphql-markdown/formatters/docusaurus",
+  formatter: "@graphql-markdown/formatters/docusaurus",
 });
 ```
+
+The legacy `mdxParser` setting still works as a deprecated alias, but new configurations should use `formatter`.
 
 ## Supported Formatters
 
 Each formatter has its own setup guide:
 
 | Framework | Package Path | Documentation |
-|-----------|--------------|---|
+| --------- | ------------ | ------------- |
 | Astro Starlight | `@graphql-markdown/formatters/starlight` | [Guide](src/starlight/README.md) |
 | DocFX | `@graphql-markdown/formatters/docfx` | [Guide](src/docfx/README.md) |
 | Docusaurus | `@graphql-markdown/formatters/docusaurus` | [Guide](src/docusaurus/README.md) |

--- a/packages/formatters/src/docfx/README.md
+++ b/packages/formatters/src/docfx/README.md
@@ -17,7 +17,7 @@ await runGraphQLMarkdown({
   schema: "./schema.graphql",
   rootPath: "./docs",
   baseURL: "api",
-  mdxParser: "@graphql-markdown/formatters/docfx",
+  formatter: "@graphql-markdown/formatters/docfx",
 });
 ```
 
@@ -31,7 +31,7 @@ extensions:
   graphql-markdown:
     rootPath: ./docs
     baseURL: api
-    mdxParser: "@graphql-markdown/formatters/docfx"
+    formatter: "@graphql-markdown/formatters/docfx"
 ```
 
 ## Features

--- a/packages/formatters/src/docusaurus/README.md
+++ b/packages/formatters/src/docusaurus/README.md
@@ -48,7 +48,7 @@ await runGraphQLMarkdown({
   schema: "./schema.graphql",
   rootPath: "./docs",
   baseURL: "api",
-  mdxParser: "@graphql-markdown/formatters/docusaurus",
+  formatter: "@graphql-markdown/formatters/docusaurus",
 });
 ```
 
@@ -62,7 +62,7 @@ extensions:
   graphql-markdown:
     rootPath: ./docs
     baseURL: api
-    mdxParser: "@graphql-markdown/formatters/docusaurus"
+    formatter: "@graphql-markdown/formatters/docusaurus"
 ```
 
 ## Features
@@ -95,7 +95,7 @@ Then use it in your config:
 ```yaml
 extensions:
   graphql-markdown:
-    mdxParser: ./src/modules/custom-mdx.cjs
+    formatter: ./src/modules/custom-mdx.cjs
 ```
 
 ## Links

--- a/packages/formatters/src/fumadocs/README.md
+++ b/packages/formatters/src/fumadocs/README.md
@@ -23,7 +23,7 @@ await runGraphQLMarkdown({
   schema: "./schema.graphql",
   rootPath: "./content/docs",
   baseURL: "api",
-  mdxParser: "@graphql-markdown/formatters/fumadocs",
+  formatter: "@graphql-markdown/formatters/fumadocs",
 });
 ```
 
@@ -37,7 +37,7 @@ extensions:
   graphql-markdown:
     rootPath: ./content/docs
     baseURL: api
-    mdxParser: "@graphql-markdown/formatters/fumadocs"
+    formatter: "@graphql-markdown/formatters/fumadocs"
 ```
 
 ## Features

--- a/packages/formatters/src/honkit/README.md
+++ b/packages/formatters/src/honkit/README.md
@@ -17,7 +17,7 @@ await runGraphQLMarkdown({
   schema: "./schema.graphql",
   rootPath: "./docs",
   baseURL: "api",
-  mdxParser: "@graphql-markdown/formatters/honkit",
+  formatter: "@graphql-markdown/formatters/honkit",
 });
 ```
 
@@ -31,7 +31,7 @@ extensions:
   graphql-markdown:
     rootPath: ./docs
     baseURL: api
-    mdxParser: "@graphql-markdown/formatters/honkit"
+    formatter: "@graphql-markdown/formatters/honkit"
 ```
 
 ## Features

--- a/packages/formatters/src/hugo/README.md
+++ b/packages/formatters/src/hugo/README.md
@@ -17,7 +17,7 @@ await runGraphQLMarkdown({
   schema: "./schema.graphql",
   rootPath: "./content",
   baseURL: "api",
-  mdxParser: "@graphql-markdown/formatters/hugo",
+  formatter: "@graphql-markdown/formatters/hugo",
 });
 ```
 
@@ -31,7 +31,7 @@ extensions:
   graphql-markdown:
     rootPath: ./content
     baseURL: api
-    mdxParser: "@graphql-markdown/formatters/hugo"
+    formatter: "@graphql-markdown/formatters/hugo"
 ```
 
 ## Requirements

--- a/packages/formatters/src/mdbook/README.md
+++ b/packages/formatters/src/mdbook/README.md
@@ -17,7 +17,7 @@ await runGraphQLMarkdown({
   schema: "./schema.graphql",
   rootPath: "./src",
   baseURL: "api",
-  mdxParser: "@graphql-markdown/formatters/mdbook",
+  formatter: "@graphql-markdown/formatters/mdbook",
 });
 ```
 
@@ -31,7 +31,7 @@ extensions:
   graphql-markdown:
     rootPath: ./src
     baseURL: api
-    mdxParser: "@graphql-markdown/formatters/mdbook"
+    formatter: "@graphql-markdown/formatters/mdbook"
 ```
 
 ## Features

--- a/packages/formatters/src/mkdocs/README.md
+++ b/packages/formatters/src/mkdocs/README.md
@@ -17,7 +17,7 @@ await runGraphQLMarkdown({
   schema: "./schema.graphql",
   rootPath: "./docs",
   baseURL: "api",
-  mdxParser: "@graphql-markdown/formatters/mkdocs",
+  formatter: "@graphql-markdown/formatters/mkdocs",
 });
 ```
 
@@ -31,7 +31,7 @@ extensions:
   graphql-markdown:
     rootPath: ./docs
     baseURL: api
-    mdxParser: "@graphql-markdown/formatters/mkdocs"
+    formatter: "@graphql-markdown/formatters/mkdocs"
 ```
 
 ## Requirements

--- a/packages/formatters/src/starlight/README.md
+++ b/packages/formatters/src/starlight/README.md
@@ -17,7 +17,7 @@ await runGraphQLMarkdown({
   schema: "./schema.graphql",
   rootPath: "./src/content/docs",
   baseURL: "api",
-  mdxParser: "@graphql-markdown/formatters/starlight",
+  formatter: "@graphql-markdown/formatters/starlight",
 });
 ```
 
@@ -31,7 +31,7 @@ extensions:
   graphql-markdown:
     rootPath: ./src/content/docs
     baseURL: api
-    mdxParser: "@graphql-markdown/formatters/starlight"
+    formatter: "@graphql-markdown/formatters/starlight"
 ```
 
 ## Features
@@ -64,7 +64,7 @@ Then reference your custom module in the config:
 ```yaml
 extensions:
   graphql-markdown:
-    mdxParser: ./src/modules/astro-mdx.cjs
+    formatter: ./src/modules/astro-mdx.cjs
 ```
 
 ## Examples

--- a/packages/formatters/src/vocs/README.md
+++ b/packages/formatters/src/vocs/README.md
@@ -23,7 +23,7 @@ await runGraphQLMarkdown({
   schema: "./schema.graphql",
   rootPath: "./docs",
   baseURL: "api",
-  mdxParser: "@graphql-markdown/formatters/vocs",
+  formatter: "@graphql-markdown/formatters/vocs",
 });
 ```
 
@@ -37,7 +37,7 @@ extensions:
   graphql-markdown:
     rootPath: ./docs
     baseURL: api
-    mdxParser: "@graphql-markdown/formatters/vocs"
+    formatter: "@graphql-markdown/formatters/vocs"
 ```
 
 ## Features


### PR DESCRIPTION
# Description

Clarify the formatter-based entry points across the main repository docs and the formatter package docs.

This changes the initial onboarding flow so non-Docusaurus users are directed earlier to `@graphql-markdown/formatters`, updates the getting-started and configuration pages to mention the formatter path explicitly, and aligns the formatter package READMEs with the current `formatter` setting instead of the deprecated `mdxParser` alias.

Validation completed:
- checked diagnostics on the touched docs files
- confirmed formatter README examples no longer use the deprecated key except where it is called out explicitly as a deprecated alias

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
