### PR TITLE
:bug: remove index.md file generation from astro starlight

### DIFF
--- a/packages/formatters/src/starlight/index.ts
+++ b/packages/formatters/src/starlight/index.ts
@@ -8,9 +8,6 @@
  * @packageDocumentation
  */
 
-import { join, dirname, resolve, basename } from "node:path";
-import { appendFile } from "node:fs/promises";
-
 import type {
   AdmonitionType,
   Badge,
@@ -20,13 +17,7 @@ import type {
   MetaInfo,
   TypeLink,
 } from "@graphql-markdown/types";
-import {
-  ensureDir,
-  fileExists,
-  MARKDOWN_EOP,
-  saveFile,
-  startCase,
-} from "@graphql-markdown/utils";
+import { MARKDOWN_EOP } from "@graphql-markdown/utils";
 import {
   formatMDXBullet,
   formatMDXDetails,
@@ -86,45 +77,6 @@ export {
   formatMDXNameEntity,
   formatMDXSpecifiedByLink,
 } from "../defaults";
-
-const INDEX_MD = "index.md" as const;
-
-/**
- * Lifecycle hook that creates an `index.md` file for a category directory
- * before Starlight indexes it. Skips creation if the file already exists.
- * @param event - Hook payload containing the target directory and category name
- */
-export const beforeGenerateIndexMetafileHook = async (event: {
-  data: { dirPath: string; category: string };
-}): Promise<void> => {
-  const { dirPath, category } = event.data;
-  const filePath = join(dirPath, INDEX_MD);
-
-  if (await fileExists(filePath)) {
-    return;
-  }
-
-  const label = startCase(category);
-  await ensureDir(dirPath);
-  await saveFile(filePath, `---\ntitle: ${label}\n---\n`);
-};
-
-/**
- * Lifecycle hook that appends a link entry to the category `index.md`
- * after each type entity page is rendered.
- * @param event - Hook payload containing the entity name and its output file path
- */
-export const afterRenderTypeEntitiesHook = async (event: {
-  data: { name: string; filePath: string };
-}): Promise<void> => {
-  const { name, filePath } = event.data;
-  const indexFilePath = resolve(dirname(filePath), INDEX_MD);
-  const pageFileName = basename(filePath);
-
-  if (await fileExists(indexFilePath)) {
-    await appendFile(indexFilePath, `- [${name}](./${pageFileName})\n`);
-  }
-};
 
 /**
  * Creates an Astro Starlight formatter.

--- a/packages/formatters/tests/unit/starlight/index.test.ts
+++ b/packages/formatters/tests/unit/starlight/index.test.ts
@@ -1,20 +1,4 @@
-import path from "node:path";
-
-jest.mock("node:fs/promises");
-jest.mock("@graphql-markdown/utils", (): unknown => {
-  return {
-    __esModule: true,
-    ...jest.requireActual("@graphql-markdown/utils"),
-    ensureDir: jest.fn(),
-    fileExists: jest.fn(),
-    saveFile: jest.fn(),
-  };
-});
-
-import * as Utils from "@graphql-markdown/utils";
 import {
-  afterRenderTypeEntitiesHook,
-  beforeGenerateIndexMetafileHook,
   createMDXFormatter,
   formatMDXAdmonition,
   formatMDXBadge,
@@ -135,82 +119,6 @@ describe("formatMDXSpecifiedByLink", () => {
     expect(formatMDXSpecifiedByLink("https://spec.example")).toBe(
       '<span class="gqlmd-mdx-specifiedby">Specification<a class="gqlmd-mdx-specifiedby-link" target="_blank" href="https://spec.example" title="Specified by https://spec.example">⎘</a></span>',
     );
-  });
-});
-
-describe("beforeGenerateIndexMetafileHook", () => {
-  const dirPath = path.join("/output/docs", "queries");
-
-  beforeEach(() => {
-    return jest.clearAllMocks();
-  });
-
-  test("creates index.md with title frontmatter when file does not exist", async () => {
-    jest.spyOn(Utils, "fileExists").mockResolvedValue(false);
-    const saveSpy = jest.spyOn(Utils, "saveFile");
-
-    await beforeGenerateIndexMetafileHook({
-      data: { dirPath, category: "queries" },
-    });
-
-    expect(saveSpy).toHaveBeenCalledWith(
-      path.join(dirPath, "index.md"),
-      "---\ntitle: Queries\n---\n",
-    );
-  });
-
-  test("skips creation when index.md already exists", async () => {
-    jest.spyOn(Utils, "fileExists").mockResolvedValue(true);
-    const saveSpy = jest.spyOn(Utils, "saveFile");
-
-    await beforeGenerateIndexMetafileHook({
-      data: { dirPath, category: "queries" },
-    });
-
-    expect(saveSpy).not.toHaveBeenCalled();
-  });
-
-  test("ensures directory exists before saving", async () => {
-    jest.spyOn(Utils, "fileExists").mockResolvedValue(false);
-    const ensureSpy = jest.spyOn(Utils, "ensureDir");
-
-    await beforeGenerateIndexMetafileHook({
-      data: { dirPath, category: "queries" },
-    });
-
-    expect(ensureSpy).toHaveBeenCalledWith(dirPath);
-  });
-});
-
-describe("afterRenderTypeEntitiesHook", () => {
-  const { appendFile } = jest.requireMock("node:fs/promises");
-
-  beforeEach(() => {
-    return jest.clearAllMocks();
-  });
-
-  test("appends entry link to index.md when it exists", async () => {
-    jest.spyOn(Utils, "fileExists").mockResolvedValue(true);
-    (appendFile as jest.Mock).mockResolvedValue(undefined);
-
-    await afterRenderTypeEntitiesHook({
-      data: { name: "Query", filePath: "/docs/queries/query.mdx" },
-    });
-
-    expect(appendFile).toHaveBeenCalledWith(
-      "/docs/queries/index.md",
-      "- [Query](./query.mdx)\n",
-    );
-  });
-
-  test("skips append when index.md does not exist", async () => {
-    jest.spyOn(Utils, "fileExists").mockResolvedValue(false);
-
-    await afterRenderTypeEntitiesHook({
-      data: { name: "Query", filePath: "/docs/queries/query.mdx" },
-    });
-
-    expect(appendFile).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
# Description

Remove hook for generating`index.md` files for categories and groups for Astro Starlight formatter.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
