### PR TITLE
📝 docs: resolve both paths in the output adapter key example

### DIFF
--- a/docs/advanced/output-adapter.md
+++ b/docs/advanced/output-adapter.md
@@ -45,13 +45,18 @@ The paths handed to an adapter are the ones the filesystem writer would use. Two
 
 **They are relative to the working directory**, not absolute, unless [`rootPath`](/docs/settings#rootpath) is itself absolute. With the default `rootPath: "./docs"` and `baseURL: "schema"`, a page arrives as `docs/schema/types/objects/book.md`. Key off them directly, or make them relative to `outputDir` — do not assume a leading `/`.
 
+Because they are relative, a key derived from them depends on the working directory the generator was started from. Resolve both sides before comparing them, and the two forms can no longer be mixed — a relative `rootPath` against an absolute path yields a key that climbs out of the tree with `..`.
+
 **One path sits outside the output directory.** mdBook requires `SUMMARY.md` one level above the generated pages, so an adapter computing keys with `path.relative(outputDir, filePath)` gets a leading `..` for that one file, which many object stores reject.
 
 Do not strip the `..`: that moves `SUMMARY.md` in among the pages, and the links it holds — `schema/index.md` and the like — then resolve one level too deep. Key off [`rootPath`](/docs/settings#rootpath) instead, which keeps every path inside the tree and preserves the layout:
 
 ```js
 const toKey = (location) =>
-  path.relative(rootPath, location).split(path.sep).join("/");
+  path
+    .relative(path.resolve(rootPath), path.resolve(location))
+    .split(path.sep)
+    .join("/");
 ```
 
 | Written | Key |

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -394,8 +394,14 @@ const r2 = new S3Client({
 // than `outputDir` keeps the layout intact for mdBook's SUMMARY.md, which sits
 // one level above the pages: it lands at `SUMMARY.md`, above `schema/`, so the
 // links it holds still resolve.
+//
+// Both sides are resolved first, so a relative `rootPath` and an absolute path
+// cannot be compared against each other and produce a key full of `..`.
 const toKey = (location) =>
-  path.relative(rootPath, location).split(path.sep).join("/");
+  path
+    .relative(path.resolve(rootPath), path.resolve(location))
+    .split(path.sep)
+    .join("/");
 
 module.exports = {
   // ...


### PR DESCRIPTION
# Description

The `toKey` helper shown in the [output adapter guide](https://graphql-markdown.dev/docs/advanced/output-adapter) and in the `outputAdapter` settings example compares `rootPath` against the path the renderer hands the adapter:

```js
path.relative(rootPath, location);
```

Both are relative in the common case (`rootPath: "./docs"`), so the keys an adapter produces depend on the working directory the generator was started from, and mixing the two forms — a relative `rootPath` against an absolute path — yields a key that climbs out of the tree with `..`, which most object stores reject.

Both examples now resolve each side before comparing them, and "Paths are keys" gains a paragraph saying why. Docs only; no code changes.

Found while building the [R2 output adapter demo](https://github.com/graphql-markdown/demo-astro-r2), which had copied the example as written.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uEjmFTGqXN7Q9BFLmzVvS