### PR TITLE
:sparkles: use Vocs native text directive for badge

### DIFF
--- a/packages/formatters/src/vocs/index.ts
+++ b/packages/formatters/src/vocs/index.ts
@@ -2,7 +2,6 @@
  * Vocs formatter for GraphQL documentation output.
  *
  * Produces MDX compatible with Vite/Vocs using its native callout syntax
- * and Material UI Chip components for badges.
  *
  * @packageDocumentation
  */
@@ -26,8 +25,6 @@ import {
 
 /** MDX import statement and inline component definitions prepended to every generated file. */
 export const mdxDeclaration: MDXString = `
-import Chip from '@mui/material/Chip';
-
 export const Bullet = () => <><span style={{ fontWeight: 'normal', fontSize: '.5em' }}>&nbsp;●&nbsp;</span></>
 ` as MDXString;
 
@@ -35,14 +32,14 @@ export const Bullet = () => <><span style={{ fontWeight: 'normal', fontSize: '.5
 export const mdxExtension = ".mdx" as const;
 
 /**
- * Formats a badge using the Material UI `<Chip>` component.
- * Maps `DEPRECATED` classname to `warning` color; all others use `info`.
+ * Formats a badge using Vocs native text directive (`:badge[...]`).
+ * Maps `DEPRECATED` classname to `warning` color; all others use default.
  * @param badge - Badge data containing text and optional classname
- * @returns Formatted MUI Chip component string
+ * @returns Formatted Vocs badge string
  */
 export const formatMDXBadge = ({ text, classname }: Badge): MDXString => {
-  const color = classname === "DEPRECATED" ? "warning" : "info";
-  return `<Chip color="${color}" label="${text as string}" size="small" variant="outlined"/>` as MDXString;
+  const badgeType = classname === "DEPRECATED" ? "{warning}" : "";
+  return `:badge[${text as string}]${badgeType}` as MDXString;
 };
 
 /**

--- a/packages/formatters/tests/unit/vocs/index.test.ts
+++ b/packages/formatters/tests/unit/vocs/index.test.ts
@@ -12,8 +12,7 @@ import {
 } from "../../../src/vocs/index";
 
 describe("mdxDeclaration", () => {
-  test("imports MUI Chip and defines Bullet component", () => {
-    expect(mdxDeclaration).toContain("@mui/material/Chip");
+  test("defines Bullet component", () => {
     expect(mdxDeclaration).toContain("Bullet");
   });
 });
@@ -21,8 +20,7 @@ describe("mdxDeclaration", () => {
 describe("formatMDXBadge", () => {
   test("renders MUI Chip for default classname", () => {
     const result = formatMDXBadge({ text: "Required", classname: "required" });
-    expect(result).toContain('<Chip color="info"');
-    expect(result).toContain('label="Required"');
+    expect(result).toMatch(":badge[Required]");
   });
 
   test("renders caution color for DEPRECATED classname", () => {
@@ -30,7 +28,7 @@ describe("formatMDXBadge", () => {
       text: "Deprecated",
       classname: "DEPRECATED",
     });
-    expect(result).toContain('color="warning"');
+    expect(result).toMatch(":badge[Deprecated]{warning}");
   });
 });
 


### PR DESCRIPTION
# Description

Replace MUI Chips component by Vocs native Markdown extension for badge `:badge[...]`

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
