### PR TITLE
🔖  release 1.35.2

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.21.1",
+  "version": "1.21.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.16",
+  "version": "1.1.17",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.35.1",
+  "version": "1.35.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.2.3",
+  "version": "1.2.4",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.1",
+  "version": "1.1.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.8",
+  "version": "1.0.9",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.16.1",
+  "version": "1.16.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-markdown/types",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "Common types for @graphql-markdown packages",
   "repository": {
     "type": "git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.12.1",
+  "version": "1.12.2",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

Release 1.35.2

# Release Notes (Draft)
1.35.2 introduces support for **GraphQL.js v17**. It also adds some minor improvements to Fumadocs, Astro Starlight, and Vocs formatters.

### Bug Fixes 🐛

- **Fumadocs formatter**: drop `.mdx` extension from links (#3218).
- **Astro Starlight formatter**: remove `index.md` file generation (#3239).

### Maintenance 🧹

- Add support for GraphQL.js v17 (#3240).
- **Vocs formatter**: use Vocs native text directive for badge instead of MUI chip component (#3248).

### Package Versions 📦

| Package | Version |
|---|---|
| @graphql-markdown/docusaurus | 1.35.2 |
| @graphql-markdown/core | 1.21.2 |
| @graphql-markdown/printer-legacy | 1.16.2 |
| @graphql-markdown/types | 1.13.2 |
| @graphql-markdown/utils | 1.12.2 |
| @graphql-markdown/graphql | 1.2.4 |
| @graphql-markdown/cli | 1.0.2 |
| @graphql-markdown/diff | 1.1.17 |
| @graphql-markdown/helpers | 1.1.2 |
| @graphql-markdown/logger | 1.0.9 |
| @graphql-markdown/formatters | 1.0.2 |

**Full Changelog (draft)**: https://github.com/graphql-markdown/graphql-markdown/compare/1.35.1...1.35.2


# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
