### PR TITLE
🐛 fix(formatters): drop .mdx extension from Fumadocs links

### DIFF
--- a/packages/formatters/src/fumadocs/index.ts
+++ b/packages/formatters/src/fumadocs/index.ts
@@ -16,7 +16,6 @@ import type {
   MetaInfo,
   TypeLink,
 } from "@graphql-markdown/types";
-import { appendLinkExtension } from "@graphql-markdown/helpers";
 import { MARKDOWN_EOP } from "@graphql-markdown/utils";
 import {
   formatMDXBullet,
@@ -62,15 +61,13 @@ export const formatMDXAdmonition = (
 };
 
 /**
- * Appends `.mdx` to internal link URLs.
+ * Returns the link unchanged — Fumadocs routes `page.mdx` to `page` so
+ * links must not include the `.mdx` extension.
  * @param link - Link data with URL and text
- * @returns Link with `.mdx` extension appended to the URL
+ * @returns Unmodified link
  */
-export const formatMDXLink = ({ text, url }: TypeLink): TypeLink => {
-  return {
-    text,
-    url: appendLinkExtension(url, mdxExtension),
-  };
+export const formatMDXLink = (link: TypeLink): TypeLink => {
+  return link;
 };
 
 export {

--- a/packages/formatters/tests/unit/fumadocs/index.test.ts
+++ b/packages/formatters/tests/unit/fumadocs/index.test.ts
@@ -84,10 +84,10 @@ describe("formatMDXFrontmatter", () => {
 });
 
 describe("formatMDXLink", () => {
-  test("appends .mdx extension", () => {
+  test("returns the link unchanged, without file extension", () => {
     expect(formatMDXLink({ text: "Type", url: "/schema/type" })).toEqual({
       text: "Type",
-      url: "/schema/type.mdx",
+      url: "/schema/type",
     });
   });
 });


### PR DESCRIPTION
## Problem

The Fumadocs preset's `formatMDXLink` appends `.mdx` to every internal link URL. Fumadocs serves `page.mdx` at `/page`, so all cross-references in generated docs point at 404s, e.g. `/docs/types/scalars/string.mdx`.

## Fix

Return the link unchanged, matching the Starlight preset, which has the same routing behaviour. Generated *files* still get `.mdx` — that comes from the separate `mdxExtension` export, which is untouched.

## Test

- Updated the `formatMDXLink` unit test to assert the URL is passed through.
- `npm run test:unit` in `packages/formatters`: 269 passed.
- Verified end to end against [demo-nextjs-fumadocs](https://github.com/graphql-markdown/demo-nextjs-fumadocs): regenerating 244 pages with the patched formatter leaves zero `.mdx` link suffixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)