### PR TITLE
✨ feat(logger): accept a logger instance, and make CLI cliOptions optional

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,7 +35,7 @@ export type GraphQLMarkdownCliType = Command;
  * Runs the GraphQL Markdown CLI to generate documentation from a GraphQL schema.
  *
  * @param options - Options for configuring the GraphQL Markdown CLI.
- * @param cliOptions - Command-line options passed to the CLI.
+ * @param cliOptions - Optional command-line options passed to the CLI.
  * @param loggerModule - Optional logger module to use.
  *
  * @example
@@ -49,13 +49,13 @@ export type GraphQLMarkdownCliType = Command;
  */
 export const runGraphQLMarkdown = async (
   options: GraphQLMarkdownCliOptions,
-  cliOptions: CliOptions,
+  cliOptions?: CliOptions,
   loggerModule?: string,
 ): Promise<void> => {
   await Logger(loggerModule);
   const config = await buildConfig(options, cliOptions, options.id);
 
-  if (cliOptions.config) {
+  if (cliOptions?.config) {
     console.dir(config, { depth: null });
     return;
   }

--- a/packages/cli/tests/unit/index.test.ts
+++ b/packages/cli/tests/unit/index.test.ts
@@ -1042,6 +1042,24 @@ describe("CLI Module", () => {
       expect(vi.mocked(core.generateDocFromSchema)).not.toHaveBeenCalled();
     });
 
+    test("runs documentation generation without CLI options", async () => {
+      expect.assertions(2);
+
+      const options = {
+        schema: "./schema.graphql",
+        rootPath: "./docs",
+      };
+
+      await runGraphQLMarkdown(options);
+
+      expect(vi.mocked(core.buildConfig)).toHaveBeenCalledWith(
+        options,
+        undefined,
+        undefined,
+      );
+      expect(vi.mocked(core.generateDocFromSchema)).toHaveBeenCalled();
+    });
+
     test("forwards noSectionId CLI option to buildConfig", async () => {
       expect.assertions(1);
 

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -95,7 +95,7 @@ const resolveLoggerInstance = (
  * Instantiate a logger module.
  * By default, the logger module uses `globalThis.console`
  *
- * @param moduleName - optional name of the logger package.
+ * @param moduleName - optional name of the logger package, or a logger instance to use directly.
  *
  * @example
  * ```js
@@ -105,18 +105,25 @@ const resolveLoggerInstance = (
  *
  * Logger("@docusaurus/logger");
  * log("Info message", "info"); // Expected Docusaurus log output "Info message"
+ *
+ * Logger({ info: (message) => process.stdout.write(message) }); // Logger instance
+ * log("Info message", "info"); // Expected custom logger output "Info message"
  * ```
  *
  */
-export const Logger = async (moduleName?: string): Promise<void> => {
+export const Logger = async (
+  moduleName?: Record<string, unknown> | string,
+): Promise<void> => {
   if (globalThis.logger?.instance && moduleName === undefined) {
     return;
   }
 
-  const moduleExports =
-    typeof moduleName === "string" && moduleName !== ""
-      ? await import(moduleName)
-      : undefined;
+  let moduleExports: Record<string, unknown> | undefined;
+  if (typeof moduleName === "string" && moduleName !== "") {
+    moduleExports = await import(moduleName);
+  } else if (typeof moduleName === "object") {
+    moduleExports = moduleName;
+  }
 
   const instance =
     resolveLoggerInstance(moduleExports) ??
@@ -138,7 +145,6 @@ export const Logger = async (moduleName?: string): Promise<void> => {
 
   const _log = (
     message: string,
-
     level: LogLevel | keyof typeof LogLevel = LogLevel.info,
   ): void => {
     const callback = getCallbackForLevel(instance, level);
@@ -167,7 +173,6 @@ export const Logger = async (moduleName?: string): Promise<void> => {
  */
 export const log = (
   message: string,
-
   level: LogLevel | keyof typeof LogLevel = LogLevel.info,
 ): void => {
   Promise.resolve(Logger()).catch(() => {});

--- a/packages/logger/tests/unit/logger.test.ts
+++ b/packages/logger/tests/unit/logger.test.ts
@@ -122,6 +122,67 @@ describe("logger", () => {
       expect(spyLogger).toHaveBeenCalledWith("test", "info");
     });
 
+    test("returns the logger instance passed as an object", async () => {
+      expect.hasAssertions();
+
+      const info = vi.fn();
+
+      await Logger.Logger({ info });
+      Logger.log("test");
+
+      expect(globalThis.logger?.instance).toEqual(
+        expect.objectContaining({ info }),
+      );
+      expect(info).toHaveBeenCalledWith("test");
+    });
+
+    test("resolves a nested logger instance passed as an object", async () => {
+      expect.hasAssertions();
+
+      const info = vi.fn();
+
+      await Logger.Logger({ default: { info } });
+      Logger.log("test");
+
+      expect(info).toHaveBeenCalledWith("test");
+    });
+
+    test("falls back to console if the object passed is not a logger", async () => {
+      expect.hasAssertions();
+
+      const spy = vi
+        .spyOn(globalThis.console, "info")
+        .mockImplementation(() => {
+          return "Mocked Console";
+        });
+
+      await Logger.Logger({ foo: "bar" });
+      Logger.log("test");
+
+      expect(spy).toHaveBeenCalledWith("test");
+      expect(globalThis.logger?.instance).toBe(globalThis.console);
+    });
+
+    test("overrides current logger with an instance passed as an object", async () => {
+      expect.hasAssertions();
+
+      const spyConsole = vi
+        .spyOn(globalThis.console, "info")
+        .mockImplementation(() => {
+          return "Mocked Console";
+        });
+      const info = vi.fn();
+
+      await Logger.Logger();
+      expect(globalThis.logger).toBeDefined();
+
+      await Logger.Logger({ info });
+      Logger.log("test");
+
+      expect(spyConsole).not.toHaveBeenCalled();
+      expect(info).toHaveBeenCalledWith("test");
+    });
+
     test("overrides current logger with Docusaurus", async () => {
       expect.hasAssertions();
 


### PR DESCRIPTION
# Description

Two small ergonomic improvements for programmatic (non-CLI) consumers.

**`@graphql-markdown/logger`** — `Logger()` now accepts either a module name to import (as before) or a ready-made logger object, so callers can inject their own instance without publishing it as a resolvable module. Objects go through the same `resolveLoggerInstance` resolution as imported modules, so nested `default`/`logger` export shapes keep working, and an object that is not a logger still falls back to `globalThis.console`.

**`@graphql-markdown/cli`** — `runGraphQLMarkdown()` no longer requires `cliOptions`. `buildConfig` already defaults `cliOpts` to `{}`, so requiring the argument only forced programmatic callers to pass an empty object.

Both changes are backward compatible: existing string / explicit-options call sites are unaffected.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)