### PR TITLE
📝 docs: strengthen formatter release guidance

### DIFF
--- a/docs/__api/__index.md
+++ b/docs/__api/__index.md
@@ -9,7 +9,7 @@ GraphQL-Markdown is organized into several packages:
 - [@graphql-markdown/cli](/api/category/graphql-markdowncli/) - Command-line interface for generating documentation
 - [@graphql-markdown/core](/api/category/graphql-markdowncore/) - Core functionality and base classes
 - [@graphql-markdown/docusaurus](/api/category/graphql-markdowndocusaurus/) - Docusaurus plugin integration
-- [@graphql-markdown/formatters](/api/category/graphql-markdownformatters/) - MDX formatter presets for all supported frameworks
+- [@graphql-markdown/formatters](/api/category/graphql-markdownformatters/) - Formatter presets for all supported documentation frameworks
 - [@graphql-markdown/graphql](/api/category/graphql-markdowngraphql/) - GraphQL schema utilities and helpers
 - [@graphql-markdown/helpers](/api/category/graphql-markdownhelpers/) - Helper functions for documentation generation
 - [@graphql-markdown/printer-legacy](/api/category/graphql-markdownprinter-legacy/) - Legacy markdown printer implementation
@@ -23,14 +23,18 @@ npm install @graphql-markdown/cli
 yarn add @graphql-markdown/cli
 ```
 
+If you are targeting a formatter-based documentation stack such as Hugo, MkDocs, DocFX, or mdBook, also install `@graphql-markdown/formatters` and configure the `formatter` option.
+
 ## Basic Usage
 
 Using the CLI:
+
 ```bash
 graphql-markdown --schema ./schema.graphql --root ./docs
 ```
 
 For programmatic usage, you can use the CLI package:
+
 ```typescript
 import { runGraphQLMarkdown } from '@graphql-markdown/cli';
 
@@ -45,6 +49,7 @@ await runGraphQLMarkdown(config);
 ## Contributing
 
 This documentation is intended primarily for those interested in:
+
 - Contributing to the GraphQL-Markdown codebase
 - Developing custom documentation generators
 - Extending the base functionality

--- a/docs/advanced/integration-with-frameworks.md
+++ b/docs/advanced/integration-with-frameworks.md
@@ -11,6 +11,38 @@ keywords:
 
 GraphQL-Markdown supports multiple documentation frameworks through formatter presets. Each framework has its own setup guide, or you can create a custom formatter for any framework.
 
+## Choose a Path
+
+Use the path that matches your documentation stack:
+
+| If you are using... | Recommended path |
+| ------------------- | ---------------- |
+| **Docusaurus** | Use the `@graphql-markdown/docusaurus` plugin when you want the official Docusaurus integration and default Docusaurus formatter behavior. |
+| **Hugo, MkDocs, DocFX, mdBook, or HonKit** | Use `@graphql-markdown/cli` with a formatter preset from `@graphql-markdown/formatters`. This is the main path for non-TS/JS documentation ecosystems. |
+| **Starlight, Fumadocs, or Vocs** | Use `@graphql-markdown/cli` with the matching formatter preset when you already have one of these frameworks in place. |
+| **Any unsupported framework** | Start from the closest preset or create a custom formatter module. |
+
+For new configurations, use the `formatter` setting. The legacy `mdxParser` setting still works as a deprecated alias.
+
+## Common Setup
+
+Install the CLI and formatter presets:
+
+```bash
+npm install @graphql-markdown/cli @graphql-markdown/formatters graphql
+```
+
+Then configure the formatter that matches your framework:
+
+```yaml
+schema: ./schema.graphql
+extensions:
+  graphql-markdown:
+    rootPath: ./docs
+    baseURL: api
+    formatter: "@graphql-markdown/formatters/hugo"
+```
+
 ## Supported Formatters
 
 Install the formatters package:

--- a/docs/configuration-cheatsheet.md
+++ b/docs/configuration-cheatsheet.md
@@ -13,6 +13,10 @@ keywords:
 This is a quick reference guide. All settings are thoroughly documented in the [**Settings** page](/docs/settings).
 :::
 
+:::tip
+For formatter-based setups, prefer `formatter`. The older `mdxParser` setting and CLI flag are deprecated aliases.
+:::
+
 ## Essential Options
 
 | Option     | Type     | Default    | Description                                               |
@@ -82,5 +86,5 @@ All config options can be passed as CLI flags to `npx docusaurus graphql-to-doc`
 | `-gdb, --groupByDirective <expr>` | `groupByDirective`                    | Group by directive: `@dir(field\|=fallback)`   |
 | `--pretty`                        | `pretty`                              | Format output with Prettier                    |
 | `--formatter <pkg>`               | `formatter`                           | Formatter package name or path                 |
-| `--mdxParser <pkg>`               | ~~`mdxParser`~~ (deprecated)          | Use `--formatter` instead                      |
+| `--mdxParser <pkg>`               | ~~`mdxParser`~~ (deprecated)          | Deprecated alias for `formatter`               |
 | `--config`                        | —                                     | Print resolved config (debug)                  |

--- a/packages/formatters/docs/index.md
+++ b/packages/formatters/docs/index.md
@@ -1,5 +1,7 @@
 # @graphql-markdown/formatters
 
+Formatter presets for supported documentation frameworks. Use these modules with the `formatter` option in GraphQL-Markdown configuration.
+
 ## Modules
 
 - [docfx](docfx.md)


### PR DESCRIPTION
# Description

Strengthen the release-facing formatter guidance after the earlier entry-point cleanup.

This tranche adds a clearer framework-selection layer for non-Docusaurus users in the integration guide, clarifies the formatter-vs-deprecated-alias wording in the configuration cheat sheet, and tightens formatter wording on the API landing pages.

Updated surfaces:
- `docs/advanced/integration-with-frameworks.md`
- `docs/configuration-cheatsheet.md`
- `docs/__api/__index.md`
- `packages/formatters/docs/index.md`

Validation completed:
- checked diagnostics on all touched files
- ran `earthly +build-docs` from `website/` successfully

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
