### PR TITLE
🔧 conf(fallow): suppress false-positive dev-deps-in-production for dangerfile.js

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -34,6 +34,12 @@
   //   eslint-import-resolver-typescript — ESLint import/resolver setting
   //   jest-environment-node           — jest testEnvironment: "node"
   //   typedoc-docusaurus-theme        — TypeDoc plugin string in typedoc config
+  //
+  // diff, lodash.filter are used only by dangerfile.js (Danger CI tooling). dangerfile.js is
+  // declared above as an `entry` point so fallow doesn't flag it as an unused file, but that
+  // makes it "reachable production code" and flags these dev-only deps as
+  // dev-dependencies-in-production. The root package.json is private with no `dependencies`
+  // field and is never installed with `--prod`, so this is a false positive.
   "ignoreDependencies": [
     "@graphql-markdown/cli",
     "@graphql-markdown/core",
@@ -51,7 +57,9 @@
     "cz-emoji",
     "eslint-import-resolver-typescript",
     "jest-environment-node",
-    "typedoc-docusaurus-theme"
+    "typedoc-docusaurus-theme",
+    "diff",
+    "lodash.filter"
   ],
 
   // Class member false-positive suppressions.


### PR DESCRIPTION
# Description

fallow's dead-code analysis flagged `diff` and `lodash.filter` as devDependencies used in production code (`dev-dependencies-in-production`). Investigation showed this is a false positive: both packages are used only by `dangerfile.js` (Danger CI tooling), which `.fallowrc.jsonc` already declares as a fallow `entry` point so it isn't flagged as an unused file. That entry declaration made fallow treat `dangerfile.js` as reachable "production" code, which in turn flagged its dev-only dependencies.

The root `package.json` is `private: true` with no `dependencies` field and is never installed with `--prod`, so there's no actual runtime risk. This follows the same suppression pattern already used for `cz-emoji` and other tooling-only dependencies in `ignoreDependencies`.

Verified with `fallow analyze --production`: `dev_dependencies_in_production` count went from 2 to 0, with no other findings affected.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)