### PR TITLE
🔒️ fix(website): allow contrib.rocks in CSP img-src

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -150,12 +150,14 @@ const config = {
     // the closest equivalent. 'unsafe-inline' on script-src is required for
     // Docusaurus's inline hydration scripts and the JSON-LD blocks below;
     // note frame-ancestors is ignored by browsers when set via meta tag.
+    // img-src allows contrib.rocks for the homepage's contributors image
+    // (src/pages/index.js).
     {
       tagName: "meta",
       attributes: {
         "http-equiv": "Content-Security-Policy",
         content:
-          "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; base-uri 'self'; frame-ancestors 'none';",
+          "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://contrib.rocks; object-src 'none'; base-uri 'self'; frame-ancestors 'none';",
       },
     },
     {


### PR DESCRIPTION
# Description

The CSP meta tag added in #3196 used `img-src 'self' data:`, which silently blocked the contributors image on the homepage (`src/pages/index.js`) — it's loaded from `https://contrib.rocks`. Adds that origin to `img-src`.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.