### PR TITLE
📝 docs: fix inaccurate references and sync hook types with the runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npx docusaurus graphql-to-doc
 Use the CLI directly for custom workflows, or pair it with `@graphql-markdown/formatters` to adapt the generated output for supported frameworks.
 
 ```shell
-npx gqlmd graphql-to-doc --schema ./schema.graphql --output ./docs
+npx gqlmd graphql-to-doc --schema ./schema.graphql --root ./docs
 ```
 
 For formatter-based setups:

--- a/docs/advanced/custom-directive.md
+++ b/docs/advanced/custom-directive.md
@@ -114,7 +114,7 @@ plugins: [
 You can use **`"*"` as a wildcard** for the directive name. This will allow all directives not declared with their name under `customDirective` to be handled by the wildcard `descriptor` and/or `tag`.
 
 ```js title="docusaurus.config.js"
-const { directiveDescriptor, tagDescriptor } = require("@graphql-markdown/helpers");
+const { directiveDescriptor, directiveTag } = require("@graphql-markdown/helpers");
 
 //...//
 
@@ -128,7 +128,7 @@ plugins: [
         // highlight-start
         "*": {
           descriptor: directiveDescriptor,
-          tag: tagDescriptor,
+          tag: directiveTag,
         },
         // highlight-end
         // ... optionally specific custom directive options
@@ -155,7 +155,7 @@ npm i @graphql-markdown/helpers
 ### `@graphql-markdown/helpers`
 
 - [`directiveDescriptor`](/api/helpers/directives/descriptor)
-- [`tagDescriptor`](/api/helpers/directives/tag)
+- [`directiveTag`](/api/helpers/directives/tag)
 
 ### `@graphql-markdown/graphql`
 

--- a/docs/advanced/examples.md
+++ b/docs/advanced/examples.md
@@ -12,7 +12,7 @@ keywords:
 
 # Examples
 
-By enabling the option [`printTypeOptions.exampleSection`](/docs/settings#printtypeoptions), you can add examples to types documentation.
+Examples are added to types documentation as soon as the schema declares an `@example` directive. The option [`printTypeOptions.exampleSection`](/docs/settings#printtypeoptions) is only needed when the directive name, its field, or the value parsing has to be customized (see [advanced options](#advanced-options)).
 
 ## Usage
 
@@ -57,7 +57,7 @@ Examples can be inherited, this is why in the above example there is no example 
 
 ## Advanced options
 
-Example directive definition and parser behavior can be customized through the configuration using a `TypeDirectiveExample` object instead of a boolean value for `printTypeOptions.exampleSection`:
+Example directive definition and parser behavior can be customized through the configuration by setting `printTypeOptions.exampleSection` to a `TypeExampleSectionOption` object (any other value is ignored, and the defaults `@example(value: ...)` apply):
 
 ```ts
 interface TypeExampleSectionOption {

--- a/docs/advanced/integration-with-frameworks.md
+++ b/docs/advanced/integration-with-frameworks.md
@@ -67,15 +67,37 @@ Then select your framework:
 
 ### Quick Example
 
-```js
-import { runGraphQLMarkdown } from '@graphql-markdown/cli';
+Declare the settings in your GraphQL Config file, then run the CLI:
 
-await runGraphQLMarkdown({
-  schema: './schema.graphql',
-  rootPath: './docs',
-  baseURL: 'api',
-  formatter: '@graphql-markdown/formatters/docusaurus', // or your framework
-});
+```yaml title=".graphqlrc"
+schema: ./schema.graphql
+extensions:
+  graphql-markdown:
+    rootPath: ./docs
+    baseURL: api
+    formatter: "@graphql-markdown/formatters/docusaurus" # or your framework
+```
+
+```bash
+npx gqlmd graphql-to-doc
+```
+
+The command name is `graphql-to-doc` for the default project, and `graphql-to-doc:<id>` for each additional [GraphQL Config project](/docs/advanced/additional-schema#graphql-config).
+
+You can also call the generator programmatically. `runGraphQLMarkdown` takes the configuration as first argument, and CLI-style overrides as second argument:
+
+```js
+import { runGraphQLMarkdown } from "@graphql-markdown/cli";
+
+await runGraphQLMarkdown(
+  {
+    schema: "./schema.graphql",
+    rootPath: "./docs",
+    baseURL: "api",
+    formatter: "@graphql-markdown/formatters/docusaurus", // or your framework
+  },
+  {}, // CLI flags overrides, eg `{ force: true }`
+);
 ```
 
 ## 3rd Party Packages

--- a/docs/configuration-cheatsheet.md
+++ b/docs/configuration-cheatsheet.md
@@ -23,7 +23,7 @@ For formatter-based setups, prefer `formatter`. The older `mdxParser` setting an
 | ---------- | -------- | ---------- | --------------------------------------------------------- |
 | `schema`   | `string` | —          | **Required**. Path to schema file or introspection result |
 | `rootPath` | `string` | `./docs`   | Root folder for documentation generation                  |
-| `baseURL`  | `string` | `/graphql` | Base URL path for generated documentation                 |
+| `baseURL`  | `string` | `schema`   | Base URL path and output folder name under `rootPath`     |
 
 ## Document Structure
 
@@ -64,7 +64,7 @@ For formatter-based setups, prefer `formatter`. The older `mdxParser` setting an
 
 ## CLI Flags
 
-All config options can be passed as CLI flags to `npx docusaurus graphql-to-doc` or `npx graphql-markdown`.
+All config options can be passed as CLI flags to `npx docusaurus graphql-to-doc` (Docusaurus plugin) or `npx gqlmd graphql-to-doc` (standalone CLI).
 
 | Flag                              | Config option                         | Description                                    |
 | --------------------------------- | ------------------------------------- | ---------------------------------------------- |
@@ -83,8 +83,10 @@ All config options can be passed as CLI flags to `npx docusaurus graphql-to-doc`
 | `--noTypeBadges`                  | `printTypeOptions.typeBadges`         | Hide type attribute badges                     |
 | `--only <@directive...>`          | `onlyDocDirective`                    | Include only types with these directives       |
 | `--skip <@directive...>`          | `skipDocDirective`                    | Exclude types with these directives            |
-| `-gdb, --groupByDirective <expr>` | `groupByDirective`                    | Group by directive: `@dir(field\|=fallback)`   |
+| `--groupByDirective <expr>`       | `groupByDirective`                    | Group by directive: `@dir(field\|=fallback)`   |
 | `--pretty`                        | `pretty`                              | Format output with Prettier                    |
-| `--formatter <pkg>`               | `formatter`                           | Formatter package name or path                 |
-| `--mdxParser <pkg>`               | ~~`mdxParser`~~ (deprecated)          | Deprecated alias for `formatter`               |
+| `--formatter <pkg>`[^1]           | `formatter`                           | Formatter package name or path                 |
+| `--mdxParser <pkg>`[^1]           | ~~`mdxParser`~~ (deprecated)          | Deprecated alias for `formatter`               |
 | `--config`                        | —                                     | Print resolved config (debug)                  |
+
+[^1]: The `--formatter` and `--mdxParser` flags are only registered when the CLI is set up with a default formatter package, as done by `@graphql-markdown/docusaurus`. The standalone `gqlmd` command does not expose them &mdash; set `formatter` in your configuration file instead.

--- a/docs/configuration-cheatsheet.md
+++ b/docs/configuration-cheatsheet.md
@@ -27,14 +27,15 @@ For formatter-based setups, prefer `formatter`. The older `mdxParser` setting an
 
 ## Document Structure
 
-| Option         | Type                     | Default | Description                                                           |
-| -------------- | ------------------------ | ------- | --------------------------------------------------------------------- |
-| `linkRoot`     | `string`                 | `/`     | Root path used for type cross-links in generated documentation        |
-| `homepage`     | `string`                 | —       | Custom homepage content file                                          |
-| `hierarchy`    | `string`                 | `api`   | Documentation structure: `api`, `entity`, or `flat`                   |
-| `index`        | `boolean`                | `false` | Generate category indices                                             |
-| `categorySort` | `string` \| `function`   | —       | Sort categories: `"natural"` for alphabetical or custom function      |
-| `pretty`       | `boolean`                | `false` | Format generated Markdown files                                       |
+| Option             | Type                   | Default        | Description                                                      |
+| ------------------ | ---------------------- | -------------- | ---------------------------------------------------------------- |
+| `linkRoot`         | `string`               | `/`            | Root path used for type cross-links in generated documentation   |
+| `homepage`         | `string` \| `false`    | `generated.md` | Custom homepage content file, `false` to disable                 |
+| `hierarchy`        | `string`               | `api`          | Documentation structure: `api`, `entity`, or `flat`              |
+| `index`            | `boolean`              | `false`        | Generate category indices                                        |
+| `categorySort`     | `string` \| `function` | —              | Sort categories: `"natural"` for alphabetical or custom function |
+| `sectionHeaderId`  | `boolean`              | `true`         | Generate custom section header IDs for permalinks                |
+| `pretty`           | `boolean`              | `false`        | Format generated Markdown files                                  |
 
 ## Content Options
 
@@ -81,6 +82,7 @@ All config options can be passed as CLI flags to `npx docusaurus graphql-to-doc`
 | `--deprecated <option>`           | `printTypeOptions.deprecated`         | `default`, `group`, or `skip`                  |
 | `--noParentType`                  | `printTypeOptions.parentTypePrefix`   | Hide parent type prefix on fields              |
 | `--noTypeBadges`                  | `printTypeOptions.typeBadges`         | Hide type attribute badges                     |
+| `--noSectionId`                   | `docOptions.sectionHeaderId`          | Disable section header IDs for permalinks      |
 | `--only <@directive...>`          | `onlyDocDirective`                    | Include only types with these directives       |
 | `--skip <@directive...>`          | `skipDocDirective`                    | Exclude types with these directives            |
 | `--groupByDirective <expr>`       | `groupByDirective`                    | Group by directive: `@dir(field\|=fallback)`   |

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -38,7 +38,7 @@ Then continue with [Integration with Frameworks](/docs/advanced/integration-with
 
 ### Requirements
 
-Node.js version [20.0](https://nodejs.org/en/download/) or above (which can be checked by running `node -v`) is required.
+Node.js version [22.12](https://nodejs.org/en/download/) or above (which can be checked by running `node -v`) is required.
 
 :::info[Package managers]
 
@@ -103,7 +103,7 @@ These requirements are specific to Docusaurus integration. See our [Framework In
 
 Your project needs to meet the following requirements:
 
-- Node.js version [20.0](https://nodejs.org/en/download/) or above
+- Node.js version [22.12](https://nodejs.org/en/download/) or above
 - [Docusaurus](https://docusaurus.io/) instance version 2.0 or above with the [docs plugin](https://docusaurus.io/docs/docs-introduction) enabled
 - [GraphQL.js](https://graphql.org/graphql-js/) version 16.0 or above
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -158,7 +158,7 @@ Use a GraphQL directive for creating documentation categories (see [documentatio
 
 | Setting            | CLI flag                                                                        | Default     |
 | ------------------ | ------------------------------------------------------------------------------- | ----------- |
-| `groupByDirective` | <code>-gdb, --groupByDirective &lt;&#64;directive(field&#124;=fallback)></code> | `undefined` |
+| `groupByDirective` | <code>--groupByDirective &lt;&#64;directive(field&#124;=fallback)></code>       | `undefined` |
 
 ## `homepage`
 
@@ -211,6 +211,12 @@ Provide a custom module for formatting output content. You can also use built-in
 :::note
 
 The `mdxParser` setting and `--mdxParser` CLI flag are deprecated aliases for `formatter` / `--formatter`. They still work but emit a deprecation warning. Migrate to `formatter`.
+
+:::
+
+:::caution
+
+The `--formatter` and `--mdxParser` CLI flags are only registered when the CLI is set up with a default formatter package, which is what `@graphql-markdown/docusaurus` does. The standalone `gqlmd` command does not expose them, so set `formatter` in your configuration file instead.
 
 :::
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -184,6 +184,14 @@ The GraphQL-Markdown template for Docusaurus provides a customized homepage loca
 
 :::
 
+## `id`
+
+The identifier of the configuration instance. It is used for supporting [additional schemas](/docs/advanced/additional-schema): each instance gets its own command `graphql-to-doc:<id>`, and it maps to the [GraphQL Config](/docs/configuration#graphql-config) project of the same name.
+
+| Setting | CLI flag        | Default     |
+| ------- | --------------- | ----------- |
+| `id`    | _not supported_ | `default`   |
+
 ## `linkRoot`
 
 The root for links in documentation. It depends on the entry for the schema main page in the Docusaurus sidebar.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,7 +20,7 @@ Add a `resolutions` entry to your `package.json`:
 ```json title="package.json"
 "resolutions": 
 {
-  "graphql": "16.9.0"
+  "graphql": "16.14.2"
 }
 ```
 

--- a/docs/try-it.md
+++ b/docs/try-it.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 20
-description: Try GraphQL-Markdown instantly with interactive CodeSandbox demos for Docusaurus, Astro, Next.js, Vocs, GitBook, and other frameworks.
+description: Try GraphQL-Markdown instantly with our demo repositories for Docusaurus, Astro, Next.js, Vocs, HonKit, Hugo, MkDocs, mdBook and DocFX.
 keywords:
   - GraphQL-Markdown demo
   - CodeSandbox
@@ -40,3 +40,27 @@ Edit the configuration in `graphql.config.mjs`.
 Fork our [demo repo](https://github.com/graphql-markdown/demo-honkit) to try with your own GraphQL schema.
 
 Edit the configuration in `graphql.config.mjs`.
+
+## Hugo
+
+Fork our [demo repo](https://github.com/graphql-markdown/demo-hugo) to try with your own GraphQL schema.
+
+Edit the configuration in `.graphqlrc.yml`.
+
+## MkDocs
+
+Fork our [demo repo](https://github.com/graphql-markdown/demo-mkdocs) to try with your own GraphQL schema.
+
+Edit the configuration in `scripts/generate-docs.mjs`.
+
+## mdBook
+
+Fork our [demo repo](https://github.com/graphql-markdown/demo-mdbook) to try with your own GraphQL schema.
+
+Edit the configuration in `scripts/generate-docs.mjs`.
+
+## DocFX
+
+Fork our [demo repo](https://github.com/graphql-markdown/demo-docfx) to try with your own GraphQL schema.
+
+Edit the configuration in `scripts/generate-docs.mjs`.

--- a/packages/printer-legacy/src/const/options.ts
+++ b/packages/printer-legacy/src/const/options.ts
@@ -57,18 +57,6 @@ export const PRINT_TYPE_DEFAULT_OPTIONS: Required<
 export const DEFAULT_OPTIONS: Required<
   Omit<
     PrintTypeOptions,
-    | "afterDiffCheckHook"
-    | "afterGenerateIndexMetafileHook"
-    | "afterRenderHomepageHook"
-    | "afterRenderRootTypesHook"
-    | "afterRenderTypeEntitiesHook"
-    | "afterSchemaLoadHook"
-    | "beforeDiffCheckHook"
-    | "beforeGenerateIndexMetafileHook"
-    | "beforeRenderHomepageHook"
-    | "beforeRenderRootTypesHook"
-    | "beforeRenderTypeEntitiesHook"
-    | "beforeSchemaLoadHook"
     | "collapsible"
     | "exampleSection"
     | "formatCategoryFolderName"

--- a/packages/types/src/core.d.ts
+++ b/packages/types/src/core.d.ts
@@ -8,8 +8,11 @@ import type { CustomDirective } from "./helpers";
 import type { Maybe, MDXString } from "./utils";
 import type { AdmonitionType, Badge, TypeLink } from "./printer";
 import type {
+  BeforeComposePageTypeHook,
   DiffCheckHook,
   GenerateIndexMetafileHook,
+  PrintCodeHook,
+  PrintTypeHook,
   RenderFilesHook,
   RenderHomepageHook,
   RenderRootTypesHook,
@@ -76,11 +79,11 @@ export interface MDXSupportType {
     formatted: Maybe<string[]>,
   ) => MDXString;
   mdxDeclaration: string;
-  // Event hooks
-  beforeSchemaLoadHook?: SchemaLoadHook;
-  afterSchemaLoadHook?: SchemaLoadHook;
-  beforeDiffCheckHook?: DiffCheckHook;
-  afterDiffCheckHook?: DiffCheckHook;
+  // Event hooks, see EVENT_CALLBACK_MAP in @graphql-markdown/core
+  beforeLoadSchemaHook?: SchemaLoadHook;
+  afterLoadSchemaHook?: SchemaLoadHook;
+  beforeCheckDiffHook?: DiffCheckHook;
+  afterCheckDiffHook?: DiffCheckHook;
   beforeRenderRootTypesHook?: RenderRootTypesHook;
   afterRenderRootTypesHook?: RenderRootTypesHook;
   beforeRenderHomepageHook?: RenderHomepageHook;
@@ -90,6 +93,11 @@ export interface MDXSupportType {
   beforeGenerateIndexMetafileHook?: GenerateIndexMetafileHook;
   afterGenerateIndexMetafileHook?: GenerateIndexMetafileHook;
   afterRenderFilesHook?: RenderFilesHook;
+  beforePrintCodeHook?: PrintCodeHook;
+  afterPrintCodeHook?: PrintCodeHook;
+  beforePrintTypeHook?: PrintTypeHook;
+  afterPrintTypeHook?: PrintTypeHook;
+  beforeComposePageTypeHook?: BeforeComposePageTypeHook;
 }
 
 /**
@@ -454,6 +462,7 @@ declare const LOCATION_PATH: unique symbol;
 
 // Re-export event system types from event.d.ts
 export type {
+  BeforeComposePageTypeHook,
   DefaultAction,
   DiffCheckHook,
   GenerateIndexMetafileHook,


### PR DESCRIPTION
# Description

Audit of `./docs` (excluding `./docs/__api`) against the current source, and the fixes for everything that no longer matched.

Three commits:

**1. `🐛 fix(docs)` — references that are wrong today**

- `tagDescriptor` does not exist in `@graphql-markdown/helpers`; the export is `directiveTag`.
- The CLI binary is `gqlmd`, not `graphql-markdown`.
- `--groupByDirective` has no `-gdb` short flag.
- The `runGraphQLMarkdown` example passed a single object; the signature is `(config, cliOptions, loggerModule?)` and it dereferences `cliOptions`, so the documented call threw. Replaced with the GraphQL Config + `npx gqlmd graphql-to-doc` path, plus a correct programmatic call.
- Cheat sheet `baseURL` default was `/graphql`; `DEFAULT_OPTIONS.baseURL` is `schema`.
- Documented Node.js minimum was 20.0; both published packages declare `"node": ">=22.12.0"`.
- `--formatter` / `--mdxParser` are only registered when the CLI is built with a default formatter package (the Docusaurus plugin); standalone `gqlmd` does not expose them.
- README used a `--output` flag that does not exist (`-r, --root`).

**2. `📝 docs` — stale or incomplete**

- Added the `id` setting to the settings reference.
- Added `sectionHeaderId` / `--noSectionId` to the cheat sheet and fixed the `homepage` default.
- Listed the Hugo, MkDocs, mdBook and DocFX demo repositories in *Try it* (config file locations verified against each repo).
- Bumped the `graphql` resolution sample to the catalog version 16.14.2.
- Clarified that the example section renders whenever the schema declares `@example`; `exampleSection` only customizes directive/field/parser.

**3. `🐛 fix(types)` — types out of sync with the runtime**

`EVENT_CALLBACK_MAP` dispatches `beforeLoadSchemaHook`, `afterLoadSchemaHook`, `beforeCheckDiffHook`, `afterCheckDiffHook`, but `MDXSupportType` declared `before|afterSchemaLoadHook` and `before|afterDiffCheckHook` — so a formatter implementing the documented hooks did not type-check. Renamed them, declared the print type hooks that were supported at runtime but missing from the type, and dropped the matching stale keys from the printer-legacy `DEFAULT_OPTIONS` omit list.

Verified accurate and left untouched: the hook reference tables, `settings.md` defaults, `rootTypes`, `groupByDirective` fallback, formatter preset list and their README links, all internal doc links and anchors.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
