### PR TITLE
🔧 conf: speed up test execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,39 +56,17 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ hashFiles('bun.lock', 'packages/*/src/**', 'packages/*/tsconfig*.json', 'tsconfig.base.json') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
 
       - name: Build packages
-        run: bun run build
+        run: bun run build -- --filter=@graphql-markdown/${{ matrix.package }}...
 
-      - name: Run Unit Tests
-        id: unit
+      - name: Run Tests
         run: |
           cd packages/${{ matrix.package }}
-          bun test:unit -- --coverage --reporter=github-actions --reporter=default
-          [ ! -d "./coverage/" ] && echo "skipped=1" >> "$GITHUB_OUTPUT" && exit 0
-          mkdir -p .nyc_output
-          mv ./coverage/coverage-final.json .nyc_output/unit.json
-
-      - name: Run Integration Tests
-        id: integration
-        run: |
-          cd packages/${{ matrix.package }}
-          bun test:integration -- --coverage --reporter=github-actions --reporter=default
-          [ ! -d "./coverage/" ] && echo "skipped=1" >> "$GITHUB_OUTPUT" && exit 0
-          mkdir -p .nyc_output
-          mv ./coverage/coverage-final.json .nyc_output/integration.json
-
-      - name: Check Code Coverage
-        id: coverage
-        if: ${{ !steps.unit.outputs.skipped && !steps.integration.outputs.skipped }}
-        run: |
-          [ ! -d "packages/${{ matrix.package }}/.nyc_output" ] && echo "skipped=1" >> "$GITHUB_OUTPUT" && exit 0
-          cd packages/${{ matrix.package }}
-          bunx -y --quiet nyc merge .nyc_output .nyc_output/coverage.json
-          bunx -y --quiet nyc report --reporter=lcov --reporter=text --temp-dir .nyc_output
+          bun test:ci -- --coverage --reporter=github-actions --reporter=default
 
       - name: SonarCloud Scan
         id: sonarcloud

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,7 @@ When making your changes, remember to check your code by running:
 - `bun run ts:check` checks that the code is TS compliant
 - `bun run lint` checks that the code respects coding standards (ESLint + Prettier)
 - `bun run test:[unit|integration]` runs the test suites for unit tests or integration tests
