### PR TITLE
chore: add renovate minimum release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,8 @@
   "baseBranchPatterns": [
     "main"
   ],
+  "minimumReleaseAge": "2 days",
+  "internalChecksFilter": "strict",
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Add Renovate's minimum release age gate so dependency updates wait 48 hours before becoming eligible.

Validation: `node -e 'JSON.parse(require("fs").readFileSync("renovate.json", "utf8")); console.log("renovate.json OK")'`