### PR TITLE
🐛 fix(formatters): remove .mdx extension from Starlight links

### DIFF
--- a/packages/formatters/src/starlight/index.ts
+++ b/packages/formatters/src/starlight/index.ts
@@ -20,7 +20,6 @@ import type {
   MetaInfo,
   TypeLink,
 } from "@graphql-markdown/types";
-import { appendLinkExtension } from "@graphql-markdown/helpers";
 import {
   ensureDir,
   fileExists,
@@ -71,15 +70,13 @@ export const formatMDXAdmonition = (
 };
 
 /**
- * Appends `.mdx` to internal link URLs.
+ * Returns the link unchanged — Starlight routes `page.mdx` to `page/` so
+ * links must not include the `.mdx` extension.
  * @param link - Link data with URL and text
- * @returns Link with `.mdx` extension appended to the URL
+ * @returns Unmodified link
  */
-export const formatMDXLink = ({ text, url }: TypeLink): TypeLink => {
-  return {
-    text,
-    url: appendLinkExtension(url, mdxExtension),
-  };
+export const formatMDXLink = (link: TypeLink): TypeLink => {
+  return link;
 };
 
 export {

--- a/packages/formatters/tests/unit/starlight/index.test.ts
+++ b/packages/formatters/tests/unit/starlight/index.test.ts
@@ -108,10 +108,10 @@ describe("formatMDXFrontmatter", () => {
 });
 
 describe("formatMDXLink", () => {
-  test("appends .mdx extension", () => {
+  test("returns link unchanged", () => {
     expect(formatMDXLink({ text: "Type", url: "/schema/type" })).toEqual({
       text: "Type",
-      url: "/schema/type.mdx",
+      url: "/schema/type",
     });
   });
 });


### PR DESCRIPTION
# Description

Astro Starlight routes `page.mdx` files to clean URLs (`page/`), so appending `.mdx` to internal links produced broken hrefs like:

```
/types/scalars/string.mdx   ← broken
/types/scalars/string/      ← correct
```

`formatMDXLink` in the Starlight formatter was calling `appendLinkExtension(url, ".mdx")`, which contradicts how Starlight's file-based routing works. The fix removes the extension appending so links resolve to the framework's clean URLs.

Fixes: https://graphql-markdown.dev/demo-astro-starlight/operations/mutations/save-thread/ (links to `string.mdx` instead of `string/`)

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.