### PR TITLE
🔖 release: prepare 1.35.0 package versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
     },
     "packages/cli": {
       "name": "@graphql-markdown/cli",
-      "version": "0.7.1",
+      "version": "1.0.0",
       "bin": {
         "gqlmd": "./dist/main.js",
       },
@@ -72,7 +72,7 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.20.0",
+      "version": "1.21.0",
       "dependencies": {
         "@fastify/deepmerge": "^3.2.1",
         "@graphql-markdown/graphql": "workspace:^",
@@ -97,7 +97,7 @@
     },
     "packages/diff": {
       "name": "@graphql-markdown/diff",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "dependencies": {
         "@graphql-inspector/core": "^7.1.3",
         "@graphql-markdown/graphql": "workspace:^",
@@ -112,7 +112,7 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.34.0",
+      "version": "1.35.0",
       "dependencies": {
         "@docusaurus/utils": "catalog:docusaurus",
         "@graphql-markdown/cli": "workspace:^",
@@ -143,7 +143,7 @@
     },
     "packages/graphql": {
       "name": "@graphql-markdown/graphql",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dependencies": {
         "@graphql-markdown/types": "workspace:^",
         "@graphql-markdown/utils": "workspace:^",
@@ -158,7 +158,7 @@
     },
     "packages/helpers": {
       "name": "@graphql-markdown/helpers",
-      "version": "1.0.13",
+      "version": "1.1.0",
       "dependencies": {
         "@graphql-markdown/graphql": "workspace:^",
         "@graphql-markdown/types": "workspace:^",
@@ -173,7 +173,7 @@
     },
     "packages/logger": {
       "name": "@graphql-markdown/logger",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "@graphql-markdown/types": "workspace:^",
       },
@@ -184,7 +184,7 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "dependencies": {
         "@graphql-markdown/formatters": "workspace:^",
         "@graphql-markdown/graphql": "workspace:^",
@@ -201,7 +201,7 @@
     },
     "packages/types": {
       "name": "@graphql-markdown/types",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "devDependencies": {
         "@graphql-tools/load": "catalog:graphql-tools",
         "@graphql-tools/utils": "catalog:graphql-tools",
@@ -211,7 +211,7 @@
     },
     "packages/utils": {
       "name": "@graphql-markdown/utils",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "dependencies": {
         "@graphql-markdown/types": "workspace:^",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "0.7.1",
+  "version": "0.8.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "0.8.0",
+  "version": "1.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.20.0",
+  "version": "1.21.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.14",
+  "version": "1.1.15",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.34.0",
+  "version": "1.35.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.13",
+  "version": "1.1.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.15.0",
+  "version": "1.16.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-markdown/types",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Common types for @graphql-markdown packages",
   "repository": {
     "type": "git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.11.0",
+  "version": "1.12.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

Prepare release branch 1.35.0 by bumping publishable package versions and promoting @graphql-markdown/cli to 1.0.0.

This PR is intentionally scoped to release version preparation so the publish scripts can produce an unpublished package set in dependency order.

## Release Notes (Draft)

1.35.0 focuses on formatter-first integration: Docusaurus, Astro Starlight, Next.js + Fumadocs, Vocs, HonKit, Hugo, MkDocs, DocFX, and mdBook.
`formatter` is now the canonical setting; `mdxParser` remains a deprecated alias for migration compatibility.
Examples: `@graphql-markdown/formatters/hugo`, `@graphql-markdown/formatters/docusaurus`, `@graphql-markdown/formatters/starlight`.

```yaml
schema: ./schema.graphql
extensions:
  graphql-markdown:
    rootPath: ./content
    baseURL: api
    formatter: "@graphql-markdown/formatters/hugo"
```

> [!WARNING]
> **Removed deprecated options/features (explicit list)**
> - Removed CLI flags: `--noCode`, `--noExample`, `--noRelatedType`.
> - Removed `printTypeOptions` toggles: `codeSection` and `relatedTypeSection`.
> - Removed boolean form of `printTypeOptions.exampleSection` (object config only).
> - Removed deprecated Docusaurus plugin option: `runOnBuild`.
> - Removed deprecated printer event type aliases: `PrintCodeEvent` and `PrintTypeEvent`.
>
> **Use instead (migration mapping)**
> - `--noCode` / `codeSection` -> use `beforeComposePageTypeHook` and remove `code` from `event.output`.
> - `--noExample` / boolean `exampleSection` -> use object `printTypeOptions.exampleSection` config, or remove `example` from `event.output` in `beforeComposePageTypeHook`.
> - `--noRelatedType` / `relatedTypeSection` -> use `beforeComposePageTypeHook` and remove `relations` from `event.output`.
> - `runOnBuild` -> run `graphql-to-doc` explicitly in your docs/build pipeline.

### Package Versions 📦

| Package | Version |
|---|---|
| @graphql-markdown/docusaurus | 1.35.0 |
| @graphql-markdown/core | 1.21.0 |
| @graphql-markdown/printer-legacy | 1.16.0 |
| @graphql-markdown/types | 1.13.0 |
| @graphql-markdown/utils | 1.12.0 |
| @graphql-markdown/graphql | 1.2.2 |
| @graphql-markdown/cli | 1.0.0 |
| @graphql-markdown/diff | 1.1.15 |
| @graphql-markdown/helpers | 1.1.0 |
| @graphql-markdown/logger | 1.0.7 |
| @graphql-markdown/formatters | 1.0.0 |

**Full Changelog (draft)**: https://github.com/graphql-markdown/graphql-markdown/compare/1.34.0...1.35.0

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.
