### PR TITLE
🐛 fix(core): address output adapter review findings

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -378,8 +378,6 @@ const baseURL = "schema";
 const outputDir = path.join(rootPath, baseURL);
 
 const BUCKET = "docs";
-const KEY_PREFIX = "schema/";
-
 const r2 = new S3Client({
   region: "auto",
   endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
@@ -389,17 +387,13 @@ const r2 = new S3Client({
   },
 });
 
-// Object keys are the page paths relative to the output directory, always
-// forward-slashed so keys are identical whichever OS generated them. mdBook
-// writes its SUMMARY.md one level above the output directory, so `..` segments
-// are folded away rather than sent to a store that would reject them.
+// Object keys are the paths relative to `rootPath`, always forward-slashed so
+// keys are identical whichever OS generated them. Keying off `rootPath` rather
+// than `outputDir` keeps the layout intact for mdBook's SUMMARY.md, which sits
+// one level above the pages: it lands at `SUMMARY.md`, above `schema/`, so the
+// links it holds still resolve.
 const toKey = (location) =>
-  KEY_PREFIX +
-  path
-    .relative(outputDir, location)
-    .split(path.sep)
-    .filter((segment) => segment !== "..")
-    .join("/");
+  path.relative(rootPath, location).split(path.sep).join("/");
 
 module.exports = {
   // ...

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -456,7 +456,9 @@ Content arrives already formatted, so an adapter never has to handle [`pretty`](
 
 :::caution
 
-The [`formatter`](#formatter) presets that post-process their own output — DocFX, mdBook and MkDocs — read each page back after it is written. A destination that cannot serve back what it wrote may return `undefined` from `readFile`, but then those presets cannot rewrite internal links, and DocFX gets no `toc.yml`: the first page that cannot be read back is reported, once per run, and the post-processing is skipped. Presets that never read back their output (Docusaurus, Starlight, Fumadocs, Vocs, Hugo, HonKit) are unaffected.
+The [`formatter`](#formatter) presets that post-process their own output — DocFX, mdBook and MkDocs — read each page back after it is written. A destination that cannot serve back what it wrote may return `undefined` from `readFile`, but then those presets cannot rewrite internal links, and DocFX gets no `toc.yml`: the first page an adapter cannot read back is reported, once for that adapter, and the post-processing is skipped.
+
+Docusaurus also reads back, once per category, to leave an existing `_category_.yml` alone: an adapter that cannot serve it back regenerates the file on every run, overwriting hand-made edits to it. Starlight, Fumadocs, Vocs, Hugo and HonKit never read back their output.
 
 :::
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -433,7 +433,10 @@ module.exports = {
         return;
       }
 
-      const Prefix = toKey(dirPath);
+      // S3 prefix matching is literal, not directory aware: without the
+      // trailing delimiter, clearing `schema` would also delete `schema-v2/`.
+      const dirKey = toKey(dirPath);
+      const Prefix = dirKey === "" ? "" : `${dirKey}/`;
       let ContinuationToken;
 
       do {
@@ -465,7 +468,7 @@ module.exports = {
 
 :::info
 
-`ensureDir` is optional so destinations with no directory concept can omit it; it receives `{ forceEmpty: true }` when [`force`](#force) is set. Paths are the same ones the filesystem writer would use, rooted at the output directory and relative to the working directory unless [`rootPath`](#rootpath) is itself absolute. The one exception is mdBook's `SUMMARY.md`, which the format requires one level above the output directory, so an adapter mapping paths to keys should expect a leading `..` there — an adapter backed by something other than a filesystem can treat them as opaque keys.
+`ensureDir` is optional so destinations with no directory concept can omit it; it receives `{ forceEmpty: true }` when [`force`](#force) is set. Paths are the same ones the filesystem writer would use, rooted at the output directory and relative to the working directory unless [`rootPath`](#rootpath) is itself absolute. The one exception is mdBook's `SUMMARY.md`, which the format requires one level above the output directory: the adapter is handed a path inside [`rootPath`](#rootpath) but outside `outputDir`, so keys derived with `path.relative(outputDir, filePath)` gain a leading `..` for that one file — an adapter backed by something other than a filesystem can treat them as opaque keys.
 
 Content arrives already formatted, so an adapter never has to handle [`pretty`](#pretty) itself.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -368,6 +368,7 @@ const path = require("node:path");
 const {
   S3Client,
   PutObjectCommand,
+  GetObjectCommand,
   ListObjectsV2Command,
   DeleteObjectsCommand,
 } = require("@aws-sdk/client-s3");
@@ -389,9 +390,16 @@ const r2 = new S3Client({
 });
 
 // Object keys are the page paths relative to the output directory, always
-// forward-slashed so keys are identical whichever OS generated them.
+// forward-slashed so keys are identical whichever OS generated them. mdBook
+// writes its SUMMARY.md one level above the output directory, so `..` segments
+// are folded away rather than sent to a store that would reject them.
 const toKey = (location) =>
-  KEY_PREFIX + path.relative(outputDir, location).split(path.sep).join("/");
+  KEY_PREFIX +
+  path
+    .relative(outputDir, location)
+    .split(path.sep)
+    .filter((segment) => segment !== "..")
+    .join("/");
 
 module.exports = {
   // ...
@@ -407,6 +415,21 @@ module.exports = {
           ContentType: "text/markdown",
         }),
       );
+    },
+    // Required: the formatters that post-process their own output read each
+    // page back. A missing object is "there is nothing here", not a failure.
+    readFile: async (filePath) => {
+      try {
+        const object = await r2.send(
+          new GetObjectCommand({ Bucket: BUCKET, Key: toKey(filePath) }),
+        );
+        return await object.Body.transformToString();
+      } catch (error) {
+        if (error.name === "NoSuchKey") {
+          return undefined;
+        }
+        throw error;
+      }
     },
     // R2 has no directories, so there is nothing to create. The work worth
     // doing is honouring `forceEmpty`: without it, pages for types deleted
@@ -448,7 +471,7 @@ module.exports = {
 
 :::info
 
-`ensureDir` is optional so destinations with no directory concept can omit it; it receives `{ forceEmpty: true }` when [`force`](#force) is set. Paths are the same ones the filesystem writer would use, rooted at the output directory and relative to the working directory unless [`rootPath`](#rootpath) is itself absolute — an adapter backed by something other than a filesystem can treat them as opaque keys.
+`ensureDir` is optional so destinations with no directory concept can omit it; it receives `{ forceEmpty: true }` when [`force`](#force) is set. Paths are the same ones the filesystem writer would use, rooted at the output directory and relative to the working directory unless [`rootPath`](#rootpath) is itself absolute. The one exception is mdBook's `SUMMARY.md`, which the format requires one level above the output directory, so an adapter mapping paths to keys should expect a leading `..` there — an adapter backed by something other than a filesystem can treat them as opaque keys.
 
 Content arrives already formatted, so an adapter never has to handle [`pretty`](#pretty) itself.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -348,16 +348,16 @@ The destination for generated documentation. By default pages are written to the
 | --------------- | -------- | -------------------- |
 | `outputAdapter` | none     | local filesystem     |
 
-An adapter must provide `writeFile`, and may provide `ensureDir` and `readFile`:
+An adapter must provide `writeFile` and `readFile`, and may provide `ensureDir`:
 
 ```ts
 interface OutputAdapter {
   writeFile: (filePath: string, content: string) => Promise<void>;
+  readFile: (filePath: string) => Promise<string | undefined>;
   ensureDir?: (
     dirPath: string,
     options?: { forceEmpty?: boolean },
   ) => Promise<void>;
-  readFile?: (filePath: string) => Promise<string | undefined>;
 }
 ```
 
@@ -456,7 +456,7 @@ Content arrives already formatted, so an adapter never has to handle [`pretty`](
 
 :::caution
 
-The [`formatter`](#formatter) presets that post-process their own output — DocFX, mdBook and MkDocs — read each page back after it is written, and so need `readFile`. Without it those runs report an error per page and skip the post-processing, which means internal links are left as absolute paths, and DocFX gets no `toc.yml`. Presets that never read back their output (Docusaurus, Starlight, Fumadocs, Vocs, Hugo, HonKit) work with `writeFile` alone.
+The [`formatter`](#formatter) presets that post-process their own output — DocFX, mdBook and MkDocs — read each page back after it is written. A destination that cannot serve back what it wrote may return `undefined` from `readFile`, but then those presets cannot rewrite internal links, and DocFX gets no `toc.yml`: the first page that cannot be read back is reported, once per run, and the post-processing is skipped. Presets that never read back their output (Docusaurus, Starlight, Fumadocs, Vocs, Hugo, HonKit) are unaffected.
 
 :::
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -348,7 +348,7 @@ The destination for generated documentation. By default pages are written to the
 | --------------- | -------- | -------------------- |
 | `outputAdapter` | none     | local filesystem     |
 
-An adapter must provide `writeFile`, and may provide `ensureDir`:
+An adapter must provide `writeFile`, and may provide `ensureDir` and `readFile`:
 
 ```ts
 interface OutputAdapter {
@@ -357,6 +357,7 @@ interface OutputAdapter {
     dirPath: string,
     options?: { forceEmpty?: boolean },
   ) => Promise<void>;
+  readFile?: (filePath: string) => Promise<string | undefined>;
 }
 ```
 
@@ -447,9 +448,15 @@ module.exports = {
 
 :::info
 
-`ensureDir` is optional so destinations with no directory concept can omit it; it receives `{ forceEmpty: true }` when [`force`](#force) is set. Paths are the same absolute paths the filesystem writer would use, rooted at the output directory — an adapter backed by something other than a filesystem can treat them as opaque keys.
+`ensureDir` is optional so destinations with no directory concept can omit it; it receives `{ forceEmpty: true }` when [`force`](#force) is set. Paths are the same ones the filesystem writer would use, rooted at the output directory and relative to the working directory unless [`rootPath`](#rootpath) is itself absolute — an adapter backed by something other than a filesystem can treat them as opaque keys.
 
 Content arrives already formatted, so an adapter never has to handle [`pretty`](#pretty) itself.
+
+:::
+
+:::caution
+
+The [`formatter`](#formatter) presets that post-process their own output — DocFX, mdBook and MkDocs — read each page back after it is written, and so need `readFile`. Without it those runs report an error per page and skip the post-processing, which means internal links are left as absolute paths, and DocFX gets no `toc.yml`. Presets that never read back their output (Docusaurus, Starlight, Fumadocs, Vocs, Hugo, HonKit) work with `writeFile` alone.
 
 :::
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -136,6 +136,9 @@ export const DEFAULT_HIERARCHY = { [TypeHierarchy.API]: {} };
  * @public
  * @see {@link Options} for the complete configuration interface
  */
+/** Memoised OS temp path, resolved on the first read of `DEFAULT_OPTIONS.tmpDir`. */
+let defaultTmpDir: string | undefined;
+
 export const DEFAULT_OPTIONS: Readonly<
   Pick<
     ConfigOptions,
@@ -193,9 +196,11 @@ export const DEFAULT_OPTIONS: Readonly<
   schema: "./schema.graphql",
   // Lazy: as a plain property this ran `tmpdir()` at module load, so merely
   // importing the config module touched the OS temp path even for runs that
-  // never diff. The getter defers it to the point a default is actually needed.
+  // never diff. The getter defers it to the point a default is actually needed,
+  // and memoises it since a single build reads it more than once.
   get tmpDir(): string {
-    return join(tmpdir(), PACKAGE_NAME);
+    defaultTmpDir ??= join(tmpdir(), PACKAGE_NAME);
+    return defaultTmpDir;
   },
   skipDocDirective: [] as DirectiveName[],
   onlyDocDirective: [] as DirectiveName[],
@@ -801,6 +806,13 @@ export const buildConfig = async (
     configFileOpts ?? {},
   );
 
+  // deepmerge rebuilds objects as prototype-less plain copies, which strips the
+  // methods off a class-based adapter. Take it from the raw sources instead, so
+  // `new MyAdapter()` keeps working as well as an object literal.
+  const outputAdapter =
+    configFileOpts?.outputAdapter ??
+    (graphqlConfig as Maybe<ConfigOptions>)?.outputAdapter;
+
   const { onlyDocDirective, skipDocDirective } = getVisibilityDirectives(
     cliOpts,
     config,
@@ -861,7 +873,7 @@ export const buildConfig = async (
     formatter: parseDeprecatedFormatterOption(cliOpts, config),
     metatags: config.metatags ?? DEFAULT_OPTIONS.metatags,
     onlyDocDirective,
-    outputAdapter: config.outputAdapter,
+    outputAdapter,
     outputDir: join(rootPath, baseURL),
     prettify,
     printTypeOptions: getPrintTypeOptions(cliOpts, config.printTypeOptions),

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -809,9 +809,13 @@ export const buildConfig = async (
   // deepmerge rebuilds objects as prototype-less plain copies, which strips the
   // methods off a class-based adapter. Take it from the raw sources instead, so
   // `new MyAdapter()` keeps working as well as an object literal.
+  // `??` would let a config file that sets `outputAdapter: null` to disable an
+  // adapter inherited from GraphQL Config fall back to that adapter instead, so
+  // precedence is decided on the property being present, not on its value.
   const outputAdapter =
-    configFileOpts?.outputAdapter ??
-    (graphqlConfig as Maybe<ConfigOptions>)?.outputAdapter;
+    configFileOpts && "outputAdapter" in configFileOpts
+      ? configFileOpts.outputAdapter
+      : (graphqlConfig as Maybe<ConfigOptions>)?.outputAdapter;
 
   const { onlyDocDirective, skipDocDirective } = getVisibilityDirectives(
     cliOpts,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -129,6 +129,9 @@ export const ASSET_HOMEPAGE_LOCATION = join(
  */
 export const DEFAULT_HIERARCHY = { [TypeHierarchy.API]: {} };
 
+/** Memoised OS temp path, resolved on the first read of `DEFAULT_OPTIONS.tmpDir`. */
+let defaultTmpDir: string | undefined;
+
 /**
  * Default configuration options used when no user options are provided.
  * These values serve as fallbacks for any missing configuration.
@@ -136,9 +139,6 @@ export const DEFAULT_HIERARCHY = { [TypeHierarchy.API]: {} };
  * @public
  * @see {@link Options} for the complete configuration interface
  */
-/** Memoised OS temp path, resolved on the first read of `DEFAULT_OPTIONS.tmpDir`. */
-let defaultTmpDir: string | undefined;
-
 export const DEFAULT_OPTIONS: Readonly<
   Pick<
     ConfigOptions,

--- a/packages/core/src/events/generate-index-metafile.ts
+++ b/packages/core/src/events/generate-index-metafile.ts
@@ -4,6 +4,7 @@
  * @packageDocumentation
  */
 
+import type { OutputAdapter } from "@graphql-markdown/types";
 import type { CancellableEventOptions } from "@graphql-markdown/utils";
 import { DataEvent } from "@graphql-markdown/utils";
 
@@ -15,12 +16,15 @@ import { DataEvent } from "@graphql-markdown/utils";
 export class GenerateIndexMetafileEvent extends DataEvent<{
   dirPath: string;
   category: string;
+  /** Destination the metafile must be written to. */
+  outputAdapter?: OutputAdapter;
   options?: Record<string, unknown>;
 }> {
   constructor(
     data: {
       dirPath: string;
       category: string;
+      outputAdapter?: OutputAdapter;
       options?: Record<string, unknown>;
     },
     options?: CancellableEventOptions,

--- a/packages/core/src/events/render-files.ts
+++ b/packages/core/src/events/render-files.ts
@@ -4,6 +4,7 @@
  * @packageDocumentation
  */
 
+import type { Maybe, OutputAdapter } from "@graphql-markdown/types";
 import type { CancellableEventOptions } from "@graphql-markdown/utils";
 import { DataEvent } from "@graphql-markdown/utils";
 
@@ -17,6 +18,8 @@ export class RenderFilesEvent extends DataEvent<{
   outputDir: string;
   rootDir: string;
   pages: unknown;
+  /** Destination the pages were written to; use it for any summary file. */
+  outputAdapter?: Maybe<OutputAdapter>;
 }> {
   constructor(
     data: {
@@ -24,6 +27,7 @@ export class RenderFilesEvent extends DataEvent<{
       outputDir: string;
       rootDir: string;
       pages: unknown;
+      outputAdapter?: Maybe<OutputAdapter>;
     },
     options?: CancellableEventOptions,
   ) {

--- a/packages/core/src/events/render-files.ts
+++ b/packages/core/src/events/render-files.ts
@@ -19,7 +19,7 @@ export class RenderFilesEvent extends DataEvent<{
   rootDir: string;
   pages: unknown;
   /** Destination the pages were written to; use it for any summary file. */
-  outputAdapter?: OutputAdapter | null;
+  outputAdapter?: OutputAdapter;
 }> {
   constructor(
     data: {
@@ -27,7 +27,7 @@ export class RenderFilesEvent extends DataEvent<{
       outputDir: string;
       rootDir: string;
       pages: unknown;
-      outputAdapter?: OutputAdapter | null;
+      outputAdapter?: OutputAdapter;
     },
     options?: CancellableEventOptions,
   ) {

--- a/packages/core/src/events/render-files.ts
+++ b/packages/core/src/events/render-files.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import type { Maybe, OutputAdapter } from "@graphql-markdown/types";
+import type { OutputAdapter } from "@graphql-markdown/types";
 import type { CancellableEventOptions } from "@graphql-markdown/utils";
 import { DataEvent } from "@graphql-markdown/utils";
 
@@ -19,7 +19,7 @@ export class RenderFilesEvent extends DataEvent<{
   rootDir: string;
   pages: unknown;
   /** Destination the pages were written to; use it for any summary file. */
-  outputAdapter?: Maybe<OutputAdapter>;
+  outputAdapter?: OutputAdapter | null;
 }> {
   constructor(
     data: {
@@ -27,7 +27,7 @@ export class RenderFilesEvent extends DataEvent<{
       outputDir: string;
       rootDir: string;
       pages: unknown;
-      outputAdapter?: Maybe<OutputAdapter>;
+      outputAdapter?: OutputAdapter | null;
     },
     options?: CancellableEventOptions,
   ) {

--- a/packages/core/src/events/render-type-entities.ts
+++ b/packages/core/src/events/render-type-entities.ts
@@ -4,6 +4,7 @@
  * @packageDocumentation
  */
 
+import type { OutputAdapter } from "@graphql-markdown/types";
 import type { CancellableEventOptions } from "@graphql-markdown/utils";
 import { DataEvent } from "@graphql-markdown/utils";
 
@@ -17,6 +18,8 @@ export class RenderTypeEntitiesEvent extends DataEvent<{
   name: string;
   filePath: string;
   outputDir: string;
+  /** Destination the page was written to; use it to read the page back. */
+  outputAdapter?: OutputAdapter;
 }> {
   constructor(
     data: {
@@ -24,6 +27,7 @@ export class RenderTypeEntitiesEvent extends DataEvent<{
       name: string;
       filePath: string;
       outputDir: string;
+      outputAdapter?: OutputAdapter;
     },
     options?: CancellableEventOptions,
   ) {

--- a/packages/core/src/generator.ts
+++ b/packages/core/src/generator.ts
@@ -40,7 +40,7 @@ import { dirname } from "node:path";
 import { DiffMethod } from "./config";
 import { hasChanges } from "./diff";
 import { getPrinter } from "./printer";
-import { getRenderer } from "./renderer";
+import { getRenderer, logHandlerErrors } from "./renderer";
 import { getEvents } from "./event-emitter";
 import {
   SchemaEvent,
@@ -541,7 +541,7 @@ export const generateDocFromSchema = async ({
     afterRenderHomepageEvent,
   );
 
-  await events.emitAsync(
+  const { errors: renderFilesErrors } = await events.emitAsync(
     RenderFilesEvents.AFTER_RENDER,
     new RenderFilesEvent({
       baseURL,
@@ -552,6 +552,9 @@ export const generateDocFromSchema = async ({
       outputAdapter: renderer.outputAdapter,
     }),
   );
+  // without this a failure to write mdBook's SUMMARY.md is dropped, and the
+  // success line below claims the documentation is complete
+  logHandlerErrors(RenderFilesEvents.AFTER_RENDER, renderFilesErrors);
 
   const duration = (
     Number(process.hrtime.bigint() - start) / NS_PER_SEC

--- a/packages/core/src/generator.ts
+++ b/packages/core/src/generator.ts
@@ -548,6 +548,7 @@ export const generateDocFromSchema = async ({
       outputDir,
       rootDir: dirname(outputDir),
       pages,
+      outputAdapter,
     }),
   );
 

--- a/packages/core/src/generator.ts
+++ b/packages/core/src/generator.ts
@@ -560,10 +560,19 @@ export const generateDocFromSchema = async ({
     Number(process.hrtime.bigint() - start) / NS_PER_SEC
   ).toFixed(SEC_DECIMALS);
 
-  log(
-    `Documentation successfully generated in "${outputDir}" with base URL "${baseURL}".`,
-    "success",
-  );
+  // a formatter that could not finish its output must not be reported as a
+  // success: mdBook cannot build without the SUMMARY.md written by that hook
+  if (renderFilesErrors.length > 0) {
+    log(
+      `Documentation generated in "${outputDir}" with base URL "${baseURL}", but ${renderFilesErrors.length} post-processing error(s) occurred: the output is incomplete.`,
+      LogLevel.error,
+    );
+  } else {
+    log(
+      `Documentation successfully generated in "${outputDir}" with base URL "${baseURL}".`,
+      "success",
+    );
+  }
   log(
     `${
       pages.flat().length

--- a/packages/core/src/generator.ts
+++ b/packages/core/src/generator.ts
@@ -548,7 +548,8 @@ export const generateDocFromSchema = async ({
       outputDir,
       rootDir: dirname(outputDir),
       pages,
-      outputAdapter,
+      // the resolved adapter, so a hook never has to fall back for itself
+      outputAdapter: renderer.outputAdapter,
     }),
   );
 

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -334,6 +334,21 @@ class CategoryPositionManager {
  * Each level has its own CategoryPositionManager that restarts numbering at 1.
  * @example
  */
+/**
+ * Reports errors thrown by event handlers.
+ *
+ * Handler errors are collected rather than thrown, so without this they are
+ * dropped and the formatter's post-processing silently does nothing.
+ *
+ * @param eventName - Name of the emitted event
+ * @param errors - Errors collected from the handlers
+ */
+const logHandlerErrors = (eventName: string, errors: Error[]): void => {
+  errors.forEach((error) => {
+    log(`Error handler for ${eventName}: ${error.message}`, LogLevel.error);
+  });
+};
+
 // Value export used only by unit tests for direct whitebox coverage; the type is used
 // elsewhere via getRenderer()'s return type.
 export class Renderer {
@@ -431,30 +446,30 @@ export class Renderer {
     const event = new GenerateIndexMetafileEvent({
       dirPath,
       category,
+      outputAdapter: this.outputAdapter,
       options: {
         ...finalOptions,
         sidebarPosition,
         index: this.options?.index,
       },
     });
-    const handlerErrors = await events.emitAsync(
+    // emitAsync resolves to an EmitResult, never an array: the previous
+    // Array.isArray() guard was always false, so handler errors went unreported
+    const { errors } = await events.emitAsync(
       GenerateIndexMetafileEvents.BEFORE_GENERATE,
       event,
     );
+    logHandlerErrors(GenerateIndexMetafileEvents.BEFORE_GENERATE, errors);
 
-    if (Array.isArray(handlerErrors) && handlerErrors.length > 0) {
-      handlerErrors.forEach((error) => {
-        log(
-          `Error handler for ${GenerateIndexMetafileEvents.BEFORE_GENERATE}: ${error.message}`,
-          LogLevel.error,
-        );
-      });
-    }
-
-    await events.emitAsync(
+    const { errors: afterErrors } = await events.emitAsync(
       GenerateIndexMetafileEvents.AFTER_GENERATE,
-      new GenerateIndexMetafileEvent({ dirPath, category }),
+      new GenerateIndexMetafileEvent({
+        dirPath,
+        category,
+        outputAdapter: this.outputAdapter,
+      }),
     );
+    logHandlerErrors(GenerateIndexMetafileEvents.AFTER_GENERATE, afterErrors);
   }
 
   /**
@@ -725,8 +740,13 @@ export class Renderer {
       name,
       filePath,
       outputDir: this.outputDir,
+      outputAdapter: this.outputAdapter,
     });
-    await events.emitAsync(RenderTypeEntitiesEvents.AFTER_RENDER, event);
+    const { errors } = await events.emitAsync(
+      RenderTypeEntitiesEvents.AFTER_RENDER,
+      event,
+    );
+    logHandlerErrors(RenderTypeEntitiesEvents.AFTER_RENDER, errors);
 
     return {
       category,

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -324,17 +324,6 @@ class CategoryPositionManager {
 }
 
 /**
- * Core renderer class responsible for generating documentation files from GraphQL schema entities.
- * Handles the conversion of schema types to markdown/MDX documentation with proper organization.
- *
- * HIERARCHY LEVELS WHEN categorySort IS ENABLED:
- * - Level 0 (root): Query, Mutation, Subscription, Custom Groups → 01-Query, 02-Mutation, etc.
- * - Level 1 (under root): Specific types within each root → 01-Objects, 02-Enums, etc.
- *
- * Each level has its own CategoryPositionManager that restarts numbering at 1.
- * @example
- */
-/**
  * Reports errors thrown by event handlers.
  *
  * Handler errors are collected rather than thrown, so without this they are
@@ -349,6 +338,17 @@ export const logHandlerErrors = (eventName: string, errors: Error[]): void => {
   });
 };
 
+/**
+ * Core renderer class responsible for generating documentation files from GraphQL schema entities.
+ * Handles the conversion of schema types to markdown/MDX documentation with proper organization.
+ *
+ * HIERARCHY LEVELS WHEN categorySort IS ENABLED:
+ * - Level 0 (root): Query, Mutation, Subscription, Custom Groups → 01-Query, 02-Mutation, etc.
+ * - Level 1 (under root): Specific types within each root → 01-Objects, 02-Enums, etc.
+ *
+ * Each level has its own CategoryPositionManager that restarts numbering at 1.
+ * @example
+ */
 // Value export used only by unit tests for direct whitebox coverage; the type is used
 // elsewhere via getRenderer()'s return type.
 export class Renderer {

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -343,7 +343,7 @@ class CategoryPositionManager {
  * @param eventName - Name of the emitted event
  * @param errors - Errors collected from the handlers
  */
-const logHandlerErrors = (eventName: string, errors: Error[]): void => {
+export const logHandlerErrors = (eventName: string, errors: Error[]): void => {
   errors.forEach((error) => {
     log(`Error handler for ${eventName}: ${error.message}`, LogLevel.error);
   });

--- a/packages/core/tests/unit/config.test.ts
+++ b/packages/core/tests/unit/config.test.ts
@@ -253,9 +253,12 @@ describe("config", () => {
       expect.assertions(2);
 
       class TestOutputAdapter {
-        public readonly writes: string[] = [];
-        async writeFile(filePath: string): Promise<void> {
-          this.writes.push(filePath);
+        public readonly writes = new Map<string, string>();
+        async writeFile(filePath: string, content: string): Promise<void> {
+          this.writes.set(filePath, content);
+        }
+        async readFile(filePath: string): Promise<string | undefined> {
+          return this.writes.get(filePath);
         }
       }
       const outputAdapter = new TestOutputAdapter();

--- a/packages/core/tests/unit/config.test.ts
+++ b/packages/core/tests/unit/config.test.ts
@@ -249,6 +249,24 @@ describe("config", () => {
   });
 
   describe("buildConfig()", () => {
+    test("preserves the methods of a class based outputAdapter", async () => {
+      expect.assertions(2);
+
+      class TestOutputAdapter {
+        public readonly writes: string[] = [];
+        async writeFile(filePath: string): Promise<void> {
+          this.writes.push(filePath);
+        }
+      }
+      const outputAdapter = new TestOutputAdapter();
+
+      const config = await buildConfig({ outputAdapter }, undefined, undefined);
+
+      // deepmerge would rebuild it as a prototype-less copy, dropping writeFile
+      expect(config.outputAdapter).toBe(outputAdapter);
+      expect(typeof config.outputAdapter!.writeFile).toBe("function");
+    });
+
     test("returns default options is no config set", async () => {
       expect.hasAssertions();
 

--- a/packages/core/tests/unit/generator.test.ts
+++ b/packages/core/tests/unit/generator.test.ts
@@ -32,13 +32,14 @@ import * as CoreDiff from "../../src/diff";
 
 vi.mock("../../src/diff");
 import * as CoreRenderer from "../../src/renderer";
+import { RenderFilesEvents } from "../../src/events";
 
 vi.mock("../../src/renderer");
 import * as CorePrinter from "../../src/printer";
 
 vi.mock("../../src/printer");
 
-import { resetEvents } from "../../src/event-emitter";
+import { getEvents, resetEvents } from "../../src/event-emitter";
 
 /*
  * `generateDocFromSchema()` calls the helpers exported by `src/generator.ts`
@@ -539,6 +540,37 @@ describe("generator", () => {
       // Verify execution completes and summary is printed even with empty schema
       expect(loggerSpy).toHaveBeenCalledWith(
         expect.stringContaining("Documentation successfully generated"),
+      );
+    });
+
+    test("does not report success when a render hook failed", async () => {
+      expect.assertions(2);
+
+      const mockSchema = { getDirective } as unknown as GraphQLSchema;
+      mockSchemaLoad(mockSchema);
+
+      vi.spyOn(GraphQL, "getSchemaMap").mockReturnValueOnce({} as SchemaMap);
+      vi.spyOn(CorePrinter, "getPrinter").mockResolvedValueOnce(
+        {} as unknown as typeof IPrinter,
+      );
+      vi.spyOn(CoreRenderer, "getRenderer").mockResolvedValueOnce(mockRenderer);
+
+      // a formatter hook that cannot finish, eg. mdBook failing to write its
+      // required SUMMARY.md
+      getEvents().on(RenderFilesEvents.AFTER_RENDER, () => {
+        throw new Error("SUMMARY.md write failed");
+      });
+
+      const infoSpy = vi.spyOn(globalThis.console, "info");
+      const errorSpy = vi.spyOn(globalThis.console, "error");
+
+      await generateDocFromSchema(options);
+
+      expect(infoSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("Documentation successfully generated"),
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("the output is incomplete"),
       );
     });
 

--- a/packages/docusaurus/src/mdx/category.ts
+++ b/packages/docusaurus/src/mdx/category.ts
@@ -7,12 +7,8 @@
 
 import { join } from "node:path";
 
-import {
-  ensureDir,
-  fileExists,
-  saveFile,
-  startCase,
-} from "@graphql-markdown/utils";
+import type { OutputAdapter } from "@graphql-markdown/types";
+import { fsOutputAdapter, startCase } from "@graphql-markdown/utils";
 
 const CATEGORY_YAML = "_category_.yml" as const;
 
@@ -32,13 +28,21 @@ export const beforeGenerateIndexMetafileHook = async (event: {
   data: {
     dirPath: string;
     category: string;
+    outputAdapter?: OutputAdapter;
     options?: Record<string, unknown>;
   };
 }): Promise<void> => {
-  const { dirPath, category, options } = event.data;
+  const { dirPath, category, options, outputAdapter } = event.data;
   const filePath = join(dirPath, CATEGORY_YAML);
+  // the metafile goes to the same destination as the pages, so a custom output
+  // adapter keeps the sidebar metadata alongside what it wrote
+  const adapter = outputAdapter ?? fsOutputAdapter;
 
-  if (await fileExists(filePath)) {
+  // preserve a metafile that is already there, when the destination can be read
+  if (
+    typeof adapter.readFile === "function" &&
+    typeof (await adapter.readFile(filePath)) === "string"
+  ) {
     return;
   }
 
@@ -59,6 +63,6 @@ export const beforeGenerateIndexMetafileHook = async (event: {
       : SidebarPosition.FIRST;
   const content = `label: ${label}\nposition: ${position}\n${className}link: ${link}\ncollapsible: ${Boolean(options?.collapsible ?? true)}\ncollapsed: ${Boolean(options?.collapsed ?? true)}\n`;
 
-  await ensureDir(dirPath);
-  await saveFile(filePath, content);
+  await adapter.ensureDir?.(dirPath);
+  await adapter.writeFile(filePath, content);
 };

--- a/packages/docusaurus/src/mdx/category.ts
+++ b/packages/docusaurus/src/mdx/category.ts
@@ -38,11 +38,8 @@ export const beforeGenerateIndexMetafileHook = async (event: {
   // adapter keeps the sidebar metadata alongside what it wrote
   const adapter = outputAdapter ?? fsOutputAdapter;
 
-  // preserve a metafile that is already there, when the destination can be read
-  if (
-    typeof adapter.readFile === "function" &&
-    typeof (await adapter.readFile(filePath)) === "string"
-  ) {
+  // preserve a metafile that is already there
+  if (typeof (await adapter.readFile(filePath)) === "string") {
     return;
   }
 

--- a/packages/docusaurus/tests/unit/mdx/category.test.ts
+++ b/packages/docusaurus/tests/unit/mdx/category.test.ts
@@ -10,6 +10,11 @@ vi.mock("@graphql-markdown/utils", async (importOriginal): Promise<unknown> => {
     saveFile: vi.fn(),
     copyFile: vi.fn(),
     readFile: vi.fn(),
+    fsOutputAdapter: {
+      writeFile: vi.fn(),
+      ensureDir: vi.fn(),
+      readFile: vi.fn(),
+    },
   };
 });
 import * as Utils from "@graphql-markdown/utils";
@@ -25,8 +30,8 @@ describe("beforeGenerateIndexMetafileHook()", () => {
     const outputPath = path.join("/output/docs", category);
     const filePath = path.join(outputPath, CATEGORY_YAML);
 
-    vi.spyOn(Utils, "fileExists").mockResolvedValue(false);
-    const spy = vi.spyOn(Utils, "saveFile");
+    vi.mocked(Utils.fsOutputAdapter.readFile!).mockResolvedValue(undefined);
+    const spy = vi.mocked(Utils.fsOutputAdapter.writeFile);
 
     await beforeGenerateIndexMetafileHook({
       data: {
@@ -48,8 +53,8 @@ describe("beforeGenerateIndexMetafileHook()", () => {
     const outputPath = path.join("/output/docs", category);
     const filePath = path.join(outputPath, CATEGORY_YAML);
 
-    vi.spyOn(Utils, "fileExists").mockResolvedValue(false);
-    const spy = vi.spyOn(Utils, "saveFile");
+    vi.mocked(Utils.fsOutputAdapter.readFile!).mockResolvedValue(undefined);
+    const spy = vi.mocked(Utils.fsOutputAdapter.writeFile);
 
     await beforeGenerateIndexMetafileHook({
       data: {
@@ -75,8 +80,8 @@ describe("beforeGenerateIndexMetafileHook()", () => {
     const outputPath = path.join("/output/docs", category);
     const filePath = path.join(outputPath, CATEGORY_YAML);
 
-    vi.spyOn(Utils, "fileExists").mockResolvedValue(false);
-    const spy = vi.spyOn(Utils, "saveFile");
+    vi.mocked(Utils.fsOutputAdapter.readFile!).mockResolvedValue(undefined);
+    const spy = vi.mocked(Utils.fsOutputAdapter.writeFile);
 
     await beforeGenerateIndexMetafileHook({
       data: {
@@ -99,8 +104,10 @@ describe("beforeGenerateIndexMetafileHook()", () => {
     const outputPath = "/output/docs";
     const filePath = path.join(outputPath, CATEGORY_YAML);
 
-    vi.spyOn(Utils, "fileExists").mockResolvedValue(true);
-    const spy = vi.spyOn(Utils, "saveFile");
+    vi.mocked(Utils.fsOutputAdapter.readFile!).mockResolvedValue(
+      "label: Existing\n",
+    );
+    const spy = vi.mocked(Utils.fsOutputAdapter.writeFile);
 
     await beforeGenerateIndexMetafileHook({
       data: {
@@ -122,8 +129,8 @@ describe("beforeGenerateIndexMetafileHook()", () => {
     const outputPath = path.join("/output/docs", category);
     const filePath = path.join(outputPath, CATEGORY_YAML);
 
-    vi.spyOn(Utils, "fileExists").mockResolvedValue(false);
-    const spy = vi.spyOn(Utils, "saveFile");
+    vi.mocked(Utils.fsOutputAdapter.readFile!).mockResolvedValue(undefined);
+    const spy = vi.mocked(Utils.fsOutputAdapter.writeFile);
 
     await beforeGenerateIndexMetafileHook({
       data: {
@@ -147,8 +154,8 @@ describe("beforeGenerateIndexMetafileHook()", () => {
     const filePath = path.join(outputPath, CATEGORY_YAML);
     const styleClass = "foo-baz";
 
-    vi.spyOn(Utils, "fileExists").mockResolvedValue(false);
-    const spy = vi.spyOn(Utils, "saveFile");
+    vi.mocked(Utils.fsOutputAdapter.readFile!).mockResolvedValue(undefined);
+    const spy = vi.mocked(Utils.fsOutputAdapter.writeFile);
 
     await beforeGenerateIndexMetafileHook({
       data: {
@@ -174,8 +181,8 @@ describe("beforeGenerateIndexMetafileHook()", () => {
     const outputPath = path.join("/output/docs", "01-common");
     const filePath = path.join(outputPath, CATEGORY_YAML);
 
-    vi.spyOn(Utils, "fileExists").mockResolvedValue(false);
-    const spy = vi.spyOn(Utils, "saveFile");
+    vi.mocked(Utils.fsOutputAdapter.readFile!).mockResolvedValue(undefined);
+    const spy = vi.mocked(Utils.fsOutputAdapter.writeFile);
 
     await beforeGenerateIndexMetafileHook({
       data: {
@@ -196,9 +203,9 @@ describe("beforeGenerateIndexMetafileHook()", () => {
     const category = "foobar";
     const outputPath = "/output/docs";
 
-    vi.spyOn(Utils, "fileExists").mockResolvedValue(false);
-    const ensureDirSpy = vi.spyOn(Utils, "ensureDir");
-    const saveFileSpy = vi.spyOn(Utils, "saveFile");
+    vi.mocked(Utils.fsOutputAdapter.readFile!).mockResolvedValue(undefined);
+    const ensureDirSpy = vi.mocked(Utils.fsOutputAdapter.ensureDir!);
+    const saveFileSpy = vi.mocked(Utils.fsOutputAdapter.writeFile);
 
     await beforeGenerateIndexMetafileHook({
       data: {

--- a/packages/formatters/src/docfx/index.ts
+++ b/packages/formatters/src/docfx/index.ts
@@ -25,6 +25,7 @@ import type {
 import { quoteMarkdownLines } from "@graphql-markdown/helpers";
 import {
   capitalize,
+  fsOutputAdapter,
   FRONT_MATTER_DELIMITER,
   MARKDOWN_EOL,
   MARKDOWN_EOP,
@@ -300,9 +301,12 @@ const updateToc = async (
   });
 };
 
-// Tracks directories whose index.md has already been prepended to their toc.yml.
-// Module-level so it persists across all hook invocations within one generation run.
-const seenDirectories = new Set<string>();
+// Tracks directories whose index.md has already been prepended to their toc.yml,
+// so the check runs once per directory rather than once per page. Keyed by
+// destination: two adapters writing the same paths keep their own state, and a
+// run with a fresh adapter starts over. `updateToc` skips an href it already
+// holds, so a repeated attempt adds nothing.
+const seenDirectories = new WeakMap<OutputAdapter, Set<string>>();
 
 /**
  * Builds DocFX `toc.yml` navigation files as each entity page is written.
@@ -364,6 +368,9 @@ const updateTocChain = async (
   outputAdapter: Maybe<OutputAdapter>,
 ): Promise<void> => {
   const { filePath, name, outputDir, pagePath } = page;
+  const destination = outputAdapter ?? fsOutputAdapter;
+  const seen = seenDirectories.get(destination) ?? new Set<string>();
+  seenDirectories.set(destination, seen);
 
   let currentRelativeDir = dirname(pagePath);
   let currentHref = basename(filePath);
@@ -374,8 +381,8 @@ const updateTocChain = async (
     const currentDir = isRoot ? outputDir : join(outputDir, currentRelativeDir);
     const tocPath = join(currentDir, "toc.yml");
 
-    if (!seenDirectories.has(currentDir)) {
-      seenDirectories.add(currentDir);
+    if (!seen.has(currentDir)) {
+      seen.add(currentDir);
       await addOverviewEntry(currentDir, tocPath, isRoot, outputAdapter);
     }
 

--- a/packages/formatters/src/docfx/index.ts
+++ b/packages/formatters/src/docfx/index.ts
@@ -38,7 +38,7 @@ import {
   formatMDXPermalink,
   formatMDXSpecifiedByLink,
 } from "../defaults";
-import { readOutput, writeOutput } from "../output";
+import { readOptionalOutput, readOutput, writeOutput } from "../output";
 
 /** Maps graphql-markdown admonition types to DocFX alert types. */
 const ALERT_TYPE_MAP: Record<string, string> = {
@@ -282,7 +282,7 @@ const updateToc = async (
   await queueFileUpdate(tocFilePath, async () => {
     const entry = `- name: ${name}${MARKDOWN_EOL}  href: ${href}`;
 
-    const existing = await readOutput(tocFilePath, outputAdapter);
+    const existing = await readOptionalOutput(tocFilePath, outputAdapter);
 
     if (typeof existing !== "string") {
       await writeOutput(tocFilePath, entry + MARKDOWN_EOL, outputAdapter);

--- a/packages/formatters/src/docfx/index.ts
+++ b/packages/formatters/src/docfx/index.ts
@@ -311,6 +311,86 @@ const seenDirectories = new Set<string>();
  * writing or updating a `toc.yml` at every directory level. Section index pages
  * are prepended as an "Overview" entry on first encounter.
  */
+/**
+ * Adds the "Overview" entry for a directory, the first time it is reached.
+ *
+ * @param currentDir - Directory whose toc.yml is being built
+ * @param tocPath - Path of that toc.yml
+ * @param isRoot - Whether the directory is the generated documentation root
+ * @param outputAdapter - Destination the pages were written to
+ */
+const addOverviewEntry = async (
+  currentDir: string,
+  tocPath: string,
+  isRoot: boolean,
+  outputAdapter: Maybe<OutputAdapter>,
+): Promise<void> => {
+  if (isRoot) {
+    // Homepage is written after hooks run, so add Overview unconditionally.
+    await updateToc(tocPath, "Overview", "index.md", outputAdapter);
+    return;
+  }
+
+  // the section index lives wherever the pages were written, which is not the
+  // local filesystem when a custom adapter is configured
+  const indexPath = join(currentDir, "index.md");
+
+  if (
+    typeof (await readOptionalOutput(indexPath, outputAdapter)) !== "string"
+  ) {
+    return;
+  }
+
+  await updateToc(
+    tocPath,
+    `${capitalize(basename(currentDir))} Overview`,
+    "index.md",
+    outputAdapter,
+  );
+};
+
+/**
+ * Adds a page, and every directory above it, to the toc.yml chain.
+ *
+ * The walk goes up in the same path shape the page was written with: resolving
+ * here would hand an adapter an absolute `toc.yml` key next to a relative page
+ * key, and a key based destination would file them apart.
+ *
+ * @param page - The rendered page, its display name and the output root
+ * @param outputAdapter - Destination the pages were written to
+ */
+const updateTocChain = async (
+  page: { filePath: string; name: string; outputDir: string; pagePath: string },
+  outputAdapter: Maybe<OutputAdapter>,
+): Promise<void> => {
+  const { filePath, name, outputDir, pagePath } = page;
+
+  let currentRelativeDir = dirname(pagePath);
+  let currentHref = basename(filePath);
+  let currentName = name;
+
+  for (;;) {
+    const isRoot = currentRelativeDir === "." || currentRelativeDir === "";
+    const currentDir = isRoot ? outputDir : join(outputDir, currentRelativeDir);
+    const tocPath = join(currentDir, "toc.yml");
+
+    if (!seenDirectories.has(currentDir)) {
+      seenDirectories.add(currentDir);
+      await addOverviewEntry(currentDir, tocPath, isRoot, outputAdapter);
+    }
+
+    await updateToc(tocPath, currentName, currentHref, outputAdapter);
+
+    if (isRoot) {
+      return;
+    }
+
+    currentHref = `${basename(currentDir)}/toc.yml`;
+    currentName = capitalize(basename(currentDir));
+    currentRelativeDir = dirname(currentRelativeDir);
+  }
+};
+
 export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
   event,
 ): Promise<void> => {
@@ -339,6 +419,7 @@ export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
 
   const withUid = content.replace(/^(\s*)uid:.*$/m, `$1uid: ${uid}`);
   const rewritten = rewriteInternalLinks(withUid, filePath, outputDir, baseURL);
+
   if (rewritten !== content) {
     await writeOutput(filePath, rewritten, outputAdapter);
   }
@@ -348,47 +429,5 @@ export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
     return;
   }
 
-  // Walk up in the same path shape the page was written with: resolving here
-  // would hand an adapter an absolute `toc.yml` key next to a relative page
-  // key, and a key based destination would file them apart.
-  let currentRelativeDir = dirname(pagePath);
-  let currentHref = basename(filePath);
-  let currentName = name;
-
-  for (;;) {
-    const isRoot = currentRelativeDir === "." || currentRelativeDir === "";
-    const currentDir = isRoot ? outputDir : join(outputDir, currentRelativeDir);
-    const tocPath = join(currentDir, "toc.yml");
-
-    if (!seenDirectories.has(currentDir)) {
-      seenDirectories.add(currentDir);
-      if (isRoot) {
-        // Homepage is written after hooks run, so add Overview unconditionally.
-        await updateToc(tocPath, "Overview", "index.md", outputAdapter);
-      } else {
-        const indexPath = join(currentDir, "index.md");
-        // the section index lives wherever the pages were written, which is not
-        // the local filesystem when a custom adapter is configured
-        if (
-          typeof (await readOptionalOutput(indexPath, outputAdapter)) ===
-          "string"
-        ) {
-          await updateToc(
-            tocPath,
-            `${capitalize(basename(currentDir))} Overview`,
-            "index.md",
-            outputAdapter,
-          );
-        }
-      }
-    }
-
-    await updateToc(tocPath, currentName, currentHref, outputAdapter);
-
-    if (isRoot) break;
-
-    currentHref = `${basename(currentDir)}/toc.yml`;
-    currentName = capitalize(basename(currentDir));
-    currentRelativeDir = dirname(currentRelativeDir);
-  }
+  await updateTocChain({ filePath, name, outputDir, pagePath }, outputAdapter);
 };

--- a/packages/formatters/src/docfx/index.ts
+++ b/packages/formatters/src/docfx/index.ts
@@ -16,6 +16,7 @@ import type {
   Formatter,
   FrontMatterOptions,
   Maybe,
+  OutputAdapter,
   MDXString,
   MetaInfo,
   RenderTypeEntitiesHook,
@@ -28,8 +29,6 @@ import {
   FRONT_MATTER_DELIMITER,
   MARKDOWN_EOL,
   MARKDOWN_EOP,
-  readFile,
-  saveFile,
   toRelativeGeneratedDocLink,
 } from "@graphql-markdown/utils";
 import {
@@ -39,6 +38,7 @@ import {
   formatMDXPermalink,
   formatMDXSpecifiedByLink,
 } from "../defaults";
+import { readOutput, writeOutput } from "../output";
 
 /** Maps graphql-markdown admonition types to DocFX alert types. */
 const ALERT_TYPE_MAP: Record<string, string> = {
@@ -277,23 +277,26 @@ const updateToc = async (
   tocFilePath: string,
   name: string,
   href: string,
+  outputAdapter: Maybe<OutputAdapter>,
 ): Promise<void> => {
   await queueFileUpdate(tocFilePath, async () => {
     const entry = `- name: ${name}${MARKDOWN_EOL}  href: ${href}`;
 
-    if (!(await fileExists(tocFilePath))) {
-      await saveFile(tocFilePath, entry + MARKDOWN_EOL);
+    const existing = await readOutput(tocFilePath, outputAdapter);
+
+    if (typeof existing !== "string") {
+      await writeOutput(tocFilePath, entry + MARKDOWN_EOL, outputAdapter);
       return;
     }
 
-    const existing = await readFile(tocFilePath, "utf-8");
     if (existing.includes(`href: ${href}`)) {
       return;
     }
 
-    await saveFile(
+    await writeOutput(
       tocFilePath,
       existing.trimEnd() + MARKDOWN_EOL + entry + MARKDOWN_EOL,
+      outputAdapter,
     );
   });
 };
@@ -312,12 +315,13 @@ const seenDirectories = new Set<string>();
 export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
   event,
 ): Promise<void> => {
-  const { baseURL, filePath, name, outputDir } = (
+  const { baseURL, filePath, name, outputAdapter, outputDir } = (
     event as {
       data: {
         baseURL: string;
         filePath: string;
         name: string;
+        outputAdapter?: OutputAdapter;
         outputDir: string;
       };
     }
@@ -330,11 +334,16 @@ export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
   const uid = relative(graphqlRoot, filePath)
     .replace(/\.mdx?$/, "")
     .replaceAll(/[/\\]/g, "-");
-  const content = await readFile(filePath, "utf-8");
+  const content = await readOutput(filePath, outputAdapter);
+
+  if (typeof content !== "string") {
+    return;
+  }
+
   const withUid = content.replace(/^(\s*)uid:.*$/m, `$1uid: ${uid}`);
   const rewritten = rewriteInternalLinks(withUid, filePath, outputDir, baseURL);
   if (rewritten !== content) {
-    await saveFile(filePath, rewritten);
+    await writeOutput(filePath, rewritten, outputAdapter);
   }
 
   let currentDir = resolve(dirname(filePath));
@@ -348,7 +357,7 @@ export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
       seenDirectories.add(currentDir);
       if (currentDir === graphqlRoot) {
         // Homepage is written after hooks run, so add Overview unconditionally.
-        await updateToc(tocPath, "Overview", "index.md");
+        await updateToc(tocPath, "Overview", "index.md", outputAdapter);
       } else {
         const indexPath = resolve(currentDir, "index.md");
         if (await fileExists(indexPath)) {
@@ -356,12 +365,13 @@ export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
             tocPath,
             `${capitalize(basename(currentDir))} Overview`,
             "index.md",
+            outputAdapter,
           );
         }
       }
     }
 
-    await updateToc(tocPath, currentName, currentHref);
+    await updateToc(tocPath, currentName, currentHref, outputAdapter);
 
     if (currentDir === graphqlRoot) break;
 

--- a/packages/formatters/src/docfx/index.ts
+++ b/packages/formatters/src/docfx/index.ts
@@ -25,7 +25,6 @@ import type {
 import { quoteMarkdownLines } from "@graphql-markdown/helpers";
 import {
   capitalize,
-  fileExists,
   FRONT_MATTER_DELIMITER,
   MARKDOWN_EOL,
   MARKDOWN_EOP,
@@ -360,7 +359,12 @@ export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
         await updateToc(tocPath, "Overview", "index.md", outputAdapter);
       } else {
         const indexPath = resolve(currentDir, "index.md");
-        if (await fileExists(indexPath)) {
+        // the section index lives wherever the pages were written, which is not
+        // the local filesystem when a custom adapter is configured
+        if (
+          typeof (await readOptionalOutput(indexPath, outputAdapter)) ===
+          "string"
+        ) {
           await updateToc(
             tocPath,
             `${capitalize(basename(currentDir))} Overview`,

--- a/packages/formatters/src/docfx/index.ts
+++ b/packages/formatters/src/docfx/index.ts
@@ -8,7 +8,7 @@
  * @packageDocumentation
  */
 
-import { dirname, resolve, basename, relative } from "node:path";
+import { dirname, join, basename, relative } from "node:path";
 
 import type {
   AdmonitionType,
@@ -326,13 +326,11 @@ export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
     }
   ).data;
 
-  const graphqlRoot = resolve(outputDir);
+  const pagePath = relative(outputDir, filePath);
 
   // Rewrite uid as a path-derived value to guarantee uniqueness across the site.
   // e.g. operations/queries/continent.md → uid: operations-queries-continent
-  const uid = relative(graphqlRoot, filePath)
-    .replace(/\.mdx?$/, "")
-    .replaceAll(/[/\\]/g, "-");
+  const uid = pagePath.replace(/\.mdx?$/, "").replaceAll(/[/\\]/g, "-");
   const content = await readOutput(filePath, outputAdapter);
 
   if (typeof content !== "string") {
@@ -345,20 +343,30 @@ export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
     await writeOutput(filePath, rewritten, outputAdapter);
   }
 
-  let currentDir = resolve(dirname(filePath));
+  // A page outside the output root has no toc to belong to.
+  if (pagePath.startsWith("..")) {
+    return;
+  }
+
+  // Walk up in the same path shape the page was written with: resolving here
+  // would hand an adapter an absolute `toc.yml` key next to a relative page
+  // key, and a key based destination would file them apart.
+  let currentRelativeDir = dirname(pagePath);
   let currentHref = basename(filePath);
   let currentName = name;
 
-  while (currentDir.startsWith(graphqlRoot)) {
-    const tocPath = resolve(currentDir, "toc.yml");
+  for (;;) {
+    const isRoot = currentRelativeDir === "." || currentRelativeDir === "";
+    const currentDir = isRoot ? outputDir : join(outputDir, currentRelativeDir);
+    const tocPath = join(currentDir, "toc.yml");
 
     if (!seenDirectories.has(currentDir)) {
       seenDirectories.add(currentDir);
-      if (currentDir === graphqlRoot) {
+      if (isRoot) {
         // Homepage is written after hooks run, so add Overview unconditionally.
         await updateToc(tocPath, "Overview", "index.md", outputAdapter);
       } else {
-        const indexPath = resolve(currentDir, "index.md");
+        const indexPath = join(currentDir, "index.md");
         // the section index lives wherever the pages were written, which is not
         // the local filesystem when a custom adapter is configured
         if (
@@ -377,10 +385,10 @@ export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
 
     await updateToc(tocPath, currentName, currentHref, outputAdapter);
 
-    if (currentDir === graphqlRoot) break;
+    if (isRoot) break;
 
     currentHref = `${basename(currentDir)}/toc.yml`;
     currentName = capitalize(basename(currentDir));
-    currentDir = dirname(currentDir);
+    currentRelativeDir = dirname(currentRelativeDir);
   }
 };

--- a/packages/formatters/src/hugo/index.ts
+++ b/packages/formatters/src/hugo/index.ts
@@ -18,6 +18,7 @@ import type {
   FrontMatterOptions,
   GenerateIndexMetafileHook,
   Maybe,
+  OutputAdapter,
   MDXString,
   MetaInfo,
   TypeLink,
@@ -30,9 +31,7 @@ import {
   FRONT_MATTER_DELIMITER,
   MARKDOWN_EOL,
   MARKDOWN_EOP,
-  ensureDir,
   formatFrontMatterObject,
-  saveFile,
   startCase,
 } from "@graphql-markdown/utils";
 import {
@@ -41,6 +40,7 @@ import {
   formatMDXPermalink,
   formatMDXSpecifiedByLink,
 } from "../defaults";
+import { writeOutput } from "../output";
 
 /**
  * Maps graphql-markdown admonition types to Hugo GitHub-style alert types (Hugo 0.132+).
@@ -181,13 +181,18 @@ export const mdxExtension = ".md" as const;
  */
 export const beforeGenerateIndexMetafileHook: GenerateIndexMetafileHook =
   async (event): Promise<void> => {
-    const { dirPath, category } = (
-      event as { data: { dirPath: string; category: string } }
+    const { dirPath, category, outputAdapter } = (
+      event as {
+        data: {
+          dirPath: string;
+          category: string;
+          outputAdapter?: OutputAdapter;
+        };
+      }
     ).data;
     const filePath = join(dirPath, "_index.md");
     const label = startCase(category);
     const content = `${FRONT_MATTER_DELIMITER}${MARKDOWN_EOL}title: "${label}"${MARKDOWN_EOL}type: docs${MARKDOWN_EOL}bookCollapseSection: true${MARKDOWN_EOL}${FRONT_MATTER_DELIMITER}${MARKDOWN_EOL}${MARKDOWN_EOL}# ${label}${MARKDOWN_EOL}${MARKDOWN_EOL}`;
 
-    await ensureDir(dirPath);
-    await saveFile(filePath, content);
+    await writeOutput(filePath, content, outputAdapter, dirPath);
   };

--- a/packages/formatters/src/mdbook/index.ts
+++ b/packages/formatters/src/mdbook/index.ts
@@ -34,7 +34,6 @@ import {
   firstUppercase,
   MARKDOWN_EOL,
   MARKDOWN_EOP,
-  saveFile,
   toRelativeGeneratedDocLink,
 } from "@graphql-markdown/utils";
 import {
@@ -236,13 +235,14 @@ const SECTION_ORDER = [
 export const afterRenderFilesHook: RenderFilesHook = async (
   event,
 ): Promise<void> => {
-  const { baseURL, outputDir, rootDir, pages } = (
+  const { baseURL, outputDir, rootDir, pages, outputAdapter } = (
     event as {
       data: {
         baseURL: string;
         outputDir: string;
         rootDir: string;
         pages: unknown[];
+        outputAdapter?: OutputAdapter;
       };
     }
   ).data;
@@ -313,5 +313,5 @@ export const afterRenderFilesHook: RenderFilesHook = async (
     lines.push("");
   }
 
-  await saveFile(summaryPath, lines.join("\n"));
+  await writeOutput(summaryPath, lines.join("\n"), outputAdapter);
 };

--- a/packages/formatters/src/mdbook/index.ts
+++ b/packages/formatters/src/mdbook/index.ts
@@ -42,7 +42,7 @@ import {
   formatMDXPermalink,
   formatMDXSpecifiedByLink,
 } from "../defaults";
-import { readOutput, writeOutput } from "../output";
+import { rewriteRenderedPage, writeOutput } from "../output";
 
 /**
  * Formats a badge as Markdown bold text — mdBook has no badge component.
@@ -164,33 +164,7 @@ const rewriteInternalLinks = (
 export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
   event,
 ): Promise<void> => {
-  const { baseURL, filePath, outputAdapter, outputDir } = (
-    event as {
-      data: {
-        baseURL: string;
-        filePath: string;
-        outputAdapter?: OutputAdapter;
-        outputDir: string;
-      };
-    }
-  ).data;
-
-  const content = await readOutput(filePath, outputAdapter);
-
-  if (typeof content !== "string") {
-    return;
-  }
-
-  const rewrittenContent = rewriteInternalLinks(
-    content,
-    filePath,
-    outputDir,
-    baseURL,
-  );
-
-  if (rewrittenContent !== content) {
-    await writeOutput(filePath, rewrittenContent, outputAdapter);
-  }
+  await rewriteRenderedPage(event, rewriteInternalLinks);
 };
 
 /**

--- a/packages/formatters/src/mdbook/index.ts
+++ b/packages/formatters/src/mdbook/index.ts
@@ -18,6 +18,7 @@ import type {
   Formatter,
   FrontMatterOptions,
   Maybe,
+  OutputAdapter,
   MDXString,
   MetaInfo,
   RenderFilesHook,
@@ -33,7 +34,6 @@ import {
   firstUppercase,
   MARKDOWN_EOL,
   MARKDOWN_EOP,
-  readFile,
   saveFile,
   toRelativeGeneratedDocLink,
 } from "@graphql-markdown/utils";
@@ -43,6 +43,7 @@ import {
   formatMDXPermalink,
   formatMDXSpecifiedByLink,
 } from "../defaults";
+import { readOutput, writeOutput } from "../output";
 
 /**
  * Formats a badge as Markdown bold text — mdBook has no badge component.
@@ -164,13 +165,23 @@ const rewriteInternalLinks = (
 export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
   event,
 ): Promise<void> => {
-  const { baseURL, filePath, outputDir } = (
+  const { baseURL, filePath, outputAdapter, outputDir } = (
     event as {
-      data: { baseURL: string; filePath: string; outputDir: string };
+      data: {
+        baseURL: string;
+        filePath: string;
+        outputAdapter?: OutputAdapter;
+        outputDir: string;
+      };
     }
   ).data;
 
-  const content = await readFile(filePath, "utf-8");
+  const content = await readOutput(filePath, outputAdapter);
+
+  if (typeof content !== "string") {
+    return;
+  }
+
   const rewrittenContent = rewriteInternalLinks(
     content,
     filePath,
@@ -179,7 +190,7 @@ export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
   );
 
   if (rewrittenContent !== content) {
-    await saveFile(filePath, rewrittenContent);
+    await writeOutput(filePath, rewrittenContent, outputAdapter);
   }
 };
 

--- a/packages/formatters/src/mkdocs/index.ts
+++ b/packages/formatters/src/mkdocs/index.ts
@@ -14,7 +14,6 @@ import type {
   Formatter,
   FrontMatterOptions,
   Maybe,
-  OutputAdapter,
   MDXString,
   MetaInfo,
   RenderTypeEntitiesHook,
@@ -33,7 +32,7 @@ import {
   formatMDXLink,
   formatMDXPermalink,
 } from "../defaults";
-import { readOutput, writeOutput } from "../output";
+import { rewriteRenderedPage } from "../output";
 
 export const __default = {
   formatMDXBullet,
@@ -159,33 +158,7 @@ export const mdxExtension = ".md" as const;
 export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
   event,
 ): Promise<void> => {
-  const { baseURL, filePath, outputAdapter, outputDir } = (
-    event as {
-      data: {
-        baseURL: string;
-        filePath: string;
-        outputAdapter?: OutputAdapter;
-        outputDir: string;
-      };
-    }
-  ).data;
-
-  const content = await readOutput(filePath, outputAdapter);
-
-  if (typeof content !== "string") {
-    return;
-  }
-
-  const rewrittenContent = rewriteInternalLinks(
-    content,
-    filePath,
-    outputDir,
-    baseURL,
-  );
-
-  if (rewrittenContent !== content) {
-    await writeOutput(filePath, rewrittenContent, outputAdapter);
-  }
+  await rewriteRenderedPage(event, rewriteInternalLinks);
 };
 
 export { formatMDXBullet, formatMDXPermalink } from "../defaults";

--- a/packages/formatters/src/mkdocs/index.ts
+++ b/packages/formatters/src/mkdocs/index.ts
@@ -14,6 +14,7 @@ import type {
   Formatter,
   FrontMatterOptions,
   Maybe,
+  OutputAdapter,
   MDXString,
   MetaInfo,
   RenderTypeEntitiesHook,
@@ -25,8 +26,6 @@ import {
 import {
   MARKDOWN_EOL,
   MARKDOWN_EOP,
-  readFile,
-  saveFile,
   toRelativeGeneratedDocLink,
 } from "@graphql-markdown/utils";
 import {
@@ -34,6 +33,7 @@ import {
   formatMDXLink,
   formatMDXPermalink,
 } from "../defaults";
+import { readOutput, writeOutput } from "../output";
 
 export const __default = {
   formatMDXBullet,
@@ -159,13 +159,23 @@ export const mdxExtension = ".md" as const;
 export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
   event,
 ): Promise<void> => {
-  const { baseURL, filePath, outputDir } = (
+  const { baseURL, filePath, outputAdapter, outputDir } = (
     event as {
-      data: { baseURL: string; filePath: string; outputDir: string };
+      data: {
+        baseURL: string;
+        filePath: string;
+        outputAdapter?: OutputAdapter;
+        outputDir: string;
+      };
     }
   ).data;
 
-  const content = await readFile(filePath, "utf-8");
+  const content = await readOutput(filePath, outputAdapter);
+
+  if (typeof content !== "string") {
+    return;
+  }
+
   const rewrittenContent = rewriteInternalLinks(
     content,
     filePath,
@@ -174,7 +184,7 @@ export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
   );
 
   if (rewrittenContent !== content) {
-    await saveFile(filePath, rewrittenContent);
+    await writeOutput(filePath, rewrittenContent, outputAdapter);
   }
 };
 

--- a/packages/formatters/src/output.ts
+++ b/packages/formatters/src/output.ts
@@ -134,7 +134,7 @@ export const rewriteRenderedPage = async (
       data: {
         baseURL: string;
         filePath: string;
-        outputAdapter?: OutputAdapter | null;
+        outputAdapter?: OutputAdapter;
         outputDir: string;
       };
     }

--- a/packages/formatters/src/output.ts
+++ b/packages/formatters/src/output.ts
@@ -1,0 +1,71 @@
+/**
+ * Output helpers for formatter lifecycle hooks.
+ *
+ * Hooks post-process pages the renderer has already written, so they must go
+ * through the same destination the renderer used. Reaching for the filesystem
+ * directly works only as long as the default adapter is in play, and silently
+ * misses every page when the output is redirected elsewhere.
+ *
+ * @packageDocumentation
+ */
+
+import type { Maybe, OutputAdapter } from "@graphql-markdown/types";
+import { fsOutputAdapter } from "@graphql-markdown/utils";
+
+/**
+ * Resolves the destination a hook must use, falling back to the filesystem.
+ *
+ * @param outputAdapter - Adapter carried by the hook event, if any
+ * @returns The adapter to read from and write to
+ */
+const getOutputAdapter = (
+  outputAdapter: Maybe<OutputAdapter>,
+): OutputAdapter => {
+  return outputAdapter ?? fsOutputAdapter;
+};
+
+/**
+ * Reads back a page the renderer has written, through its output destination.
+ *
+ * @param filePath - Path of the generated page
+ * @param outputAdapter - Adapter carried by the hook event, if any
+ * @returns The page content, or `undefined` if it does not exist
+ * @throws An error if the configured adapter cannot read back what it wrote,
+ * so the skipped post-processing is reported rather than silently dropped.
+ */
+export const readOutput = async (
+  filePath: string,
+  outputAdapter: Maybe<OutputAdapter>,
+): Promise<string | undefined> => {
+  const adapter = getOutputAdapter(outputAdapter);
+
+  if (typeof adapter.readFile !== "function") {
+    throw new Error(
+      `Cannot post-process "${filePath}": the configured outputAdapter does not implement readFile().`,
+    );
+  }
+
+  return adapter.readFile(filePath);
+};
+
+/**
+ * Writes a file through the output destination, creating its directory first.
+ *
+ * @param filePath - Path of the file to write
+ * @param content - File content
+ * @param outputAdapter - Adapter carried by the hook event, if any
+ */
+export const writeOutput = async (
+  filePath: string,
+  content: string,
+  outputAdapter: Maybe<OutputAdapter>,
+  dirPath?: string,
+): Promise<void> => {
+  const adapter = getOutputAdapter(outputAdapter);
+
+  if (typeof dirPath === "string") {
+    await adapter.ensureDir?.(dirPath);
+  }
+
+  await adapter.writeFile(filePath, content);
+};

--- a/packages/formatters/src/output.ts
+++ b/packages/formatters/src/output.ts
@@ -109,3 +109,46 @@ export const writeOutput = async (
 
   await adapter.writeFile(filePath, content);
 };
+
+/**
+ * Rewrites the content of a page a formatter has just rendered.
+ *
+ * The read-modify-write around an `afterRenderTypeEntities` hook is identical
+ * for every preset that post-processes its own output; only the rewriting
+ * differs. Presets supply that and nothing else.
+ *
+ * @param event - The hook event, carrying the page path and its destination
+ * @param rewrite - Returns the new content, or the content unchanged to skip
+ */
+export const rewriteRenderedPage = async (
+  event: unknown,
+  rewrite: (
+    content: string,
+    filePath: string,
+    outputDir: string,
+    baseURL: string,
+  ) => string,
+): Promise<void> => {
+  const { baseURL, filePath, outputAdapter, outputDir } = (
+    event as {
+      data: {
+        baseURL: string;
+        filePath: string;
+        outputAdapter?: OutputAdapter | null;
+        outputDir: string;
+      };
+    }
+  ).data;
+
+  const content = await readOutput(filePath, outputAdapter);
+
+  if (typeof content !== "string") {
+    return;
+  }
+
+  const rewritten = rewrite(content, filePath, outputDir, baseURL);
+
+  if (rewritten !== content) {
+    await writeOutput(filePath, rewritten, outputAdapter);
+  }
+};

--- a/packages/formatters/src/output.ts
+++ b/packages/formatters/src/output.ts
@@ -25,27 +25,66 @@ const getOutputAdapter = (
 };
 
 /**
+ * Adapters a failed read-back has already been reported for.
+ *
+ * A destination that cannot read back its own writes fails on every page, so
+ * reporting each one would bury the run in identical errors. Keyed by adapter
+ * rather than a flag, so the report is per destination and does not leak into
+ * another run in the same process.
+ */
+const readBackReported = new WeakSet<OutputAdapter>();
+
+/**
  * Reads back a page the renderer has written, through its output destination.
+ *
+ * The page was just written, so nothing coming back means the destination
+ * cannot be read - a write-only adapter, a stubbed `readFile`, or a store that
+ * is not read-your-writes consistent. Post-processing cannot run without it,
+ * which is reported rather than silently skipped.
  *
  * @param filePath - Path of the generated page
  * @param outputAdapter - Adapter carried by the hook event, if any
- * @returns The page content, or `undefined` if it does not exist
- * @throws An error if the configured adapter cannot read back what it wrote,
- * so the skipped post-processing is reported rather than silently dropped.
+ * @returns The page content, or `undefined` if it cannot be read back
+ * @throws An error the first time a page cannot be read back, so the skipped
+ * post-processing surfaces once instead of once per page.
  */
 export const readOutput = async (
   filePath: string,
   outputAdapter: Maybe<OutputAdapter>,
 ): Promise<string | undefined> => {
   const adapter = getOutputAdapter(outputAdapter);
+  const content = await adapter.readFile(filePath);
 
-  if (typeof adapter.readFile !== "function") {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (!readBackReported.has(adapter)) {
+    readBackReported.add(adapter);
     throw new Error(
-      `Cannot post-process "${filePath}": the configured outputAdapter does not implement readFile().`,
+      `Cannot read back "${filePath}" from the output destination: the formatter cannot post-process what it wrote, so internal links are left unresolved for this run.`,
     );
   }
 
-  return adapter.readFile(filePath);
+  return undefined;
+};
+
+/**
+ * Reads a file the formatter maintains itself, where absence is expected.
+ *
+ * Unlike {@link readOutput} this reports nothing when there is no content: a
+ * navigation or metadata file legitimately does not exist until the formatter
+ * creates it on the first page of a directory.
+ *
+ * @param filePath - Path of the file to read
+ * @param outputAdapter - Adapter carried by the hook event, if any
+ * @returns The file content, or `undefined` when there is none
+ */
+export const readOptionalOutput = async (
+  filePath: string,
+  outputAdapter: Maybe<OutputAdapter>,
+): Promise<string | undefined> => {
+  return getOutputAdapter(outputAdapter).readFile(filePath);
 };
 
 /**

--- a/packages/formatters/src/output.ts
+++ b/packages/formatters/src/output.ts
@@ -29,8 +29,9 @@ const getOutputAdapter = (
  *
  * A destination that cannot read back its own writes fails on every page, so
  * reporting each one would bury the run in identical errors. Keyed by adapter
- * rather than a flag, so the report is per destination and does not leak into
- * another run in the same process.
+ * rather than a flag, so one destination going quiet says nothing about
+ * another. An adapter instance reused across several runs in one process is
+ * therefore reported on its first failing run only.
  */
 const readBackReported = new WeakSet<OutputAdapter>();
 
@@ -45,8 +46,8 @@ const readBackReported = new WeakSet<OutputAdapter>();
  * @param filePath - Path of the generated page
  * @param outputAdapter - Adapter carried by the hook event, if any
  * @returns The page content, or `undefined` if it cannot be read back
- * @throws An error the first time a page cannot be read back, so the skipped
- * post-processing surfaces once instead of once per page.
+ * @throws An error the first time this adapter cannot read a page back, so the
+ * skipped post-processing surfaces once instead of once per page.
  */
 export const readOutput = async (
   filePath: string,

--- a/packages/formatters/tests/unit/docfx/index.test.ts
+++ b/packages/formatters/tests/unit/docfx/index.test.ts
@@ -203,6 +203,49 @@ describe("afterRenderTypeEntitiesHook", () => {
     expect(typeof afterRenderTypeEntitiesHook).toBe("function");
   });
 
+  test("keys toc.yml and index.md the same way as the page it is given", async () => {
+    expect.assertions(3);
+
+    // a key based destination files an absolute `toc.yml` apart from a
+    // relative page key, so both must keep the shape the renderer used
+    const store = new Map<string, string>([
+      ["docs/api/types/objects/book.md", "---\n  uid: book\n---\n\n# Book\n"],
+      ["docs/api/types/objects/index.md", "# Objects"],
+    ]);
+    const outputAdapter = {
+      writeFile: vi.fn(async (filePath: string, content: string) => {
+        store.set(filePath, content);
+      }),
+      readFile: vi.fn(async (filePath: string) => {
+        return store.get(filePath);
+      }),
+    };
+
+    await afterRenderTypeEntitiesHook({
+      data: {
+        baseURL: "api",
+        filePath: "docs/api/types/objects/book.md",
+        name: "Book",
+        outputDir: "docs/api",
+        outputAdapter,
+      },
+    });
+
+    const written = outputAdapter.writeFile.mock.calls.map(([path]) => {
+      return path;
+    });
+
+    expect(written).toContain("docs/api/types/objects/toc.yml");
+    expect(
+      written.some((path) => {
+        return path.startsWith("/");
+      }),
+    ).toBe(false);
+    expect(outputAdapter.readFile).toHaveBeenCalledWith(
+      "docs/api/types/objects/index.md",
+    );
+  });
+
   test("rewrites absolute links with linkRoot prefix to relative paths", async () => {
     const { mkdtempSync, mkdirSync, writeFileSync, readFileSync } =
       await import("node:fs");

--- a/packages/formatters/tests/unit/mkdocs/index.test.ts
+++ b/packages/formatters/tests/unit/mkdocs/index.test.ts
@@ -204,31 +204,27 @@ describe("afterRenderTypeEntitiesHook", () => {
     expect(outputAdapter.writeFile).not.toHaveBeenCalled();
   });
 
-  test("skips the rewrite when the page cannot be read back", async () => {
-    outputAdapter.readFile.mockResolvedValue(undefined);
+  test("reports the first page that cannot be read back, then stays quiet", async () => {
+    // a write-only destination fails on every page, so it must be reported once
+    // rather than once per page
+    const writeOnly = {
+      writeFile: vi.fn(),
+      readFile: vi.fn().mockResolvedValue(undefined),
+    };
+    const data = {
+      baseURL: "graphql",
+      filePath: "/workspace/docs/graphql/types/objects/book.md",
+      outputDir: "/workspace/docs",
+      outputAdapter: writeOnly,
+    };
 
-    await afterRenderTypeEntitiesHook({
-      data: {
-        baseURL: "graphql",
-        filePath: "/workspace/docs/graphql/types/objects/book.md",
-        outputDir: "/workspace/docs",
-        outputAdapter,
-      },
-    });
+    await expect(afterRenderTypeEntitiesHook({ data })).rejects.toThrow(
+      "Cannot read back",
+    );
 
-    expect(outputAdapter.writeFile).not.toHaveBeenCalled();
-  });
-
-  test("reports an adapter that cannot read back its own output", async () => {
     await expect(
-      afterRenderTypeEntitiesHook({
-        data: {
-          baseURL: "graphql",
-          filePath: "/workspace/docs/graphql/types/objects/book.md",
-          outputDir: "/workspace/docs",
-          outputAdapter: { writeFile: vi.fn() },
-        },
-      }),
-    ).rejects.toThrow("does not implement readFile()");
+      afterRenderTypeEntitiesHook({ data }),
+    ).resolves.toBeUndefined();
+    expect(writeOnly.writeFile).not.toHaveBeenCalled();
   });
 });

--- a/packages/formatters/tests/unit/mkdocs/index.test.ts
+++ b/packages/formatters/tests/unit/mkdocs/index.test.ts
@@ -14,17 +14,6 @@ import {
 
 const { formatMDXBullet, formatMDXLink } = __default;
 
-import * as Utils from "@graphql-markdown/utils";
-
-vi.mock("@graphql-markdown/utils", async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...actual,
-    readFile: vi.fn(),
-    saveFile: vi.fn(),
-  };
-});
-
 describe("formatMDXBadge", () => {
   test("renders inline mark tag", () => {
     expect(formatMDXBadge({ text: "Required" })).toBe(
@@ -169,50 +158,77 @@ describe("createMDXFormatter", () => {
 });
 
 describe("afterRenderTypeEntitiesHook", () => {
+  const outputAdapter = {
+    writeFile: vi.fn(),
+    readFile: vi.fn(),
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   test("rewrites baseURL absolute links to relative markdown links", async () => {
-    const readFileMock = vi.mocked(Utils.readFile);
-    const saveFileMock = vi.mocked(Utils.saveFile);
-
-    readFileMock.mockResolvedValue(
+    outputAdapter.readFile.mockResolvedValue(
       "See [Book](/graphql/types/objects/book) and [ID](/graphql/types/scalars/id#value)",
     );
-    saveFileMock.mockResolvedValue(undefined);
 
     await afterRenderTypeEntitiesHook({
       data: {
         baseURL: "graphql",
         filePath: "/workspace/docs/graphql/operations/queries/book-by-id.md",
         outputDir: "/workspace/docs/graphql",
+        outputAdapter,
       },
     });
 
-    expect(saveFileMock).toHaveBeenCalledWith(
+    expect(outputAdapter.writeFile).toHaveBeenCalledWith(
       "/workspace/docs/graphql/operations/queries/book-by-id.md",
       "See [Book](../../types/objects/book.md) and [ID](../../types/scalars/id.md#value)",
     );
   });
 
   test("leaves non-baseURL absolute links unchanged", async () => {
-    const readFileMock = vi.mocked(Utils.readFile);
-    const saveFileMock = vi.mocked(Utils.saveFile);
-
-    readFileMock.mockResolvedValue(
+    outputAdapter.readFile.mockResolvedValue(
       "See [Site](/other/path) and [Spec](https://example.com)",
     );
-    saveFileMock.mockResolvedValue(undefined);
 
     await afterRenderTypeEntitiesHook({
       data: {
         baseURL: "graphql",
         filePath: "/workspace/docs/graphql/types/objects/book.md",
         outputDir: "/workspace/docs",
+        outputAdapter,
       },
     });
 
-    expect(saveFileMock).not.toHaveBeenCalled();
+    expect(outputAdapter.writeFile).not.toHaveBeenCalled();
+  });
+
+  test("skips the rewrite when the page cannot be read back", async () => {
+    outputAdapter.readFile.mockResolvedValue(undefined);
+
+    await afterRenderTypeEntitiesHook({
+      data: {
+        baseURL: "graphql",
+        filePath: "/workspace/docs/graphql/types/objects/book.md",
+        outputDir: "/workspace/docs",
+        outputAdapter,
+      },
+    });
+
+    expect(outputAdapter.writeFile).not.toHaveBeenCalled();
+  });
+
+  test("reports an adapter that cannot read back its own output", async () => {
+    await expect(
+      afterRenderTypeEntitiesHook({
+        data: {
+          baseURL: "graphql",
+          filePath: "/workspace/docs/graphql/types/objects/book.md",
+          outputDir: "/workspace/docs",
+          outputAdapter: { writeFile: vi.fn() },
+        },
+      }),
+    ).rejects.toThrow("does not implement readFile()");
   });
 });

--- a/packages/types/src/utils.d.ts
+++ b/packages/types/src/utils.d.ts
@@ -26,7 +26,9 @@ export type EnsureDirOptions = Maybe<{ forceEmpty?: boolean }>;
  * Paths passed to an adapter are the same ones the filesystem writer would use:
  * rooted at `outputDir`, and relative to the working directory unless the
  * configured `rootPath` is itself absolute. An adapter backed by something
- * other than a filesystem can treat them as opaque keys.
+ * other than a filesystem can treat them as opaque keys. The one path that sits
+ * outside `outputDir` is mdBook's `SUMMARY.md`, which the format requires one
+ * level above it.
  */
 export interface OutputAdapter {
   /**

--- a/packages/types/src/utils.d.ts
+++ b/packages/types/src/utils.d.ts
@@ -28,7 +28,8 @@ export type EnsureDirOptions = Maybe<{ forceEmpty?: boolean }>;
  * configured `rootPath` is itself absolute. An adapter backed by something
  * other than a filesystem can treat them as opaque keys. The one path that sits
  * outside `outputDir` is mdBook's `SUMMARY.md`, which the format requires one
- * level above it.
+ * level above it: still inside `rootPath`, so keys taken relative to `rootPath`
+ * stay within the tree.
  */
 export interface OutputAdapter {
   /**

--- a/packages/types/src/utils.d.ts
+++ b/packages/types/src/utils.d.ts
@@ -24,8 +24,9 @@ export type EnsureDirOptions = Maybe<{ forceEmpty?: boolean }>;
  * an in-memory map, an object store - without forking the renderer.
  *
  * Paths passed to an adapter are the same ones the filesystem writer would use:
- * absolute, rooted at `outputDir`. An adapter backed by something other than a
- * filesystem can treat them as opaque keys.
+ * rooted at `outputDir`, and relative to the working directory unless the
+ * configured `rootPath` is itself absolute. An adapter backed by something
+ * other than a filesystem can treat them as opaque keys.
  */
 export interface OutputAdapter {
   /**
@@ -42,4 +43,10 @@ export interface OutputAdapter {
     dirPath: string,
     options?: EnsureDirOptions,
   ) => Promise<void>;
+  /**
+   * Reads back a page this adapter wrote. Optional, but required by the
+   * formatters that post-process their own output (DocFX, mdBook, MkDocs);
+   * when it is missing, those post-processing steps are skipped with a warning.
+   */
+  readFile?: (filePath: string) => Promise<string | undefined>;
 }

--- a/packages/types/src/utils.d.ts
+++ b/packages/types/src/utils.d.ts
@@ -44,9 +44,13 @@ export interface OutputAdapter {
     options?: EnsureDirOptions,
   ) => Promise<void>;
   /**
-   * Reads back a page this adapter wrote. Optional, but required by the
-   * formatters that post-process their own output (DocFX, mdBook, MkDocs);
-   * when it is missing, those post-processing steps are skipped with a warning.
+   * Reads back a page this adapter wrote, or resolves `undefined` when there is
+   * nothing at that path.
+   *
+   * The formatters that post-process their own output (DocFX, mdBook, MkDocs)
+   * read each page back after it is written. A write-only destination can
+   * return `undefined`, but the first page that cannot be read back is
+   * reported, since post-processing is skipped for the whole run.
    */
-  readFile?: (filePath: string) => Promise<string | undefined>;
+  readFile: (filePath: string) => Promise<string | undefined>;
 }

--- a/packages/utils/src/fs.ts
+++ b/packages/utils/src/fs.ts
@@ -132,9 +132,16 @@ export const fsOutputAdapter: OutputAdapter = {
     await ensureDir(dirPath, options);
   },
   readFile: async (filePath: string): Promise<string | undefined> => {
-    if (!(await fileExists(filePath))) {
-      return undefined;
+    try {
+      return await readFile(filePath, "utf-8");
+    } catch (error) {
+      // a missing entry is the answer "there is nothing here", not a failure;
+      // reading once rather than stat-then-read also closes the window in
+      // which the file can vanish between the two calls
+      if ((error as { code?: string }).code === "ENOENT") {
+        return undefined;
+      }
+      throw error;
     }
-    return readFile(filePath, "utf-8");
   },
 };

--- a/packages/utils/src/fs.ts
+++ b/packages/utils/src/fs.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import { mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import type {
@@ -130,5 +130,11 @@ export const fsOutputAdapter: OutputAdapter = {
     options?: EnsureDirOptions,
   ): Promise<void> => {
     await ensureDir(dirPath, options);
+  },
+  readFile: async (filePath: string): Promise<string | undefined> => {
+    if (!(await fileExists(filePath))) {
+      return undefined;
+    }
+    return readFile(filePath, "utf-8");
   },
 };

--- a/packages/utils/tests/unit/fs.test.ts
+++ b/packages/utils/tests/unit/fs.test.ts
@@ -181,5 +181,31 @@ describe("fs", () => {
 
       expect(await fileExists("/testFolder/testFile")).toBe(false);
     });
+
+    test("readFile() returns the content of an existing entry", async () => {
+      expect.assertions(1);
+
+      expect(await fsOutputAdapter.readFile("/testFolder/testFile")).toBe(
+        "just a test",
+      );
+    });
+
+    test("readFile() returns undefined when there is no entry", async () => {
+      expect.assertions(1);
+
+      expect(
+        await fsOutputAdapter.readFile("/testFolder/missing"),
+      ).toBeUndefined();
+    });
+
+    test("readFile() reads back what writeFile() persisted", async () => {
+      expect.assertions(1);
+
+      await fsOutputAdapter.writeFile("/roundtrip/page.md", "# Page");
+
+      expect(await fsOutputAdapter.readFile("/roundtrip/page.md")).toBe(
+        "# Page",
+      );
+    });
   });
 });

--- a/packages/utils/tests/unit/fs.test.ts
+++ b/packages/utils/tests/unit/fs.test.ts
@@ -198,6 +198,14 @@ describe("fs", () => {
       ).toBeUndefined();
     });
 
+    test("readFile() propagates an error that is not a missing entry", async () => {
+      expect.assertions(1);
+
+      // a directory is readable as a path but not as a file: the adapter must
+      // not swallow that the way it swallows a missing entry
+      await expect(fsOutputAdapter.readFile("/testFolder")).rejects.toThrow();
+    });
+
     test("readFile() reads back what writeFile() persisted", async () => {
       expect.assertions(1);
 

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"],
+      "outputs": ["dist/**", "*.tsbuildinfo"],
       "inputs": ["src/**/*.ts", "tsconfig*.json", "package.json"]
     },
     "clean": {


### PR DESCRIPTION
# Description

Fixes the findings from the code review of `feat/output-adapter`. Targets that branch, not `main`.

## 1. A class based `outputAdapter` lost its methods

`buildConfig` read the adapter off the `deepmerge()` result. deepmerge rebuilds objects as prototype-less plain copies, so `outputAdapter: new R2Adapter()` arrived at the renderer without any of its methods, and the first page write threw `outputAdapter.writeFile is not a function`. Object literals — the documented shape — survived, because functions are copied by reference.

Reproduced against the pinned `@fastify/deepmerge`:

```
class method writeFile: undefined
own prop client.send  : function
plain object writeFile: function
```

The adapter is now taken from the raw config sources, bypassing the merge. Covered by a new `buildConfig` test.

## 2. Formatter post-processing bypassed the adapter, and failed silently

Only page bodies went through the adapter:

- `_category_.yml` (Docusaurus) and `_index.md` (Hugo) were written straight to the local filesystem.
- The DocFX, mdBook and MkDocs `afterRenderTypeEntities` hooks called `readFile` on a path the adapter may never have written to, then `saveFile` back to it.

With a custom adapter those reads throw ENOENT. Handler errors are collected rather than raised, so nothing surfaced: internal link rewriting, the DocFX `uid` rewrite and every `toc.yml` were dropped without a message.

- The hook events now carry the adapter, and all five hooks read and write through it.
- `OutputAdapter` gains a required `readFile`; `fsOutputAdapter` implements it.
- A page that cannot be read back is reported, once per adapter, rather than skipped in silence. The renderer has just written the page, so nothing coming back is an anomaly whatever the cause — a stubbed `readFile`, a write-only destination, or a store that is not read-your-writes consistent.
- Navigation files a formatter maintains itself (DocFX `toc.yml`) legitimately do not exist until first written, so they use `readOptionalOutput` and report nothing.
- Fixed the error reporting itself: `emitAsync` resolves to an `EmitResult`, so the `Array.isArray(handlerErrors)` guard around the index metafile hook was always false and never logged.

## 3. Documented path contract was wrong

`OutputAdapter` and `docs/settings.md` both promised absolute paths, but `outputDir` is `join(rootPath, baseURL)` with `rootPath` defaulting to `./docs`, so adapters receive `docs/schema/types/objects/foo.mdx`. Corrected in both places rather than resolving the paths, since relative keys are what an object store wants — the R2 example in the docs relies on it.

## 4. `tmpDir` getter recomputed on every read

Included in the first commit: the getter defers `tmpdir()` past module load as intended, but `buildConfig` spreads `DEFAULT_OPTIONS` and `OptionBuilder.addDefault` reads it again, so it ran twice per build. Now memoised.

## Not changed

The fifth review finding — that the prettify test no longer asserts prettification — does not apply to the current head: the test stubs `prettifyMarkdown` to return `"## Prettified content"` and asserts on that.

## Follow-up from review feedback

- **DocFX section index** read through `fileExists` on the local filesystem, so a custom adapter lost every sub-directory "Overview" entry from `toc.yml`.
- **mdBook `SUMMARY.md`** was still written with `saveFile`, so pages went to the adapter while the summary landed on local disk. mdBook will not build without it. The `RenderFiles` event now carries the adapter like the other render events.
- **Docusaurus does read its output back**, once per category, to leave an existing `_category_.yml` alone; the docs claimed it never reads back.
- **The read-back failure is reported once per adapter**, not once per run, which is what the comment and the docs now say.
- `fsOutputAdapter.readFile` is covered by unit tests, and the config test adapter implements the full contract.

## CI

The `Mutation tests package utils` job failed with `File 'packages/utils/dist/index.d.ts' is not a module`. The build task declared only `dist/**` as its output, but `composite` and `incremental` are on and each package writes `tsconfig.tsbuildinfo` at its root, outside that glob. Restoring one without the other leaves tsgo believing the project is up to date, so it emits nothing and every dependent fails to resolve the package. Reproduced locally by deleting `dist` and rebuilding on a cache hit; fixed by caching the tsbuildinfo alongside `dist`.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
