### PR TITLE
fix(formatters): rewrite mdBook internal links to relative paths

### DIFF
--- a/packages/formatters/src/mdbook/index.ts
+++ b/packages/formatters/src/mdbook/index.ts
@@ -21,6 +21,7 @@ import type {
   MDXString,
   MetaInfo,
   RenderFilesHook,
+  RenderTypeEntitiesHook,
   TypeLink,
 } from "@graphql-markdown/types";
 import {
@@ -32,7 +33,9 @@ import {
   firstUppercase,
   MARKDOWN_EOL,
   MARKDOWN_EOP,
+  readFile,
   saveFile,
+  toRelativeGeneratedDocLink,
 } from "@graphql-markdown/utils";
 import {
   formatMDXBullet,
@@ -122,6 +125,61 @@ export {
   formatMDXNameEntity,
   formatMDXSpecifiedByLink,
 } from "../defaults";
+
+const rewriteInternalLinks = (
+  content: string,
+  filePath: string,
+  outputDir: string,
+  baseURL: string,
+): string => {
+  return content.replaceAll(
+    /\]\((\/[^)\s#]+)(#[^)\s]+)?\)/g,
+    (_match, urlPath, hash = "") => {
+      const relativePath = toRelativeGeneratedDocLink({
+        baseURL,
+        currentFilePath: filePath,
+        extension: mdxExtension,
+        outputDir,
+        targetUrlPath: urlPath,
+      });
+
+      const target = relativePath ?? urlPath;
+      return `](${target}${hash})`;
+    },
+  );
+};
+
+/**
+ * Rewrites absolute generated doc links to page-relative `.md` paths after each page is rendered.
+ *
+ * mdBook resolves links relative to the book source root, so absolute paths
+ * like `/graphql/types/scalars/id.md` are rendered as `/graphql/types/scalars/id.html`
+ * in the output HTML — which breaks when the book is served under a subdirectory
+ * (e.g. `https://example.com/demo-mdbook/`).
+ * Converting them to relative paths (e.g. `../../scalars/id.md`) makes links
+ * work correctly regardless of where the book is hosted.
+ */
+export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
+  event,
+): Promise<void> => {
+  const { baseURL, filePath, outputDir } = (
+    event as {
+      data: { baseURL: string; filePath: string; outputDir: string };
+    }
+  ).data;
+
+  const content = await readFile(filePath, "utf-8");
+  const rewrittenContent = rewriteInternalLinks(
+    content,
+    filePath,
+    outputDir,
+    baseURL,
+  );
+
+  if (rewrittenContent !== content) {
+    await saveFile(filePath, rewrittenContent);
+  }
+};
 
 /**
  * Creates an mdBook formatter.
@@ -219,7 +277,7 @@ export const afterRenderFilesHook: RenderFilesHook = async (
     "",
     "---",
     "",
-    `[GraphQL API Reference](${baseURL}/index${mdxExtension}})`,
+    `[GraphQL API Reference](${baseURL}/index${mdxExtension})`,
     "",
   ];
 

--- a/packages/formatters/tests/unit/mdbook/index.test.ts
+++ b/packages/formatters/tests/unit/mdbook/index.test.ts
@@ -1,5 +1,6 @@
 import {
   afterRenderFilesHook,
+  afterRenderTypeEntitiesHook,
   createMDXFormatter,
   formatMDXAdmonition,
   formatMDXBadge,
@@ -654,5 +655,112 @@ describe("afterRenderFilesHook", () => {
     const opsIdx = summary.indexOf("# Operations");
     // Operations must come before Types, not tied
     expect(opsIdx).toBeLessThan(typesIdx);
+  });
+});
+
+describe("afterRenderTypeEntitiesHook", () => {
+  test("is a function (lifecycle hook contract)", () => {
+    expect(typeof afterRenderTypeEntitiesHook).toBe("function");
+  });
+
+  test("rewrites absolute internal links to relative paths", async () => {
+    const { mkdtempSync, mkdirSync, writeFileSync, readFileSync } =
+      await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join: pathJoin } = await import("node:path");
+
+    const rootDir = mkdtempSync(pathJoin(tmpdir(), "mdbook-hook-"));
+    const outputDir = pathJoin(rootDir, "graphql");
+    const filePath = pathJoin(outputDir, "types", "objects", "country.md");
+
+    mkdirSync(pathJoin(outputDir, "types", "objects"), { recursive: true });
+
+    const content = "# Country\n\n[ID!](/graphql/types/scalars/id.md) scalar\n";
+    writeFileSync(filePath, content, "utf-8");
+
+    await afterRenderTypeEntitiesHook({
+      data: { baseURL: "graphql", filePath, outputDir },
+    });
+
+    const result = readFileSync(filePath, "utf-8");
+    expect(result).not.toContain("](/graphql/");
+    expect(result).toContain("](../scalars/id.md)");
+  });
+
+  test("preserves fragment anchors when rewriting links", async () => {
+    const { mkdtempSync, writeFileSync, readFileSync, mkdirSync } =
+      await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join: pathJoin } = await import("node:path");
+
+    const rootDir = mkdtempSync(pathJoin(tmpdir(), "mdbook-frag-"));
+    const outputDir = pathJoin(rootDir, "graphql");
+    const filePath = pathJoin(outputDir, "types", "objects", "country.md");
+
+    mkdirSync(pathJoin(outputDir, "types", "objects"), { recursive: true });
+
+    const content =
+      "# Country\n\n[field](/graphql/types/scalars/id.md#field)\n";
+    writeFileSync(filePath, content, "utf-8");
+
+    await afterRenderTypeEntitiesHook({
+      data: { baseURL: "graphql", filePath, outputDir },
+    });
+
+    const result = readFileSync(filePath, "utf-8");
+    expect(result).toContain("](../scalars/id.md#field)");
+  });
+
+  test("does not modify the file when no internal links are present", async () => {
+    const { mkdtempSync, mkdirSync, writeFileSync, statSync } =
+      await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join: pathJoin } = await import("node:path");
+
+    const rootDir = mkdtempSync(pathJoin(tmpdir(), "mdbook-noop-"));
+    const outputDir = pathJoin(rootDir, "graphql");
+    const filePath = pathJoin(outputDir, "types", "scalars", "string.md");
+
+    mkdirSync(pathJoin(outputDir, "types", "scalars"), { recursive: true });
+
+    const content = "# String\n\nBuilt-in scalar.\n";
+    writeFileSync(filePath, content, "utf-8");
+
+    const mtimeBefore = statSync(filePath).mtimeMs;
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 10);
+    });
+
+    await afterRenderTypeEntitiesHook({
+      data: { baseURL: "graphql", filePath, outputDir },
+    });
+
+    const mtimeAfter = statSync(filePath).mtimeMs;
+    expect(mtimeBefore).toBe(mtimeAfter);
+  });
+
+  test("leaves external URLs unchanged", async () => {
+    const { mkdtempSync, writeFileSync, readFileSync, mkdirSync } =
+      await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join: pathJoin } = await import("node:path");
+
+    const rootDir = mkdtempSync(pathJoin(tmpdir(), "mdbook-ext-"));
+    const outputDir = pathJoin(rootDir, "graphql");
+    const filePath = pathJoin(outputDir, "types", "scalars", "id.md");
+
+    mkdirSync(pathJoin(outputDir, "types", "scalars"), { recursive: true });
+
+    const content =
+      "# ID\n\n[Spec](https://spec.example.com/id)\n[Repo](https://github.com/example)\n";
+    writeFileSync(filePath, content, "utf-8");
+
+    await afterRenderTypeEntitiesHook({
+      data: { baseURL: "graphql", filePath, outputDir },
+    });
+
+    const result = readFileSync(filePath, "utf-8");
+    expect(result).toContain("(https://spec.example.com/id)");
+    expect(result).toContain("(https://github.com/example)");
   });
 });


### PR DESCRIPTION
## Problem

Links in mdBook-generated docs (e.g. [demo-mdbook](https://graphql-markdown.dev/demo-mdbook/graphql/types/objects/country.html)) resolve incorrectly when the book is served under a subdirectory.

mdBook converts `.md` links to absolute HTML paths at build time (e.g. `/graphql/types/scalars/id.md` → `/graphql/types/scalars/id.html`). When the book is hosted under a subpath like `/demo-mdbook/`, these absolute paths miss the subdirectory prefix and 404.

## Solution

Add an `afterRenderTypeEntitiesHook` to the mdBook formatter (mirroring the same pattern already used in the MkDocs formatter) that rewrites absolute internal doc links to page-relative `.md` paths after each page is written. mdBook natively resolves relative `.md` links correctly regardless of hosting subdirectory.

**Example:** from a file at `graphql/types/objects/country.md`:
- Before: `](/graphql/types/scalars/id.md)`
- After:  `](../../scalars/id.md)`

## Also fixed

Typo in `SUMMARY.md` generation: `${baseURL}/index${mdxExtension}}` had an extra `}` leaking into the link.

## Changes

- `packages/formatters/src/mdbook/index.ts` — adds `rewriteInternalLinks` helper and `afterRenderTypeEntitiesHook` export; imports `readFile` and `toRelativeGeneratedDocLink`; imports `RenderTypeEntitiesHook` type; fixes SUMMARY typo
- `packages/formatters/tests/unit/mdbook/index.test.ts` — 4 new tests: relative link rewriting, fragment preservation, no-op when no internal links, external URLs left unchanged