### PR TITLE
👷 ci: write a mutation score summary to the PR checks

### DIFF
--- a/.github/scripts/mutation-summary.mjs
+++ b/.github/scripts/mutation-summary.mjs
@@ -1,0 +1,94 @@
+// @ts-check
+
+// Renders a Stryker JSON report as a markdown table into the GitHub Actions step
+// summary, so a PR shows the mutation score per package without a dashboard
+// round-trip.
+//
+// StrykerJS has no markdown reporter: markdown-summary-reporter is a Stryker.NET
+// feature, and the `html` reporter writes a page that boots a custom element,
+// which a sanitized check summary cannot render. So the summary is built here
+// from the `json` reporter output, aggregated with the same
+// mutation-testing-metrics package the HTML report uses, so the numbers match
+// the dashboard exactly.
+//
+// Usage: node mutation-summary.mjs <package> <path/to/mutation.json>
+
+import { appendFile, readFile } from "node:fs/promises";
+
+import { calculateMetrics } from "mutation-testing-metrics";
+
+// Mirrors `thresholds` in packages/tooling-config/stryker/stryker.conf.mjs.
+const THRESHOLDS = { high: 85, low: 75 };
+
+/**
+ * Appends to the step summary, or prints to stdout when run outside Actions.
+ *
+ * @param {string} markdown
+ * @returns {Promise<void>}
+ */
+const write = async (markdown) => {
+  const summaryFile = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryFile) {
+    await appendFile(summaryFile, markdown, "utf-8");
+    return;
+  }
+  process.stdout.write(markdown);
+};
+
+/**
+ * @param {number} score
+ * @returns {string}
+ */
+const marker = (score) => {
+  if (Number.isNaN(score)) {
+    return "⚪";
+  }
+  if (score >= THRESHOLDS.high) {
+    return "🟢";
+  }
+  return score >= THRESHOLDS.low ? "🟡" : "🔴";
+};
+
+/**
+ * @param {number} score
+ * @returns {string}
+ */
+const formatScore = (score) =>
+  Number.isNaN(score) ? "n/a" : `${score.toFixed(2)}%`;
+
+const [packageName, reportPath] = process.argv.slice(2);
+if (!packageName || !reportPath) {
+  console.error(
+    "usage: mutation-summary.mjs <package> <path/to/mutation.json>",
+  );
+  process.exit(1);
+}
+
+let report;
+try {
+  report = JSON.parse(await readFile(reportPath, "utf-8"));
+} catch {
+  // A run that fell over must not turn into a second, confusing failure: the
+  // mutation step itself already reported it.
+  await write(
+    `## \`${packageName}\` mutation score\n\nNo mutation report was produced (\`${reportPath}\`).\n\n`,
+  );
+  process.exit(0);
+}
+
+const { metrics } = calculateMetrics(report.files);
+const { mutationScore } = metrics;
+
+await write(
+  [
+    `## ${marker(mutationScore)} \`${packageName}\` — ${formatScore(mutationScore)}`,
+    "",
+    "| Killed | Survived | Timeout | No coverage | Ignored | Errors | Total |",
+    "| -----: | -------: | ------: | ----------: | ------: | -----: | ----: |",
+    `| ${metrics.killed} | ${metrics.survived} | ${metrics.timeout} | ${metrics.noCoverage} | ${metrics.ignored} | ${metrics.totalInvalid} | ${metrics.totalMutants} |`,
+    "",
+    `Thresholds: high ${THRESHOLDS.high}%, low ${THRESHOLDS.low}%.`,
+    "",
+    "",
+  ].join("\n"),
+);

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -55,4 +55,8 @@ jobs:
         run: bun run build
 
       - name: Run Mutations Tests
-        run: bun run --filter '@graphql-markdown/${{ matrix.package }}' stryker --allowEmpty --reporters dashboard --dashboard.module ${{matrix.package}}
+        run: bun run --filter '@graphql-markdown/${{ matrix.package }}' stryker --allowEmpty --reporters dashboard,json --dashboard.module ${{matrix.package}}
+
+      - name: Mutation summary
+        if: always()
+        run: bun .github/scripts/mutation-summary.mjs ${{ matrix.package }} packages/${{ matrix.package }}/reports/mutation/mutation.json

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "knip": "6.32.3",
         "lodash.filter": "4.6.0",
         "memfs": "4.68.1",
+        "mutation-testing-metrics": "3.8.4",
         "prettier": "catalog:",
         "turbo": "2.10.12",
         "typedoc": "0.28.20",

--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "knip": "6.32.3",
     "lodash.filter": "4.6.0",
     "memfs": "4.68.1",
+    "mutation-testing-metrics": "3.8.4",
     "prettier": "catalog:",
     "turbo": "2.10.12",
     "typedoc": "0.28.20",


### PR DESCRIPTION
# Description

The `Mutation Test` workflow reported only to the Stryker dashboard, so reading a PR's mutation outcome meant leaving GitHub and opening the dashboard per module. This adds a per-package mutation score summary to the checks page.

Stryker's own `markdown-summary-reporter` cannot do this — it is a **Stryker.NET** feature. StrykerJS 10 registers only `clear-text`, `progress`, `progress-append-only`, `dots`, `event-recorder`, `html`, `json` and `dashboard`; `htmlReporter` is a single-key object (`fileName`) whose output boots a `<mutation-test-report-app>` custom element, which a sanitized check summary cannot render; and `reporters/ci/github-actions-provider.js` only feeds the dashboard reporter its repo slug and branch.

So the summary is built CI-side from the `json` report:

- `.github/scripts/mutation-summary.mjs` reads `mutation.json` and appends a markdown table to `$GITHUB_STEP_SUMMARY` (stdout when run locally). It aggregates with `mutation-testing-metrics` — the same package the HTML report uses — so the numbers match the dashboard rather than re-deriving score semantics.
- The mutation step now passes `--reporters dashboard,json` (the CLI flag *replaces* the config's reporters, so `json` has to be listed explicitly).
- The summary step runs on `if: always()`, so a run that breaks the threshold still shows its score.
- `mutation-testing-metrics` was only a transitive dep of `@stryker-mutator/core` and not resolvable from the root, so it is now an explicit root devDependency pinned to the version core uses.

Per-package summaries only — no roll-up job.

Verified locally against `@graphql-markdown/logger`: the rendered table (89.13%, 41 killed, 5 survived, 36 errors) matches Stryker's own `clear-text` score table for the same run. Also checked that a missing report writes a note and exits `0`, that the summary file is appended to rather than overwritten, and that missing arguments exit `1`.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)