### PR TITLE
📝 docs: add demo repo links to formatter READMEs

### DIFF
--- a/packages/formatters/src/docfx/README.md
+++ b/packages/formatters/src/docfx/README.md
@@ -63,6 +63,10 @@ module.exports = {
 
 The `uid` field in frontmatter is computed from `props.id` by the default formatter and rewritten to a path-derived value by the `afterRenderTypeEntitiesHook`. Override `formatMDXFrontmatter` only if you need to change the frontmatter structure beyond the `uid` field.
 
+## Examples
+
+See the complete implementation: [demo-docfx](https://github.com/graphql-markdown/demo-docfx)
+
 ## Links
 
 - [DocFX Documentation](https://dotnet.github.io/docfx/)

--- a/packages/formatters/src/docusaurus/README.md
+++ b/packages/formatters/src/docusaurus/README.md
@@ -98,6 +98,10 @@ extensions:
     formatter: ./src/modules/custom-mdx.cjs
 ```
 
+## Examples
+
+See the complete implementation: [demo-docusaurus](https://github.com/graphql-markdown/demo-docusaurus)
+
 ## Links
 
 - [GraphQL-Markdown Docusaurus Plugin](https://github.com/graphql-markdown/graphql-markdown/tree/main/packages/docusaurus)

--- a/packages/formatters/src/hugo/README.md
+++ b/packages/formatters/src/hugo/README.md
@@ -64,6 +64,10 @@ module.exports = {
 };
 ```
 
+## Examples
+
+See the complete implementation: [demo-hugo](https://github.com/graphql-markdown/demo-hugo)
+
 ## Links
 
 - [Hugo Documentation](https://gohugo.io/)

--- a/packages/formatters/src/mdbook/README.md
+++ b/packages/formatters/src/mdbook/README.md
@@ -63,6 +63,10 @@ module.exports = {
 
 Since mdBook doesn't support frontmatter, metadata (title, description, etc.) is typically handled through mdBook's `SUMMARY.md` file for navigation and book.toml for configuration.
 
+## Examples
+
+See the complete implementation: [demo-mdbook](https://github.com/graphql-markdown/demo-mdbook)
+
 ## Links
 
 - [mdBook Documentation](https://rust-lang.github.io/mdBook/)

--- a/packages/formatters/src/mkdocs/README.md
+++ b/packages/formatters/src/mkdocs/README.md
@@ -71,6 +71,10 @@ module.exports = {
 };
 ```
 
+## Examples
+
+See the complete implementation: [demo-mkdocs](https://github.com/graphql-markdown/demo-mkdocs)
+
 ## Links
 
 - [MkDocs Documentation](https://www.mkdocs.org/)


### PR DESCRIPTION
# Description

Add `## Examples` section with a link to the matching demo repository in the 5 formatter READMEs that were missing it (docfx, docusaurus, hugo, mdbook, mkdocs).

The other 4 formatters (fumadocs, honkit, starlight, vocs) already had this section. This makes all 9 formatter READMEs consistent.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.