### PR TITLE
chore(ci): add Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 2
     rebase-strategy: "auto"
     labels:
       - "automerge"
@@ -17,6 +19,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 2
     open-pull-requests-limit: 10
     commit-message:
       prefix: "🔧 gha"


### PR DESCRIPTION
## Summary

Add a 2-day Dependabot cooldown so dependency update PRs respect the minimum package age strategy.

## Validation

- Parsed `.github/dependabot.yml` successfully
- Existing repo hooks/tests passed during commit