### PR TITLE
🔧 chore: clear the fallow stale suppressions and hoisted dev deps

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -41,6 +41,12 @@
   // makes it "reachable production code" and flags these dev-only deps as
   // dev-dependencies-in-production. The root package.json is private with no `dependencies`
   // field and is never installed with `--prod`, so this is a false positive.
+  // mutation-testing-metrics is the same case: it is only read by dangerfile.js.
+  //
+  // memfs is declared once in the root package.json, like every other test tool, and is
+  // hoisted to the workspace packages that mock the filesystem in their tests. fallow reads
+  // each package.json on its own and so reports it as unlisted for packages/core, /diff and
+  // /utils; the packages deliberately declare no test tooling of their own.
   "ignoreDependencies": [
     "@graphql-markdown/cli",
     "@graphql-markdown/core",
@@ -60,7 +66,9 @@
     "jest-environment-node",
     "typedoc-docusaurus-theme",
     "diff",
-    "lodash.filter"
+    "lodash.filter",
+    "memfs",
+    "mutation-testing-metrics"
   ],
 
   // Class member false-positive suppressions.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -218,7 +218,6 @@ export const DEFAULT_OPTIONS: Readonly<
  * ```
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const getDocDirective = (name: Maybe<DirectiveName>): DirectiveName => {
   if (typeof name !== "string" || !PATTERNS.DIRECTIVE_NAME.test(name)) {
     throw new Error(`Invalid "${name}"`);
@@ -395,7 +394,6 @@ export const getVisibilityDirectives = (
  * @see {@link DOCS_URL}/advanced/custom-directive for custom directive format documentation
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const getCustomDirectives = (
   customDirectiveOptions: Maybe<CustomDirective>,
   skipDocDirective?: Maybe<DirectiveName[]>,
@@ -442,7 +440,6 @@ export const getCustomDirectives = (
  * @see {@link DiffMethod} for available diff methods
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const getForcedDiffMethod = (): TypeDiffMethod => {
   return DiffMethod.FORCE;
 };
@@ -452,13 +449,11 @@ const getNormalizedDiffMethod = (diff: TypeDiffMethod): TypeDiffMethod => {
 };
 
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const getDiffMethod = (diff: TypeDiffMethod): TypeDiffMethod => {
   return getNormalizedDiffMethod(diff);
 };
 
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const parseDeprecatedDocOptions = (
   _cliOpts?: Maybe<CliOptions>,
   _configOptions?: Maybe<ConfigDocOptions>,
@@ -487,7 +482,6 @@ export const parseDeprecatedDocOptions = (
  * ```
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const getDocOptions = (
   cliOpts?: Maybe<CliOptions>,
   configOptions?: Maybe<ConfigDocOptions>,
@@ -544,7 +538,6 @@ export const getDocOptions = (
  * @see {@link TypeHierarchy} for available hierarchy types
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const getTypeHierarchyOption = (
   cliOption?: Maybe<TypeHierarchyValueType>,
   configOption?: Maybe<TypeHierarchyType>,
@@ -590,7 +583,6 @@ export const getTypeHierarchyOption = (
 };
 
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const parseDeprecatedFormatterOption = (
   cliOpts?: Maybe<CliOptions>,
   configOptions?: Maybe<ConfigOptions>,
@@ -612,7 +604,6 @@ export const parseDeprecatedFormatterOption = (
 };
 
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const parseDeprecatedPrintTypeOptions = (
   _cliOpts?: Maybe<CliOptions>,
   _configOptions?: Maybe<ConfigPrintTypeOptions>,
@@ -702,7 +693,6 @@ const getPrintTypeOptions = (
  * ```
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const parseGroupByOption = (
   groupOptions: unknown,
 ): Maybe<GroupByDirectiveOptions> => {
@@ -724,7 +714,6 @@ export const parseGroupByOption = (
 };
 
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const parseHomepageOption = (
   cliHomepage: Maybe<string | false>,
   configHomepage: Maybe<string | false>,

--- a/packages/core/src/directives/validation.ts
+++ b/packages/core/src/directives/validation.ts
@@ -37,7 +37,6 @@ const isTypeObject = (
  * ```
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const hasDescriptor = (
   config: unknown,
 ): config is Record<"descriptor", (...args: unknown[]) => unknown> => {
@@ -65,7 +64,6 @@ export const hasDescriptor = (
  * ```
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const hasTag = (
   config: unknown,
 ): config is Record<"tag", (...args: unknown[]) => unknown> => {

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -13,7 +13,6 @@ export { RenderFilesEvents } from "./render-files-events";
 export { RenderTypeEntitiesEvents } from "./render-type-entities-events";
 export { GenerateIndexMetafileEvents } from "./generate-index-metafile-events";
 // Re-export used only by unit tests via the events barrel.
-// fallow-ignore-next-line unused-export
 export { PrintTypeEvents } from "./print-type-events";
 
 // Event classes

--- a/packages/core/src/generator.ts
+++ b/packages/core/src/generator.ts
@@ -267,7 +267,6 @@ export const loadGraphqlSchema = async (
  * When no changes are detected, a log message is generated indicating that the schema is unchanged.
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const checkSchemaDifferences = async (
   schema: GraphQLSchema,
   schemaLocation: string,
@@ -300,7 +299,6 @@ export const checkSchemaDifferences = async (
  *          the second with resolved "skip" directives. Only defined directives are included.
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const resolveSkipAndOnlyDirectives = (
   onlyDocDirective: Maybe<DirectiveName | DirectiveName[]>,
   skipDocDirective: Maybe<DirectiveName | DirectiveName[]>,

--- a/packages/core/src/graphql-config.ts
+++ b/packages/core/src/graphql-config.ts
@@ -44,7 +44,6 @@ const EXTENSION_NAME = "graphql-markdown" as const;
  * ```
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const graphQLConfigExtension: GraphQLExtensionDeclaration = () => {
   return { name: EXTENSION_NAME } as const;
 };
@@ -94,7 +93,6 @@ const DEFAULT_THROW_OPTIONS: ThrowOptions = {
  * ```
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const setLoaderOptions = (
   loaders: LoaderOption,
   options: PackageOptionsConfig,

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -122,7 +122,6 @@ enum SidebarPosition {
  * @see {@link getApiGroupFolder} For usage with type categorization
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const API_GROUPS: Required<ApiGroupOverrideType> = {
   operations: "operations",
   types: "types",
@@ -145,7 +144,6 @@ export const API_GROUPS: Required<ApiGroupOverrideType> = {
  * ```
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const getApiGroupFolder = (
   type: unknown,
   groups?: Maybe<ApiGroupOverrideType | boolean>,
@@ -338,7 +336,6 @@ class CategoryPositionManager {
  */
 // Value export used only by unit tests for direct whitebox coverage; the type is used
 // elsewhere via getRenderer()'s return type.
-// fallow-ignore-next-line unused-export
 export class Renderer {
   readonly group: Maybe<SchemaEntitiesGroupMap>;
   readonly outputDir: string;

--- a/packages/printer-legacy/src/badge.ts
+++ b/packages/printer-legacy/src/badge.ts
@@ -42,7 +42,6 @@ export const CSS_BADGE_CLASSNAME = {
  * @returns Array of Badge objects containing text and optional classnames
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const getTypeBadges = (
   type: unknown,
   groups?: Maybe<SchemaEntitiesGroupMap>,

--- a/packages/printer-legacy/src/common.ts
+++ b/packages/printer-legacy/src/common.ts
@@ -31,7 +31,6 @@ import { getCustomDirectiveResolver } from "./directive";
  * @returns Formatted directive documentation string
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const getCustomDirectivesText = (
   type: unknown,
   options?: PrintTypeOptions,
@@ -93,7 +92,6 @@ const formatDescription = (
  * @returns Formatted warning message as MDX string
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const printWarning = (
   { text, title }: { text?: string; title?: string },
   options: PrintTypeOptions,
@@ -116,7 +114,6 @@ export const printWarning = (
  * @returns Formatted deprecation warning as MDX string, or empty string if not deprecated
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const printDeprecation = (
   type: unknown,
   options: PrintTypeOptions,

--- a/packages/printer-legacy/src/const/options.ts
+++ b/packages/printer-legacy/src/const/options.ts
@@ -24,7 +24,6 @@ import {
 export enum TypeHierarchy {
   API = "api",
   // Used only by unit tests for direct whitebox coverage.
-  // fallow-ignore-next-line unused-enum-member
   ENTITY = "entity",
   FLAT = "flat",
 }
@@ -34,7 +33,6 @@ export enum SectionLevels {
    * @deprecated Use `SectionLevels.LEVEL` instead.
    */
   // Reserved for future usage.
-  // fallow-ignore-next-line unused-enum-member
   NONE = "",
   LEVEL = "#",
 }

--- a/packages/printer-legacy/src/directive.ts
+++ b/packages/printer-legacy/src/directive.ts
@@ -55,7 +55,6 @@ export const getCustomDirectiveResolver = (
  * @returns Formatted Markdown string for the directive or `undefined`
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const printCustomDirective = (
   type: unknown,
   constDirectiveOption: CustomDirectiveMapItem,
@@ -125,7 +124,6 @@ export const printCustomDirectives = (
  * @returns Array of badge configurations from directive tags
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const getCustomTags = (
   type: unknown,
   options: PrintTypeOptions,

--- a/packages/printer-legacy/src/example.ts
+++ b/packages/printer-legacy/src/example.ts
@@ -42,7 +42,6 @@ import { hasPrintableDirective } from "./link";
  * @returns The directive example configuration if valid, otherwise `undefined`
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const getDirectiveExampleOption = ({
   exampleSection,
   schema,

--- a/packages/printer-legacy/src/graphql/scalar.ts
+++ b/packages/printer-legacy/src/graphql/scalar.ts
@@ -17,7 +17,6 @@ import { getTypeName } from "@graphql-markdown/graphql";
  * @returns A specification PageSection, or undefined when no URL exists
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const printSpecification = (
   type: unknown,
   options: PrintTypeOptions,

--- a/packages/printer-legacy/src/link.ts
+++ b/packages/printer-legacy/src/link.ts
@@ -49,7 +49,6 @@ import { DEPRECATED, ROOT_TYPE_LOCALE } from "./const/strings";
 import { TypeHierarchy } from "./const/options";
 
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const API_GROUPS: Required<ApiGroupOverrideType> = {
   operations: "operations",
   types: "types",
@@ -131,7 +130,6 @@ export const getCategoryLocale = (type: unknown): Maybe<TypeLocale> => {
  * @returns The folder name for the link category, or `undefined` if not found
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const getLinkCategoryFolder = (
   type: unknown,
   operationLocale?: Maybe<TypeLocale>,
@@ -164,7 +162,6 @@ export const getLinkCategoryFolder = (
  * @returns `true` if the options include `withAttributes`, `false` otherwise
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const hasOptionWithAttributes = (options: PrintLinkOptions): boolean => {
   return "withAttributes" in options && options.withAttributes === true;
 };
@@ -176,7 +173,6 @@ export const hasOptionWithAttributes = (options: PrintLinkOptions): boolean => {
  * @returns `true` if the options include `parentTypePrefix`, `false` otherwise
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const hasOptionParentType = (options: PrintLinkOptions): boolean => {
   return (
     "parentTypePrefix" in options &&
@@ -194,7 +190,6 @@ export const hasOptionParentType = (options: PrintLinkOptions): boolean => {
  * @returns The folder name for the API group
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const getLinkApiGroupFolder = (
   type: unknown,
   groups?: Maybe<ApiGroupOverrideType | boolean>,
@@ -357,7 +352,6 @@ export const getRelationLink = (
  * @returns The text with appended attributes
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const printLinkAttributes = (
   type: unknown,
   text: Maybe<string> = "",

--- a/packages/printer-legacy/src/relation.ts
+++ b/packages/printer-legacy/src/relation.ts
@@ -38,7 +38,6 @@ import { SectionLevels } from "./const/options";
  * ```
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const getRootTypeLocaleFromString = (
   text: string,
 ): Maybe<TypeLocale> => {
@@ -65,7 +64,6 @@ export const getRootTypeLocaleFromString = (
  * ```
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const printRelationOf = <T>(
   type: unknown,
   section: unknown,

--- a/packages/printer-legacy/src/section.ts
+++ b/packages/printer-legacy/src/section.ts
@@ -67,7 +67,6 @@ const printPermalink = (
  * @template T - Type of the GraphQL element being printed
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const printSectionItem = <T>(
   type: T,
   options: PrintTypeOptions,
@@ -128,7 +127,6 @@ export const printSectionItem = <T>(
  * @template V - Type of the values being printed
  */
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
-// fallow-ignore-next-line unused-export
 export const printSectionItems = <V>(
   values: V | V[],
   options: PrintTypeOptions,


### PR DESCRIPTION
# Description

`fallow dead-code` reports 41 stale suppressions and two dependency false positives on `main`. None of them fail CI on their own, but `fallow audit` is scoped to changed files, so every PR that happens to touch one of those files inherits the noise in its Linter output — which is how they were found, while reviewing #3258.

## Stale suppressions

All 41 are `// fallow-ignore-next-line unused-export` (and two `unused-enum-member`) markers that no longer match any issue: fallow finds no unused export on the line below them. The directive is removed while the comment explaining why the export exists stays, so the intent is still recorded and a genuinely unused export would be reported again rather than silently swallowed.

Verified that nothing takes their place: `fallow dead-code` reports no `unused-export` or `unused-enum-member` finding after the removal.

Files: `packages/core` (config, renderer, generator, graphql-config, events, directives/validation) and `packages/printer-legacy` (link, common, section, relation, directive, badge, example, graphql/scalar, const/options).

## Dependencies

- **`memfs`** is declared once in the root `package.json`, like every other test tool, and hoisted to the packages that mock the filesystem in their tests (`core`, `diff`, `utils`). Those packages deliberately declare no test tooling of their own — each lists only `@graphql-markdown/tooling-config` — so fallow, which reads each `package.json` on its own, calls it unlisted. Ignored rather than duplicated into three `devDependencies` blocks, to keep the existing convention.
- **`mutation-testing-metrics`** is the case the config already documents for `diff` and `lodash.filter`: only `dangerfile.js` reads it, and `dangerfile.js` is declared as an entry point, which makes it look like reachable production code.

## Not addressed here

`fallow dead-code` still reports 24 unlisted dependencies repo-wide (`@eslint/js`, `@typescript-eslint/*`, `@graphql-tools/*`, and so on). They follow the same hoisting pattern, but they do not surface in PR audits today and each deserves a look rather than a blanket ignore, so they are left alone.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.
