### PR TITLE
🔒️ feat(website): add CSP meta tag and SRI guidance

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -141,7 +141,23 @@ const config = {
     ],
   ],
 
+  // No third-party/CDN scripts or stylesheets are loaded today (everything is
+  // bundled and served from 'self'). If one is ever added here, pair its tag
+  // with an `integrity` hash and `crossorigin: "anonymous"` (SRI).
   headTags: [
+    // GitHub Pages doesn't support custom HTTP response headers, so a real
+    // Content-Security-Policy header isn't possible here — this meta tag is
+    // the closest equivalent. 'unsafe-inline' on script-src is required for
+    // Docusaurus's inline hydration scripts and the JSON-LD blocks below;
+    // note frame-ancestors is ignored by browsers when set via meta tag.
+    {
+      tagName: "meta",
+      attributes: {
+        "http-equiv": "Content-Security-Policy",
+        content:
+          "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none';",
+      },
+    },
     {
       tagName: "script",
       attributes: {


### PR DESCRIPTION
# Description

GitHub Pages doesn't support custom HTTP response headers, so a real `Content-Security-Policy` header isn't achievable for the docs site. This adds a `Content-Security-Policy` meta tag to `headTags` in `docusaurus.config.js` as the closest available equivalent, plus a comment documenting that any future third-party script/stylesheet must carry Subresource Integrity (SRI) attributes — no such scripts exist today, so nothing to add there yet.

Notes:
- `script-src`/`style-src` include `'unsafe-inline'`, required by Docusaurus's inline hydration scripts and the existing JSON-LD `headTags` blocks.
- `frame-ancestors` is included but browsers ignore it when set via `<meta>` — kept for documentation/defense-in-depth, not enforcement.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.