### PR TITLE
✨ feat(graphql): add getTypeDirectiveValuesList for repeatable directives

### DIFF
--- a/packages/graphql/src/introspection.ts
+++ b/packages/graphql/src/introspection.ts
@@ -270,6 +270,32 @@ export const getDirective = (
 };
 
 /**
+ * Returns the AST node holding the directives for a GraphQL schema type.
+ *
+ * @internal
+ *
+ * @param type - the GraphQL schema type to parse.
+ *
+ * @returns the AST node carrying the `directives` list.
+ *
+ */
+const getDirectivesHolder = (
+  type: unknown,
+): Maybe<{ readonly directives?: readonly DirectiveNode[] }> => {
+  if (typeof type !== "object" || type === null) {
+    return undefined;
+  }
+  if (hasAstNode(type)) {
+    return (type as GraphQLNamedType).astNode as {
+      readonly directives?: readonly DirectiveNode[];
+    };
+  }
+  return type as ASTNode as {
+    readonly directives?: readonly DirectiveNode[];
+  };
+};
+
+/**
  * Returns all directive's arguments' values linked to a GraphQL schema type.
  *
  * @param directive - a GraphQL directive defined in the schema.
@@ -282,20 +308,63 @@ export const getTypeDirectiveValues = (
   directive: GraphQLDirective,
   type: unknown,
 ): Maybe<Record<string, unknown>> => {
-  if (hasAstNode(type)) {
-    return getDirectiveValues(
-      directive,
-      (type as GraphQLNamedType).astNode as {
-        readonly directives?: readonly DirectiveNode[];
-      },
-    );
+  const node = getDirectivesHolder(type);
+
+  if (!node) {
+    return undefined;
   }
-  return getDirectiveValues(
-    directive,
-    type as ASTNode as {
-      readonly directives?: readonly DirectiveNode[];
-    },
-  );
+
+  return getDirectiveValues(directive, node);
+};
+
+/**
+ * Returns the arguments' values of every occurrence of a directive on a GraphQL schema type.
+ *
+ * Unlike {@link getTypeDirectiveValues}, which resolves only the first occurrence,
+ * this returns one record per occurrence, in schema declaration order. This is
+ * required for [repeatable directives](https://spec.graphql.org/draft/#sec-Type-System.Directives).
+ *
+ * @param directive - a GraphQL directive defined in the schema.
+ * @param type - the GraphQL schema type to parse.
+ *
+ * @returns a list of records k/v with arguments' name as keys and arguments' value, empty if the directive is not present.
+ *
+ * @example
+ * ```graphql
+ * type Query {
+ *   user(id: ID!): User
+ *     @httpResponse(code: 200, description: "OK")
+ *     @httpResponse(code: 404, description: "User not found")
+ * }
+ * ```
+ * ```js
+ * getTypeDirectiveValuesList(httpResponseDirective, queryUserField);
+ * // [ { code: 200, description: "OK" }, { code: 404, description: "User not found" } ]
+ * ```
+ *
+ */
+export const getTypeDirectiveValuesList = (
+  directive: GraphQLDirective,
+  type: unknown,
+): Record<string, unknown>[] => {
+  const node = getDirectivesHolder(type);
+
+  if (!Array.isArray(node?.directives)) {
+    return [];
+  }
+
+  return node.directives
+    .filter((directiveNode: DirectiveNode): boolean => {
+      return directiveNode.name.value === directive.name;
+    })
+    .map((directiveNode: DirectiveNode): Maybe<Record<string, unknown>> => {
+      // Coerce each occurrence in isolation, as `getDirectiveValues` only ever
+      // resolves the first directive node matching the directive name.
+      return getDirectiveValues(directive, { directives: [directiveNode] });
+    })
+    .filter((values): values is Record<string, unknown> => {
+      return typeof values !== "undefined";
+    });
 };
 
 /**

--- a/packages/graphql/tests/unit/introspection.test.ts
+++ b/packages/graphql/tests/unit/introspection.test.ts
@@ -35,6 +35,7 @@ import {
   getOperation,
   getSchemaMap,
   getTypeDirectiveValues,
+  getTypeDirectiveValuesList,
   getTypeFromSchema,
   getTypeName,
   hasDirective,
@@ -807,6 +808,78 @@ describe("introspection", () => {
         typeAstNode,
       );
       expect(values).toMatchObject({ arg: "ARGA" });
+    });
+  });
+
+  describe("getTypeDirectiveValuesList", () => {
+    const schema = buildSchema(`
+      directive @dirWithoutArg on OBJECT | FIELD_DEFINITION
+
+      directive @httpResponse(
+        code: Int!
+        description: String
+      ) repeatable on OBJECT | FIELD_DEFINITION
+
+      type Test 
+        @httpResponse(code: 200, description: "OK") 
+        @dirWithoutArg
+        @httpResponse(code: 404, description: "Not found")
+        @httpResponse(code: 500) {
+        id: ID!
+        fieldA: [String!] @httpResponse(code: 201)
+        fieldB: ID! @dirWithoutArg
+      }
+    `);
+    const type = schema.getType("Test")!;
+    const directiveType = schema.getDirective("httpResponse")!;
+
+    test("returns one record per directive occurrence in declaration order", () => {
+      expect.assertions(1);
+
+      expect(getTypeDirectiveValuesList(directiveType, type)).toStrictEqual([
+        { code: 200, description: "OK" },
+        { code: 404, description: "Not found" },
+        { code: 500 },
+      ]);
+    });
+
+    test("converts type to astNode", () => {
+      expect.assertions(1);
+
+      expect(getTypeDirectiveValuesList(directiveType, type)).toStrictEqual(
+        getTypeDirectiveValuesList(directiveType, type.astNode!),
+      );
+    });
+
+    test("returns values for a field definition", () => {
+      expect.assertions(1);
+
+      const field = (type as GraphQLObjectType).getFields()["fieldA"];
+
+      expect(getTypeDirectiveValuesList(directiveType, field)).toStrictEqual([
+        { code: 201 },
+      ]);
+    });
+
+    test("returns an empty list if the directive is not present", () => {
+      expect.assertions(1);
+
+      const field = (type as GraphQLObjectType).getFields()["fieldB"];
+
+      expect(getTypeDirectiveValuesList(directiveType, field)).toStrictEqual(
+        [],
+      );
+    });
+
+    test("returns an empty list if the type has no directives", () => {
+      expect.assertions(2);
+
+      expect(
+        getTypeDirectiveValuesList(directiveType, undefined),
+      ).toStrictEqual([]);
+      expect(
+        getTypeDirectiveValuesList(directiveType, { name: "NoAstNode" }),
+      ).toStrictEqual([]);
     });
   });
 


### PR DESCRIPTION
# Description

First PR of #3273 (`customSections`), and a prerequisite for it.

`getTypeDirectiveValues` delegates to the `graphql-js` `getDirectiveValues`, which only ever resolves the **first** directive node matching a given directive name. Every directive path in the repo goes through it, so a [repeatable directive](https://spec.graphql.org/draft/#sec-Type-System.Directives) collapses to a single entry:

```graphql
type Query {
  user(id: ID!): User
    @httpResponse(code: 200, description: "OK")
    @httpResponse(code: 404, description: "User not found")
}
```

Only the `200` occurrence is ever readable today. `customSections` cannot render a table of status codes or headers without this, and `customDirective.<name>.descriptor` silently drops occurrences for the same reason.

This PR adds `getTypeDirectiveValuesList`, which returns one record of coerced argument values **per occurrence**, in schema declaration order:

```js
getTypeDirectiveValuesList(httpResponseDirective, queryUserField);
// [ { code: 200, description: "OK" }, { code: 404, description: "User not found" } ]
```

Each occurrence is coerced in isolation by passing a single-directive node to `getDirectiveValues`, so argument coercion (defaults, enums, input objects, lists) stays owned by `graphql-js` rather than being reimplemented here.

Also extracts the AST-node lookup shared with `getTypeDirectiveValues` into a `getDirectivesHolder` helper, which additionally guards nullish input instead of throwing on `undefined.astNode`.

No existing behaviour changes: `getTypeDirectiveValues` keeps its first-occurrence semantics, and nothing is rewired to the new function yet. Wiring `descriptor` and the new sections to it belongs to the follow-up PRs on #3273.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.

Notes on the checklist: the new function carries TSDoc with a worked example, and the API reference is generated from source, so no separate docs change is needed — user-facing documentation lands with the `customSections` option itself. Tests cover multiple occurrences in declaration order, interleaved unrelated directives, omitted optional arguments, field-definition nodes, raw AST nodes vs. types, absent directives, and nullish input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
