### PR TITLE
🔖 release 1.36.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
     },
     "packages/cli": {
       "name": "@graphql-markdown/cli",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "bin": {
         "gqlmd": "./dist/main.js",
       },
@@ -70,7 +70,7 @@
     },
     "packages/core": {
       "name": "@graphql-markdown/core",
-      "version": "1.21.2",
+      "version": "1.22.0",
       "dependencies": {
         "@fastify/deepmerge": "^3.2.1",
         "@graphql-markdown/graphql": "workspace:",
@@ -95,7 +95,7 @@
     },
     "packages/diff": {
       "name": "@graphql-markdown/diff",
-      "version": "1.1.17",
+      "version": "1.1.18",
       "dependencies": {
         "@graphql-inspector/core": "^8.0.0",
         "@graphql-markdown/graphql": "workspace:",
@@ -110,7 +110,7 @@
     },
     "packages/docusaurus": {
       "name": "@graphql-markdown/docusaurus",
-      "version": "1.35.2",
+      "version": "1.36.0",
       "dependencies": {
         "@docusaurus/utils": "catalog:docusaurus",
         "@graphql-markdown/cli": "workspace:",
@@ -129,7 +129,7 @@
     },
     "packages/formatters": {
       "name": "@graphql-markdown/formatters",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dependencies": {
         "@graphql-markdown/helpers": "workspace:",
         "@graphql-markdown/types": "workspace:",
@@ -141,7 +141,7 @@
     },
     "packages/graphql": {
       "name": "@graphql-markdown/graphql",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "dependencies": {
         "@graphql-markdown/types": "workspace:",
         "@graphql-markdown/utils": "workspace:",
@@ -156,7 +156,7 @@
     },
     "packages/helpers": {
       "name": "@graphql-markdown/helpers",
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dependencies": {
         "@graphql-markdown/graphql": "workspace:",
         "@graphql-markdown/types": "workspace:",
@@ -171,7 +171,7 @@
     },
     "packages/logger": {
       "name": "@graphql-markdown/logger",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "dependencies": {
         "@graphql-markdown/types": "workspace:",
       },
@@ -182,7 +182,7 @@
     },
     "packages/printer-legacy": {
       "name": "@graphql-markdown/printer-legacy",
-      "version": "1.16.2",
+      "version": "1.17.0",
       "dependencies": {
         "@graphql-markdown/formatters": "workspace:",
         "@graphql-markdown/graphql": "workspace:",
@@ -199,7 +199,7 @@
     },
     "packages/types": {
       "name": "@graphql-markdown/types",
-      "version": "1.13.2",
+      "version": "1.14.0",
       "dependencies": {
         "@graphql-tools/load": "catalog:graphql-tools",
         "@graphql-tools/utils": "catalog:graphql-tools",
@@ -209,7 +209,7 @@
     },
     "packages/utils": {
       "name": "@graphql-markdown/utils",
-      "version": "1.12.2",
+      "version": "1.13.0",
       "dependencies": {
         "@graphql-markdown/types": "workspace:",
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.21.2",
+  "version": "1.22.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.17",
+  "version": "1.1.18",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/docusaurus/package.json
+++ b/packages/docusaurus/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.35.2",
+  "version": "1.36.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.2",
+  "version": "1.1.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.2.4",
+  "version": "1.2.5",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.1.2",
+  "version": "1.1.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.0.9",
+  "version": "1.0.10",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/printer-legacy/package.json
+++ b/packages/printer-legacy/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.16.2",
+  "version": "1.17.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphql-markdown/types",
-  "version": "1.13.2",
+  "version": "1.14.0",
   "description": "Common types for @graphql-markdown packages",
   "repository": {
     "type": "git",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "bugs": {
     "url": "https://github.com/graphql-markdown/graphql-markdown/issues"
   },
-  "version": "1.12.2",
+  "version": "1.13.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

Prepares the **1.36.0** release by bumping every workspace package version and syncing `bun.lock`. No source changes.

| Package | 1.35.2 | 1.36.0 | Bump |
|---|---|---|---|
| @graphql-markdown/docusaurus | 1.35.2 | 1.36.0 | minor |
| @graphql-markdown/core | 1.21.2 | 1.22.0 | minor |
| @graphql-markdown/printer-legacy | 1.16.2 | 1.17.0 | minor |
| @graphql-markdown/types | 1.13.2 | 1.14.0 | minor |
| @graphql-markdown/utils | 1.12.2 | 1.13.0 | minor |
| @graphql-markdown/formatters | 1.0.2 | 1.1.0 | minor |
| @graphql-markdown/graphql | 1.2.4 | 1.2.5 | patch |
| @graphql-markdown/cli | 1.0.2 | 1.0.3 | patch |
| @graphql-markdown/diff | 1.1.17 | 1.1.18 | patch |
| @graphql-markdown/helpers | 1.1.2 | 1.1.3 | patch |
| @graphql-markdown/logger | 1.0.9 | 1.0.10 | patch |

Minor bumps go to the packages that gained public API since 1.35.2:

- **core** — pluggable output adapter for non-filesystem destinations (#3238, #3258)
- **utils** — `fsOutputAdapter`, the default filesystem destination (#3238)
- **types** — `OutputAdapter` and related formatter/utils types (#3238, #3255)
- **formatters** — output & version helpers, section header permalink support (#3238, #3255)
- **printer-legacy** — expose section header permalink to formatters (#3255)

The remaining packages have no source changes since 1.35.2 and get a patch bump to stay aligned with the release.

# Draft release notes

Proposed body for the `1.36.0` GitHub release. Publishing the release with this body triggers the [changelog workflow](https://github.com/graphql-markdown/graphql-markdown/blob/main/.github/workflows/changelog.yml), which copies it into `CHANGELOG.md`.

<details>
<summary>Release body</summary>

1.36.0 makes the output destination pluggable: `outputAdapter` lets the generator write somewhere other than the local filesystem — object storage, a CMS, an in-memory bundle — while the filesystem stays the default. It also switches section header IDs to the syntax native to each target framework, which changes generated output by default.

### 💥 Breaking Change

- **Formatters**: `formatMDXPermalink` is now a required member of the [`Formatter`](https://graphql-markdown.dev/docs/settings#formatter) interface. The built-in presets are unaffected; a [custom formatter](https://graphql-markdown.dev/docs/settings#formatter) written in TypeScript must implement it to type-check — spreading a built-in preset is the easiest way. At runtime a default permalink format is applied, so JavaScript formatters keep working ([#3255](https://github.com/graphql-markdown/graphql-markdown/issues/3255)).

### What's New

- **Core**: pluggable `outputAdapter` sends generated pages to a destination other than the local filesystem. `fsOutputAdapter` remains the default, so existing setups are unchanged, and formatter lifecycle hooks write through the same adapter — post-processed pages follow the output instead of silently landing on disk ([#3238](https://github.com/graphql-markdown/graphql-markdown/issues/3238), [#3258](https://github.com/graphql-markdown/graphql-markdown/issues/3258)). See the [output adapter guide](https://graphql-markdown.dev/docs/advanced/output-adapter).
- **Formatters**: section header IDs now use each framework's native syntax — `{/* #ID */}` on Docusaurus 3.10 and later, `[#ID]` on Fumadocs, escaped `\{#ID\}` on Starlight and Vocs, and the classic `{#ID}` elsewhere. Since `docOptions.sectionHeaderId` defaults to `true`, this changes generated output without any config change: set it to `false` to restore the previous behaviour, or override `formatMDXPermalink` in a custom formatter ([#3255](https://github.com/graphql-markdown/graphql-markdown/issues/3255)).

### Documentation

- Add an output adapter guide ([#3261](https://github.com/graphql-markdown/graphql-markdown/issues/3261)).
- Resolve both paths in the output adapter key example ([#3267](https://github.com/graphql-markdown/graphql-markdown/issues/3267)).

### Maintenance 🧹

- Drop Docusaurus 2 from the smoke test matrix.
- Clear the fallow stale suppressions and hoisted dev dependencies ([#3260](https://github.com/graphql-markdown/graphql-markdown/issues/3260)).

### Package Versions 📦

| Package | Version |
|---|---|
| @graphql-markdown/docusaurus | 1.36.0 |
| @graphql-markdown/core | 1.22.0 |
| @graphql-markdown/printer-legacy | 1.17.0 |
| @graphql-markdown/types | 1.14.0 |
| @graphql-markdown/utils | 1.13.0 |
| @graphql-markdown/graphql | 1.2.5 |
| @graphql-markdown/cli | 1.0.3 |
| @graphql-markdown/diff | 1.1.18 |
| @graphql-markdown/helpers | 1.1.3 |
| @graphql-markdown/logger | 1.0.10 |
| @graphql-markdown/formatters | 1.1.0 |

**Full Changelog**: https://github.com/graphql-markdown/graphql-markdown/compare/1.35.2...1.36.0
</details>

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