+- `bun run test:all` runs every package's tests in a single Vitest instance, which is the quickest way to check the whole workspace (add `--watch` to keep it running)
 - `bun run knip` checks dependencies
 
 Smoke tests for the CLI and Docusaurus plugin run automatically in CI on every pull request (see [`.github/workflows/smoke.yml`](.github/workflows/smoke.yml)). Run them locally with `bun run smoke` (see [Tests](#tests) below).
@@ -233,6 +234,17 @@ There are 3 types of tests used in this project, all based on [Vitest](https://v
   > ```
   >
   > The script builds and packs the workspace once, then scaffolds each selected suite into its own throwaway project under a fresh scratch directory (printed at the end of the run — left in place for debugging, not auto-removed). Must be run from the repository root; `REPO_ROOT` can be overridden if needed.
+
+#### Test configuration
+
+Every package's `vitest.config.mjs` is a thin wrapper around `createPackageConfig` in [`packages/tooling-config/vitest/base.mjs`](packages/tooling-config/vitest/base.mjs) — change shared test behaviour there rather than in a package.
+
+Two settings in it are load-bearing for how fast the suite runs:
+
+- tests run on Vitest's `threads` pool, which is safe because every package tests plain Node code with no native addon and no `process.chdir`. If you add a test that needs a real child process, override `pool` in that package's config rather than in the shared base;
+- `isolate` stays `true`. Turning it off is worth roughly another 25%, but some suites currently leak state between files and fail without a fresh module registry, so it needs those suites fixed first.
+
+`test:ci` shuffles file order (`--sequence.shuffle`) to catch tests that depend on running after another file. If a test only passes in a particular order, fix the test rather than the flag.
 
 #### Mutation testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,7 +242,7 @@ Every package's `vitest.config.mjs` is a thin wrapper around `createPackageConfi
 Two settings in it are load-bearing for how fast the suite runs:
 
 - tests run on Vitest's `threads` pool, which is safe because every package tests plain Node code with no native addon and no `process.chdir`. If you add a test that needs a real child process, override `pool` in that package's config rather than in the shared base;
-- `isolate` stays `true`. Turning it off is worth roughly another 25%, but some suites currently leak state between files and fail without a fresh module registry, so it needs those suites fixed first.
+- `isolate` stays `true`, deliberately. Turning it off saves ~160ms across the workspace (1.82s → 1.66s), and in exchange `printer-legacy` fails nondeterministically — four identical runs produced 35, 46, 41 and 5 failures, since which test files share a worker changes between runs. The other nine packages are already clean. The coupling is the `Printer` class's mutable static state, which only `printer.test.ts` resets, plus a few `vi.mock` factories that replace a module's whole surface instead of spreading `importOriginal()`. Both are worth fixing so tests do not depend on each other, but not in pursuit of 160ms.
 
 `test:ci` shuffles file order (`--sequence.shuffle`) to catch tests that depend on running after another file. If a test only passes in a particular order, fix the test rather than the flag.
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "prettier:fix": "turbo run prettier:fix",
     "smoke": ".github/scripts/e2e/run-smoke.sh",
     "test": "turbo run test",
+    "test:all": "vitest run --passWithNoTests",
     "test:unit": "turbo run test:unit",
     "test:integration": "turbo run test:integration",
     "test:ci": "turbo run test:ci",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -58,7 +58,7 @@
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests tests/unit",
     "test:integration": "vitest run --passWithNoTests tests/integration",
-    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle --no-file-parallelism",
+    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle",
     "test:watch": "vitest --watch"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,7 +68,7 @@
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests tests/unit",
     "test:integration": "vitest run --passWithNoTests tests/integration",
-    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle --no-file-parallelism",
+    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle",
     "test:watch": "vitest --watch"
   },
   "dependencies": {

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -61,7 +61,7 @@
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests tests/unit",
     "test:integration": "vitest run --passWithNoTests tests/integration",
-    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle --no-file-parallelism",
+    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle",
     "test:watch": "vitest --watch"
   },
   "dependencies": {

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -70,7 +70,7 @@
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests tests/unit",
     "test:integration": "vitest run --passWithNoTests tests/integration",
-    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle --no-file-parallelism",
+    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle",
     "test:watch": "vitest --watch"
   },
   "dependencies": {

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -202,7 +202,7 @@
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests tests/unit",
     "test:integration": "vitest run --passWithNoTests tests/integration",
-    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle --no-file-parallelism",
+    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle",
     "test:watch": "vitest --watch"
   },
   "dependencies": {

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -61,7 +61,7 @@
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests tests/unit",
     "test:integration": "vitest run --passWithNoTests tests/integration",
-    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle --no-file-parallelism",
+    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle",
     "test:watch": "vitest --watch"
   },
   "dependencies": {

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -61,7 +61,7 @@
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests tests/unit",
     "test:integration": "vitest run --passWithNoTests tests/integration",
-    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle --no-file-parallelism",
+    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle",
     "test:watch": "vitest --watch"
   },
   "dependencies": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -47,7 +47,7 @@
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests tests/unit",
     "test:integration": "vitest run --passWithNoTests tests/integration",
-    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle --no-file-parallelism",
+    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle",
     "test:watch": "vitest --watch"
   },
   "dependencies": {

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -61,7 +61,7 @@
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests tests/unit",
     "test:integration": "vitest run --passWithNoTests tests/integration",
-    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle --no-file-parallelism",
+    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle",
     "test:watch": "vitest --watch"
   },
   "dependencies": {

--- a/packages/tooling-config/stryker/stryker.conf.mjs
+++ b/packages/tooling-config/stryker/stryker.conf.mjs
@@ -34,6 +34,7 @@ const config = {
     // importing the mutated module directly, so Vitest's related-test
     // filtering would skip the tests that actually cover those mutants.
     related: false,
+    reporters: ["minimal"],
   },
   warnings: true,
 };

--- a/packages/tooling-config/stryker/stryker.conf.mjs
+++ b/packages/tooling-config/stryker/stryker.conf.mjs
@@ -34,7 +34,12 @@ const config = {
     // importing the mutated module directly, so Vitest's related-test
     // filtering would skip the tests that actually cover those mutants.
     related: false,
-    reporters: ["minimal"],
+    // Only `dir`, `related` and `configFile` are accepted here — the runner's
+    // schema sets `additionalProperties: false`, so anything else is a hard
+    // config error rather than an ignored key. In particular there is no
+    // `reporters` option: the runner never forwards one to Vitest, and it
+    // already silences test output with `onConsoleLog: () => false`. To make a
+    // Stryker run quieter, use the top-level `logLevel` instead.
   },
   warnings: true,
 };

