### PR TITLE
🔧 chore(ci): cancel superseded workflow runs on new push

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: "19 6 * * 5"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/danger-js.yml
+++ b/.github/workflows/danger-js.yml
@@ -4,6 +4,10 @@ on: pull_request
 env:
   HUSKY: 0
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   danger-js:
     name: Danger.js Checks

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ on:
       - "*.mjs"
       - ".github/workflows/test.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test ${{ matrix.package }}


### PR DESCRIPTION
# Description

Adds `concurrency` groups with `cancel-in-progress: true` to the Test, Linter, CodeQL, and Danger JS workflows, matching the pattern already used in `smoke.yml` and `mutation.yml`. A new push now cancels the previous in-progress run of the same workflow for the same ref, avoiding wasted CI minutes on superseded commits.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.