### PR TITLE
♻️ refactor: build the example section as a custom section

### DIFF
--- a/docs/advanced/custom-sections.md
+++ b/docs/advanced/custom-sections.md
@@ -110,6 +110,12 @@ Optional directive arguments that were omitted are absent from the record rather
 
 Another custom section can also be named, as long as it is declared earlier. A section whose `position` names an unknown section is appended last.
 
+:::note
+
+`example` is itself a custom section, specialized: it is built from the [`printTypeOptions.exampleSection`](/docs/settings#printtypeoptions) option and rendered as a code block. It is configured through that option, not through `customSections`.
+
+:::
+
 :::tip
 
 Use [`beforeComposePageTypeHook`](/docs/advanced/hook-recipes) when the placement has to be decided per type, rather than once in the configuration.

--- a/packages/printer-legacy/src/custom-section.ts
+++ b/packages/printer-legacy/src/custom-section.ts
@@ -30,7 +30,34 @@ import {
   isUnionType,
 } from "@graphql-markdown/graphql";
 
-import { MARKDOWN_EOP } from "./const/strings";
+import { printExample } from "./example";
+
+import { MARKDOWN_EOC, MARKDOWN_EOP, MARKDOWN_SOC } from "./const/strings";
+
+/**
+ * Resolves the values a section renders, replacing the default directive lookup.
+ *
+ * Used by the built-in sections, such as the example section, whose values do
+ * not come from reading directive occurrences off the type.
+ *
+ * @internal
+ */
+export type SectionValuesResolver = (
+  type: unknown,
+  options: PrintTypeOptions,
+) => Maybe<Record<string, unknown>[]>;
+
+/**
+ * A custom section, optionally resolving its own values.
+ *
+ * The `resolve` callback is internal: a section declared through
+ * `printTypeOptions.customSections` always reads directive occurrences.
+ *
+ * @internal
+ */
+export type SectionDefinition = TypeCustomSectionOption & {
+  resolve?: SectionValuesResolver;
+};
 
 /**
  * Section keys owned by the printer, which a custom section cannot claim.
@@ -123,11 +150,97 @@ const appliesToEntity = (
 };
 
 /**
+ * Builds the example section as a custom section definition.
+ *
+ * The example section is a specialized custom section: it is driven by a schema
+ * directive, named by [`printTypeOptions.exampleSection`](https://graphql-markdown.dev/docs/settings#printtypeoptions),
+ * and rendered as a code block.
+ *
+ * It resolves its own value rather than reading directive occurrences, because
+ * an example is also derived from the fields of a type carrying no example
+ * directive itself. The `directive` name is therefore descriptive only: the
+ * schema lookup belongs to {@link printExample}.
+ *
+ * @param options - the print options in effect.
+ *
+ * @returns the example section definition.
+ *
+ * @example
+ * ```ts
+ * const section = getExampleSectionDefinition(options);
+ * const example = printCustomSection(type, section, options);
+ * ```
+ *
+ */
+export const getExampleSectionDefinition = (
+  options: PrintTypeOptions,
+): SectionDefinition => {
+  const { exampleSection } = options;
+  // Matches `getDirectiveExampleOption`: an empty directive name falls back too.
+  const directive =
+    exampleSection &&
+    typeof exampleSection === "object" &&
+    exampleSection.directive
+      ? exampleSection.directive
+      : "example";
+
+  return {
+    name: "example",
+    title: "Example",
+    directive,
+    resolve: (
+      type: unknown,
+      printOptions: PrintTypeOptions,
+    ): Record<string, unknown>[] => {
+      const example = printExample(type, printOptions);
+      return example ? [{ example }] : [];
+    },
+    render: (values: Record<string, unknown>[]): string => {
+      return `${MARKDOWN_SOC}${values[0]!.example as string}${MARKDOWN_EOC}`;
+    },
+  };
+};
+
+/**
+ * Reads every occurrence of a section's directive on a type.
+ *
+ * @internal
+ *
+ * @param type - the GraphQL type being printed.
+ * @param section - the section declaration.
+ * @param options - the print options in effect.
+ *
+ * @returns one record of arguments per occurrence, empty when the directive is
+ * absent from the schema or from the type.
+ *
+ */
+const getDirectiveValues = (
+  type: unknown,
+  section: SectionDefinition,
+  options: PrintTypeOptions,
+): Record<string, unknown>[] => {
+  const schema = options.schema;
+  const directive =
+    schema && instanceOf(schema, GraphQLSchema as never)
+      ? schema.getDirective(section.directive)
+      : undefined;
+
+  if (!directive) {
+    return [];
+  }
+
+  return getTypeDirectiveValuesList(directive, type);
+};
+
+/**
  * Prints a single custom section for a type.
  *
- * The section is skipped, returning `undefined`, when its name is reserved, its
- * `appliesTo` filter excludes the type, the directive is absent from the schema
- * or from the type, or the render callback returns no content.
+ * The section is skipped, returning `undefined`, when its `appliesTo` filter
+ * excludes the type, no value is resolved for it, or the render callback returns
+ * no content.
+ *
+ * Reserved names are filtered by `getDeclaredSections`, not here: the built-in
+ * sections are themselves declared with a reserved name.
  *
  * @param type - the GraphQL type being printed.
  * @param section - the custom section declaration.
@@ -138,30 +251,21 @@ const appliesToEntity = (
  */
 export const printCustomSection = (
   type: unknown,
-  section: TypeCustomSectionOption,
+  section: SectionDefinition,
   options: PrintTypeOptions,
 ): Maybe<PageSection> => {
   if (
-    RESERVED_SECTION_NAMES.includes(section.name) ||
     typeof section.render !== "function" ||
     !appliesToEntity(type, section, options)
   ) {
     return undefined;
   }
 
-  const schema = options.schema;
-  const directive =
-    schema && instanceOf(schema, GraphQLSchema as never)
-      ? schema.getDirective(section.directive)
-      : undefined;
+  const values = section.resolve
+    ? section.resolve(type, options)
+    : getDirectiveValues(type, section, options);
 
-  if (!directive) {
-    return undefined;
-  }
-
-  const values = getTypeDirectiveValuesList(directive, type);
-
-  if (values.length === 0) {
+  if (!Array.isArray(values) || values.length === 0) {
     return undefined;
   }
 

--- a/packages/printer-legacy/src/printer.ts
+++ b/packages/printer-legacy/src/printer.ts
@@ -73,7 +73,12 @@ import { pathUrl } from "@graphql-markdown/utils";
 import { printRelations } from "./relation";
 import { printDescription } from "./common";
 import { printCustomDirectives, printCustomTags } from "./directive";
-import { getCustomSectionsOrder, printCustomSections } from "./custom-section";
+import {
+  getCustomSectionsOrder,
+  getExampleSectionDefinition,
+  printCustomSection,
+  printCustomSections,
+} from "./custom-section";
 import { printFrontMatter } from "./frontmatter";
 import {
   printCodeDirective,
@@ -107,7 +112,6 @@ import {
   PRINT_TYPE_DEFAULT_OPTIONS,
   SectionLevels,
 } from "./const/options";
-import { printExample } from "./example";
 import {
   PrintCodeEvent,
   PrintTypeEvent,
@@ -446,16 +450,11 @@ export class Printer implements IPrinter {
     type: unknown,
     options: PrintTypeOptions,
   ): Maybe<PageSection> => {
-    const example = printExample(type, options);
-
-    if (!example) {
-      return undefined;
-    }
-
-    return {
-      content: `${MARKDOWN_SOC}${example}${MARKDOWN_EOC}${MARKDOWN_EOP}`,
-      title: "Example",
-    };
+    return printCustomSection(
+      type,
+      getExampleSectionDefinition(options),
+      options,
+    );
   };
 
   /**

--- a/packages/printer-legacy/tests/unit/__snapshots__/printer.test.ts.snap
+++ b/packages/printer-legacy/tests/unit/__snapshots__/printer.test.ts.snap
@@ -74,13 +74,12 @@ Union
 
 exports[`Printer > printExample() > returns a Markdown graphql codeblock with example 1`] = `
 {
-  "content": "
-\`\`\`graphql
+  "content": "\`\`\`graphql
 This is an example
 \`\`\`
 
-
 ",
+  "level": 3,
   "title": "Example",
 }
 `;

--- a/packages/printer-legacy/tests/unit/__snapshots__/printer.test.ts.snap
+++ b/packages/printer-legacy/tests/unit/__snapshots__/printer.test.ts.snap
@@ -74,9 +74,11 @@ Union
 
 exports[`Printer > printExample() > returns a Markdown graphql codeblock with example 1`] = `
 {
-  "content": "\`\`\`graphql
+  "content": "
+\`\`\`graphql
 This is an example
 \`\`\`
+
 
 ",
   "level": 3,

--- a/packages/printer-legacy/tests/unit/custom-section.test.ts
+++ b/packages/printer-legacy/tests/unit/custom-section.test.ts
@@ -10,6 +10,7 @@ import { Printer } from "../../src/printer";
 
 import {
   getCustomSectionsOrder,
+  getExampleSectionDefinition,
   getSchemaEntity,
   printCustomSection,
   printCustomSections,
@@ -168,18 +169,6 @@ describe("custom-section", () => {
       ).toBeUndefined();
     });
 
-    test("returns undefined if the section name is reserved", () => {
-      expect.assertions(1);
-
-      expect(
-        printCustomSection(
-          type,
-          { ...httpResponses, name: "metadata" },
-          options,
-        ),
-      ).toBeUndefined();
-    });
-
     test("renders if appliesTo matches the entity kind", () => {
       expect.assertions(1);
 
@@ -303,6 +292,84 @@ describe("custom-section", () => {
           }),
         ),
       ).toStrictEqual([]);
+    });
+  });
+
+  describe("getExampleSectionDefinition()", () => {
+    const exampleSchema = buildSchema(`
+      directive @example(value: String) on OBJECT | FIELD_DEFINITION
+
+      type Sample @example(value: "42") {
+        id: ID!
+      }
+
+      type NoSample {
+        id: ID! @example(value: "7")
+      }
+    `);
+
+    const exampleOptions = {
+      ...DEFAULT_OPTIONS,
+      schema: exampleSchema,
+    } as PrintTypeOptions;
+
+    test("renders the example as a code block section", () => {
+      expect.assertions(1);
+
+      expect(
+        printCustomSection(
+          exampleSchema.getType("Sample")!,
+          getExampleSectionDefinition(exampleOptions),
+          exampleOptions,
+        ),
+      ).toMatchInlineSnapshot(`
+        {
+          "content": "\`\`\`graphql
+        42
+        \`\`\`
+
+        ",
+          "level": 3,
+          "title": "Example",
+        }
+      `);
+    });
+
+    test("returns undefined if the schema declares no example directive", () => {
+      expect.assertions(1);
+
+      expect(
+        printCustomSection(type, getExampleSectionDefinition(options), options),
+      ).toBeUndefined();
+    });
+
+    test("derives an example from the fields of a type carrying none", () => {
+      expect.assertions(1);
+
+      // `NoSample` has no example directive of its own: `printExample` walks its
+      // fields instead, which is why the example section resolves its own values
+      // rather than reading directive occurrences.
+      expect(
+        printCustomSection(
+          exampleSchema.getType("NoSample")!,
+          getExampleSectionDefinition(exampleOptions),
+          exampleOptions,
+        ),
+      ).toBeDefined();
+    });
+
+    test("uses the directive name from the exampleSection option", () => {
+      expect.assertions(2);
+
+      expect(getExampleSectionDefinition(exampleOptions).directive).toBe(
+        "example",
+      );
+      expect(
+        getExampleSectionDefinition({
+          ...exampleOptions,
+          exampleSection: { directive: "sample" },
+        }).directive,
+      ).toBe("sample");
     });
   });
 

--- a/packages/printer-legacy/tests/unit/custom-section.test.ts
+++ b/packages/printer-legacy/tests/unit/custom-section.test.ts
@@ -324,9 +324,11 @@ describe("custom-section", () => {
         ),
       ).toMatchInlineSnapshot(`
         {
-          "content": "\`\`\`graphql
+          "content": "
+        \`\`\`graphql
         42
         \`\`\`
+
 
         ",
           "level": 3,

--- a/packages/printer-legacy/tests/unit/printer.test.ts
+++ b/packages/printer-legacy/tests/unit/printer.test.ts
@@ -47,7 +47,15 @@ import * as GraphQL from "@graphql-markdown/graphql";
 vi.mock("../../src/graphql");
 import * as GraphQLPrinter from "../../src/graphql";
 
-vi.mock("../../src/example");
+// Partial mock: `printExample` is stubbed per test, while
+// `getExampleSectionDefinition` stays real so the example section is still built
+// through the shared custom section machinery.
+vi.mock("../../src/example", async (importOriginal) => {
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    printExample: vi.fn(),
+  };
+});
 import * as ExamplePrinter from "../../src/example";
 
 import * as Link from "../../src/link";


### PR DESCRIPTION
# Description

Third PR of #3273. **Stacked on #3275** — review that one first; this PR's base is `feat/custom-sections`, so its diff shows only the refactor.

`exampleSection` stays exactly as it is: same option, same shape, no deprecation, no alias. What changes is the implementation — the example section is now built by the custom section machinery instead of its own parallel code path.

## Why they were the same thing

Both did: resolve a directive-driven value, skip the section when there is none, wrap the result in a titled page section, and take a slot in the type page order. The example section just did it in `Printer.printExample` with the wrapping inlined.

## What made it not quite the same thing

A custom section reads directive occurrences off the type, and no occurrences means nothing to render. The example section cannot work that way: `printExample` also derives an example from the **fields** of a type carrying no example directive itself, so an empty occurrence list does not mean there is no example.

So a section definition gains an optional internal `resolve` callback, which supplies the section's values in place of the directive lookup. The example section is the first and only user of it:

```ts
{
  name: "example",
  title: "Example",
  directive: exampleSection?.directive ?? "example",
  resolve: (type, options) => {
    const example = printExample(type, options);
    return example ? [{ example }] : [];
  },
  render: (values) => `${MARKDOWN_SOC}${values[0].example}${MARKDOWN_EOC}`,
}
```

`resolve` is deliberately **not** part of `TypeCustomSectionOption`, so it stays out of the public configuration surface: a section declared through `printTypeOptions.customSections` always reads directive occurrences. The `directive` name on the built-in definition is descriptive only — the schema lookup belongs to `printExample`.

The reserved name check also moves from `printCustomSection` to `getDeclaredSections`, because the built-in sections are themselves declared with a reserved name (`example`). `getDeclaredSections` is what guards the user-supplied list, so the check is still enforced where it matters.

## Behaviour

`Printer.printExample` keeps its signature and returns the same `PageSection`, and the rendered page is **byte-identical** to before the refactor. The only difference in the whole suite is that the returned section now carries `level: 3` explicitly, which is what `renderPageSection` already defaulted to.

(An earlier revision of this PR trimmed the example code block's leading newline. The review of #3275 established that the section builder must not trim the render callback's output at all — leading whitespace is significant in Markdown — so that difference is gone after rebasing on the fixed base.)

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.

Tests cover the example section rendering as a code block, the schema declaring no example directive, the directive name coming from the option, and the field-derived example that motivates `resolve` in the first place. `printer.test.ts` moves from an automock of `../../src/example` to a partial mock so `getExampleSectionDefinition` runs for real while `printExample` stays stubbed. Full suite: 1586 passing.

The docs gain one note saying `example` is itself a specialized custom section, configured through its own option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)