### PR TITLE
🔒️ fix(website): allow npm downloads API in CSP connect-src

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -149,15 +149,17 @@ const config = {
     // Content-Security-Policy header isn't possible here — this meta tag is
     // the closest equivalent. 'unsafe-inline' on script-src is required for
     // Docusaurus's inline hydration scripts and the JSON-LD blocks below;
-    // note frame-ancestors is ignored by browsers when set via meta tag.
+    // frame-ancestors is omitted because browsers ignore it in a meta tag and
+    // log a console warning.
     // img-src allows contrib.rocks for the homepage's contributors image
-    // (src/pages/index.js).
+    // (src/pages/index.js), and connect-src allows the npm downloads API used
+    // by src/hooks/useNpmDownloads.js.
     {
       tagName: "meta",
       attributes: {
         "http-equiv": "Content-Security-Policy",
         content:
-          "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://contrib.rocks; object-src 'none'; base-uri 'self'; frame-ancestors 'none';",
+          "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://contrib.rocks; connect-src 'self' https://api.npmjs.org; object-src 'none'; base-uri 'self';",
       },
     },
     {


### PR DESCRIPTION
# Description

The homepage download counters (`website/src/hooks/useNpmDownloads.js`) fetch `https://api.npmjs.org/downloads/point/last-week/...`, but the CSP meta tag had no `connect-src`, so the `default-src 'self'` fallback blocked the request:

```
Fetch API cannot load https://api.npmjs.org/downloads/point/last-week/@graphql-markdown/core.
Refused to connect because it violates the document's Content Security Policy.
```

- Add `connect-src 'self' https://api.npmjs.org`.
- Drop `frame-ancestors 'none'`, which browsers ignore when the policy is delivered via a `<meta>` element (it only logged a console warning).

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)