### PR TITLE
chore: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           ref: main
           token: ${{ secrets.BOT_PAT }}
+          persist-credentials: false
 
       - uses: rhysd/changelog-from-release/action@78b335bb7d059f35ad04c5428d50711726feee50 # v3
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/danger-js.yml
+++ b/.github/workflows/danger-js.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout Code Base
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup environment
         uses: ./.github/actions/setup

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout Code Base
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup environment
         uses: ./.github/actions/setup

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -38,7 +38,7 @@ jobs:
       SMOKE_TARGET: smoke-docusaurus-run
     steps:
       - name: Install earthly
-        uses: earthly/actions-setup@v1
+        uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
         with:
           version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
       SMOKE_TARGET: smoke-cli-test
     steps:
       - name: Install earthly
-        uses: earthly/actions-setup@v1
+        uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203 # v1.0.13
         with:
           version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup environment
         uses: ./.github/actions/setup


### PR DESCRIPTION
## Summary

Pin GitHub Actions to specific commit SHAs for improved security and reproducibility.

### Changes

- `earthly/actions-setup@v1` → pinned to `43211c7a` (v1.0.13) in `smoke.yml`
- Added `persist-credentials: false` to `actions/checkout` steps in:
  - `changelog.yml`
  - `codeql-analysis.yml`
  - `danger-js.yml`
  - `linter.yml`
  - `mutation.yml`
  - `test.yml`