--- a/packages/tooling-config/vitest/base.mjs
+++ b/packages/tooling-config/vitest/base.mjs
@@ -103,6 +103,16 @@ export const createPackageConfig = (name, configUrl, options = {}) => {
       ],
       exclude: ["**/node_modules/**", "**/dist/**", "**/__data__/**"],
       testTimeout: options.testTimeout ?? 5000,
+      // Every package tests plain Node code with no native addon and no
+      // `process.chdir`, so worker threads are safe and avoid a child process
+      // per test file. Roughly 30% off the wall time of the larger packages,
+      // where module transform and import dominate over the assertions.
+      pool: "threads",
+      poolOptions: {
+        threads: {
+          useAtomics: true,
+        },
+      },
       // `graphql` ships a CJS and an ESM build with no `exports` map, so Vite
       // resolves it to `index.mjs` while an externalised dependency gets the
       // CJS `index.js` through Node. That yields two instances, and the library
@@ -117,6 +127,10 @@ export const createPackageConfig = (name, configUrl, options = {}) => {
       },
       // Replaces Jest's `testEnvironmentOptions.globalsCleanup`: each test file
       // runs in a fresh module registry so globals cannot leak between files.
+      //
+      // Do not flip this to `false` for speed without fixing the suites first:
+      // it is worth another ~25% but 17 tests in `printer-legacy` (7 of them
+      // snapshots) fail when the registry is shared, so state does leak today.
       isolate: true,
       coverage: {
         enabled: options.coverage ?? false,

--- a/packages/tooling-config/vitest/base.mjs
+++ b/packages/tooling-config/vitest/base.mjs
@@ -108,11 +108,6 @@ export const createPackageConfig = (name, configUrl, options = {}) => {
       // per test file. Roughly 30% off the wall time of the larger packages,
       // where module transform and import dominate over the assertions.
       pool: "threads",
-      poolOptions: {
-        threads: {
-          useAtomics: true,
-        },
-      },
       // `graphql` ships a CJS and an ESM build with no `exports` map, so Vite
       // resolves it to `index.mjs` while an externalised dependency gets the
       // CJS `index.js` through Node. That yields two instances, and the library
@@ -128,9 +123,15 @@ export const createPackageConfig = (name, configUrl, options = {}) => {
       // Replaces Jest's `testEnvironmentOptions.globalsCleanup`: each test file
       // runs in a fresh module registry so globals cannot leak between files.
       //
-      // Do not flip this to `false` for speed without fixing the suites first:
-      // it is worth another ~25% but 17 tests in `printer-legacy` (7 of them
-      // snapshots) fail when the registry is shared, so state does leak today.
+      // Turning this off is not worth it, and the question is settled: measured
+      // across the workspace it saves ~160ms (1.82s -> 1.66s, 9%), and in return
+      // `printer-legacy` fails nondeterministically — four identical runs gave
+      // 35, 46, 41 and 5 failures, because which files share a worker varies.
+      // The other nine packages are already clean; the coupling is `Printer`'s
+      // mutable static state (`src/printer.ts`, only reset by `printer.test.ts`)
+      // plus a few whole-surface `vi.mock` factories that clobber each other in
+      // a shared registry. Both are worth fixing for order-independence, but on
+      // their own merits — not for 160ms.
       isolate: true,
       coverage: {
         enabled: options.coverage ?? false,

--- a/packages/tooling-config/vitest/base.mjs
+++ b/packages/tooling-config/vitest/base.mjs
@@ -108,6 +108,15 @@ export const createPackageConfig = (name, configUrl, options = {}) => {
       // per test file. Roughly 30% off the wall time of the larger packages,
       // where module transform and import dominate over the assertions.
       pool: "threads",
+      // Vitest auto-appends the `github-actions` reporter when GITHUB_ACTIONS is
+      // set and no reporter is configured, and that reporter writes a "Vitest
+      // Test Report" into $GITHUB_STEP_SUMMARY — a file, so it shows up in
+      // neither stdout nor the job log. Stryker runs Vitest once per mutant,
+      // which stacked ~1200 of those reports into a single mutation job's
+      // summary. Naming a reporter here stops the auto-append; the Test workflow
+      // still asks for the GitHub reporter on the command line, where it is
+      // wanted, and CLI reporters replace this value rather than merge with it.
+      reporters: ["default"],
       // `graphql` ships a CJS and an ESM build with no `exports` map, so Vite
       // resolves it to `index.mjs` while an externalised dependency gets the
       // CJS `index.js` through Node. That yields two instances, and the library

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -61,7 +61,7 @@
     "test": "vitest run --passWithNoTests",
     "test:unit": "vitest run --passWithNoTests tests/unit",
     "test:integration": "vitest run --passWithNoTests tests/integration",
-    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle --no-file-parallelism",
+    "test:ci": "vitest run --passWithNoTests --silent --sequence.shuffle",
     "test:watch": "vitest --watch"
   },
   "dependencies": {

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,17 @@
+// @ts-check
+
+import { defineConfig } from "vitest/config";
+
+/**
+ * Root config for running the whole workspace in one Vitest instance, sharing a
+ * single Vite server and transform cache across every package instead of
+ * bootstrapping ten of them through turbo. Used by `bun run test:all`.
+ *
+ * The per-package `vitest.config.mjs` files remain the entry point for turbo,
+ * the CI matrix and Stryker, which all need a single package in isolation.
+ */
+export default defineConfig({
+  test: {
+    projects: ["packages/*/vitest.config.mjs"],
+  },
+});


### PR DESCRIPTION
# Description

Test wall time is dominated by module transform and import, not by the assertions: across the whole suite Vitest reports ~0.9s in `tests` against ~9s `transform` + ~15s `import` of cumulative worker time. These changes target that overhead, plus the shape of the CI job.

**Local**

| | before | after |
| --- | --- | --- |
| `bun run test --force` | 2.34s | 1.98s |
| `bun run test:all` (new) | — | 1.76s |
| `test:ci`, `printer-legacy` | 2.57s | 674ms → 486ms |

**Changes**

1. **`pool: "threads"`** in the shared vitest base config. Every package tests plain Node code with no native addon and no `process.chdir`, so worker threads are safe and avoid a child process per test file. ~30% off the larger packages. (An accompanying `poolOptions` block was dead on arrival — `poolOptions` was removed in Vitest 4 and `useAtomics` no longer exists — so it only printed a `DEPRECATED` banner once per package. Removed; timings are unchanged, confirming it was inert.)
2. **Dropped `--no-file-parallelism` from `test:ci`.** It serialised every file into a single worker at a 3.8x cost, for no benefit that `--sequence.shuffle` (kept) does not already provide.
3. **New root `vitest.config.mjs` + `bun run test:all`** — runs all 67 files in one Vitest instance sharing one Vite server and transform cache, instead of ten turbo-driven bootstraps. Modest on a cold run, but it is what makes watch mode across packages usable. Per-package configs stay the entry point for turbo, the CI matrix and Stryker.
4. **One test step per CI matrix job.** Each job ran `test:unit --coverage`, then `test:integration --coverage`, then two `bunx -y nyc` calls (a network install each) to merge the coverage back together. The base config's `include` already covers `tests/{unit,integration}`, so one `test:ci --coverage` run emits the `coverage/lcov.info` SonarCloud reads — verified on `core`, where `src/generator.ts` (integration-only) comes back 109/109 lines.
5. **Scoped build + a working turbo cache key.** `bun run build` rebuilt all 11 packages in each of the 10 jobs; it is now filtered to the package under test and its dependencies (`logger`: 11 build tasks → 2). The cache key was `${{ runner.os }}-turbo-${{ github.sha }}`, which can never hit on a first run for a commit, so it is now keyed on the lockfile and sources.

**Not done — `isolate: false`, and the reason is measured, not assumed:** an earlier revision of this description called it "another ~25%". That figure came from timing `printer-legacy` alone; across the workspace it is **1.82s → 1.66s, about 160ms (9%)**. In exchange, `printer-legacy` fails *nondeterministically* — four identical `--isolate=false` runs produced 35, 46, 41 and 5 failures, because which files share a worker varies between runs. The other nine packages are already clean.

The coupling has two sources, one in production code: the `Printer` class's mutable static state (`_options`, `_eventEmitter`, `_mdxDeclaration` in `packages/printer-legacy/src/printer.ts`), which only `printer.test.ts` resets — isolation is what hides it from everyone else — and five test files whose `vi.mock("@graphql-markdown/graphql", ...)` factories replace the module's whole surface instead of spreading `importOriginal()`, so in a shared registry the narrowest factory wins and other files lose exports. Both are worth fixing so tests stop depending on each other, but on those merits rather than for 160ms, so they are left for a separate PR and the code comments now say so.

**Stryker:** verified compatible — `bun run stryker` passes on `logger` (89.13) and `utils` (84.45). The Vitest runner sets its own concurrency and reads each package config via `configFile`, so neither the pool change nor the new root config affects it.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work. — no behaviour change; verified by running every package's `test:ci --coverage` and Stryker.
- [x] New and existing unit tests pass locally with my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
