### PR TITLE
💥 refactor: key customSections by directive name

### DIFF
--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -5,13 +5,16 @@
   // but still needed. Declaring them as entry points silences unused-file
   // false positives. Stryker and danger configs are dev tooling so they must
   // be declared explicitly. E2e specs are run via Earthfile (outside jest plugin
-  // detection range) so they are declared here too.
+  // detection range) so they are declared here too, as are the CI tooling specs,
+  // which run through their own vitest config (`tests/ci/vitest.config.mjs`)
+  // rather than the workspace one.
   "entry": [
     "dangerfile.js",
     ".github/scripts/**",
     "**/stryker.conf.mjs",
     "packages/tooling-config/scripts/**",
     "packages/tooling-config/typedoc/**",
+    "tests/ci/**",
     "tests/e2e/*/specs/*.spec.mjs",
     "tests/e2e/helpers/**"
   ],

--- a/.github/scripts/affected-packages.mts
+++ b/.github/scripts/affected-packages.mts
@@ -43,18 +43,29 @@ type AffectedOutputs = {
   docs_only: boolean;
 };
 
-// Anything matching these invalidates every assumption below (shared build
-// config, the toolchain, the type definitions every package compiles against,
-// or this script itself), so they fail open to the full matrix.
-const GLOBAL_PATTERNS = [
+// Anything matching these invalidates the workspace graph the closure below is
+// computed from, so the unit test matrix fails open to every package.
+//
+// They are split in two tiers because they do not all invalidate the same
+// thing. A `_RUNTIME` entry changes what a package's own tests actually
+// execute -- the installed dependency tree, the compiler settings, the test
+// runner, the CI toolchain -- so it fans out to mutation testing as well. A
+// `_STATIC` entry cannot: type definitions are erased before a mutant ever
+// runs, and the CI tooling is not part of any package. Those keep mutation
+// testing on the packages genuinely touched, which is most of the saving on a
+// `packages/types` change -- the shape of nearly every public API PR.
+const GLOBAL_RUNTIME_PATTERNS = [
   /^bun\.lock$/u,
   /^package\.json$/u,
   /^tsconfig(\..+)?\.json$/u,
   /^turbo\.json$/u,
   /^vitest\.config\.mjs$/u,
-  /^packages\/types\//u,
   /^packages\/tooling-config\//u,
   /^\.github\/actions\//u,
+];
+
+const GLOBAL_STATIC_PATTERNS = [
+  /^packages\/types\//u,
   /^\.github\/scripts\//u,
   /^tests\/ci\//u,
 ];
@@ -131,15 +142,94 @@ const expandDependents = (
 
   while (queue.length > 0) {
     const packageName = queue.shift()!;
-    for (const dependent of dependentsMap.get(packageName) ?? []) {
-      if (!closure.has(dependent)) {
-        closure.add(dependent);
-        queue.push(dependent);
-      }
-    }
+    const added = [...(dependentsMap.get(packageName) ?? [])].filter(
+      (dependent) => {
+        return !closure.has(dependent);
+      },
+    );
+
+    added.forEach((dependent) => {
+      closure.add(dependent);
+    });
+    queue.push(...added);
   }
 
   return closure;
+};
+
+/**
+ * Which global tier the change set falls into: `runtime` also invalidates
+ * mutation testing, `any` only the dependency closure.
+ */
+const getGlobalScope = (
+  files: string[],
+): { runtime: boolean; any: boolean } => {
+  const runtime = files.some((file) => {
+    return matches(file, GLOBAL_RUNTIME_PATTERNS);
+  });
+
+  const staticOnly = files.some((file) => {
+    return matches(file, GLOBAL_STATIC_PATTERNS);
+  });
+
+  return { runtime, any: runtime || staticOnly };
+};
+
+/**
+ * The packages a change set touches directly, ignoring the dependency graph.
+ */
+const getTouchedPackages = (
+  files: string[],
+  allPackages: string[],
+): Set<string> => {
+  return new Set(
+    files.flatMap((file) => {
+      const name = /^packages\/([^/]+)\//u.exec(file)?.[1];
+      return name && allPackages.includes(name) ? [name] : [];
+    }),
+  );
+};
+
+/**
+ * Both smoke scaffolds install every workspace package, so any package change
+ * runs every smoke job; only the e2e spec directories are target-specific.
+ */
+const getSmokeTargets = (
+  files: string[],
+  packagesTouched: boolean,
+): { cli: boolean; docusaurus: boolean; any: boolean } => {
+  const touches = (patterns: RegExp[]): boolean => {
+    return files.some((file) => {
+      return matches(file, patterns) || matches(file, SMOKE_PATTERNS.both);
+    });
+  };
+
+  const cli = packagesTouched || touches(SMOKE_PATTERNS.cli);
+  const docusaurus = packagesTouched || touches(SMOKE_PATTERNS.docusaurus);
+
+  return { cli, docusaurus, any: cli || docusaurus };
+};
+
+/**
+ * "CI tooling", not just workflow YAML: this drives the linter job's
+ * actionlint / shellcheck / `test:scripts` steps, and the gate's own suite
+ * lives under `tests/ci`.
+ */
+const touchesCiTooling = (files: string[]): boolean => {
+  return files.some((file) => {
+    return file.startsWith(".github/") || file.startsWith("tests/ci/");
+  });
+};
+
+/**
+ * Nothing outside documentation changed: every gated job can skip.
+ */
+const isDocsOnly = (
+  packagesTouched: boolean,
+  smoke: boolean,
+  workflows: boolean,
+): boolean => {
+  return !packagesTouched && !smoke && !workflows;
 };
 
 const computeAffected = (
@@ -157,52 +247,23 @@ const computeAffected = (
       return !matches(file, DOC_PATTERNS);
     });
 
-  const isGlobal = files.some((file) => {
-    return matches(file, GLOBAL_PATTERNS);
-  });
+  const global = getGlobalScope(files);
+  const touched = getTouchedPackages(files, allPackages);
 
   // `direct` drives mutation testing: Stryker mutates `src/**/*.ts` and runs
   // that same package's tests, so a module's score is a pure function of its
   // own sources and specs. An upstream change cannot move it -- it can only
   // make the tests fail, which the closure-gated unit test job already reports.
-  const direct = new Set(
-    isGlobal
-      ? allPackages
-      : files.flatMap((file) => {
-          const name = /^packages\/([^/]+)\//u.exec(file)?.[1];
-          return name && allPackages.includes(name) ? [name] : [];
-        }),
-  );
+  // Only a runtime-tier global widens it past the packages actually touched.
+  const direct = global.runtime ? new Set(allPackages) : touched;
 
-  const affected = isGlobal
+  const affected = global.any
     ? new Set(allPackages)
-    : expandDependents(direct, getDependentsMap(packagesMap));
+    : expandDependents(touched, getDependentsMap(packagesMap));
 
-  // Both smoke scaffolds install every workspace package, so any package change
-  // runs every smoke job; only the e2e spec directories are target-specific.
   const packagesTouched = affected.size > 0;
-  const smokeCli =
-    packagesTouched ||
-    files.some((file) => {
-      return (
-        matches(file, SMOKE_PATTERNS.cli) || matches(file, SMOKE_PATTERNS.both)
-      );
-    });
-  const smokeDocusaurus =
-    packagesTouched ||
-    files.some((file) => {
-      return (
-        matches(file, SMOKE_PATTERNS.docusaurus) ||
-        matches(file, SMOKE_PATTERNS.both)
-      );
-    });
-
-  // "CI tooling", not just workflow YAML: this drives the linter job's
-  // actionlint / shellcheck / `test:scripts` steps, and the gate's own suite
-  // lives under `tests/ci`.
-  const workflows = files.some((file) => {
-    return file.startsWith(".github/") || file.startsWith("tests/ci/");
-  });
+  const smoke = getSmokeTargets(files, packagesTouched);
+  const workflows = touchesCiTooling(files);
 
   const sort = (names: Iterable<string>): string[] => {
     return [...names].sort();
@@ -212,11 +273,11 @@ const computeAffected = (
     code: packagesTouched,
     packages: sort(affected),
     direct_packages: sort(direct),
-    smoke: smokeCli || smokeDocusaurus,
-    smoke_cli: smokeCli,
-    smoke_docusaurus: smokeDocusaurus,
+    smoke: smoke.any,
+    smoke_cli: smoke.cli,
+    smoke_docusaurus: smoke.docusaurus,
     workflows,
-    docs_only: !packagesTouched && !smokeCli && !smokeDocusaurus && !workflows,
+    docs_only: isDocsOnly(packagesTouched, smoke.any, workflows),
   };
 };
 

--- a/.github/scripts/affected-packages.mts
+++ b/.github/scripts/affected-packages.mts
@@ -1,0 +1,250 @@
+// Maps a list of changed files to the CI work that actually needs to run, so
+// workflows can skip jobs instead of filtering triggers.
+//
+// Trigger-level `paths:` filters are NOT usable in this repo: the
+// `main-checklist` ruleset requires ~32 named checks, and a workflow that never
+// starts produces no check run at all, leaving those checks pending forever. A
+// job skipped by a job-level `if:` still reports a `skipped` check run, which
+// GitHub counts as satisfied. So every matrix stays full width and the gating
+// happens through the outputs computed here.
+//
+// Usage: .github/scripts/changed-files.sh <base> | node affected-packages.mts
+//
+// Run directly by Node (>= 22.18) through type stripping, so it must stay
+// within erasable syntax: no enums, no parameter properties, no namespaces.
+
+import { appendFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ORG_NAME = "@graphql-markdown";
+
+type PackageMeta = {
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+};
+
+type PackagesMap = Record<string, PackageMeta>;
+
+type AffectedOutputs = {
+  code: boolean;
+  packages: string[];
+  direct_packages: string[];
+  smoke: boolean;
+  smoke_cli: boolean;
+  smoke_docusaurus: boolean;
+  workflows: boolean;
+  docs_only: boolean;
+};
+
+// Anything matching these invalidates every assumption below (shared build
+// config, the toolchain, the type definitions every package compiles against,
+// or this script itself), so they fail open to the full matrix.
+const GLOBAL_PATTERNS = [
+  /^bun\.lock$/u,
+  /^package\.json$/u,
+  /^tsconfig(\..+)?\.json$/u,
+  /^turbo\.json$/u,
+  /^vitest\.config\.mjs$/u,
+  /^packages\/types\//u,
+  /^packages\/tooling-config\//u,
+  /^\.github\/actions\//u,
+  /^\.github\/scripts\//u,
+];
+
+// Scoped deliberately rather than a blanket `\.md$`: `tests/e2e/__data__` holds
+// Markdown fixtures (homepages fed to the generator) that smoke tests consume.
+const DOC_PATTERNS = [
+  /^docs\//u,
+  /^website\//u,
+  /^api\//u,
+  /^[^/]+\.md$/u,
+  /^\.github\/[^/]*\.md$/u,
+  /^packages\/[^/]+\/docs\//u,
+  /^packages\/[^/]+\/[^/]*\.md$/u,
+];
+
+const SMOKE_PATTERNS = {
+  cli: [/^tests\/e2e\/cli\//u],
+  docusaurus: [/^tests\/e2e\/docusaurus\//u],
+  both: [
+    /^tests\/e2e\/__data__\//u,
+    /^tests\/e2e\/helpers\//u,
+    /^\.github\/workflows\/smoke\.yml$/u,
+  ],
+};
+
+const matches = (file: string, patterns: RegExp[]): boolean => {
+  return patterns.some((pattern) => {
+    return pattern.test(file);
+  });
+};
+
+const shortName = (packageName: string): string => {
+  return packageName.slice(ORG_NAME.length + 1);
+};
+
+/**
+ * Reverse workspace graph: package short name -> short names that depend on it.
+ */
+const getDependentsMap = (
+  packagesMap: PackagesMap,
+): Map<string, Set<string>> => {
+  const dependents = new Map<string, Set<string>>();
+
+  for (const [name, meta] of Object.entries(packagesMap)) {
+    const workspaceDependencies = Object.keys({
+      ...meta.dependencies,
+      ...meta.peerDependencies,
+    }).filter((dependencyName) => {
+      return dependencyName.startsWith(`${ORG_NAME}/`);
+    });
+
+    for (const dependencyName of workspaceDependencies) {
+      const key = shortName(dependencyName);
+      const entry = dependents.get(key) ?? new Set<string>();
+      entry.add(shortName(name));
+      dependents.set(key, entry);
+    }
+  }
+
+  return dependents;
+};
+
+/**
+ * Expands a seed set into its transitive dependents: a change in `utils` has to
+ * retest everything that consumes `utils`.
+ */
+const expandDependents = (
+  seed: Iterable<string>,
+  dependentsMap: Map<string, Set<string>>,
+): Set<string> => {
+  const closure = new Set(seed);
+  const queue = [...closure];
+
+  while (queue.length > 0) {
+    const packageName = queue.shift()!;
+    for (const dependent of dependentsMap.get(packageName) ?? []) {
+      if (!closure.has(dependent)) {
+        closure.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+
+  return closure;
+};
+
+const computeAffected = (
+  changedFiles: string[],
+  packagesMap: PackagesMap,
+): AffectedOutputs => {
+  const allPackages = Object.keys(packagesMap).map(shortName);
+
+  const files = changedFiles
+    .map((file) => {
+      return file.trim();
+    })
+    .filter(Boolean)
+    .filter((file) => {
+      return !matches(file, DOC_PATTERNS);
+    });
+
+  const isGlobal = files.some((file) => {
+    return matches(file, GLOBAL_PATTERNS);
+  });
+
+  // `direct` drives mutation testing: Stryker mutates `src/**/*.ts` and runs
+  // that same package's tests, so a module's score is a pure function of its
+  // own sources and specs. An upstream change cannot move it -- it can only
+  // make the tests fail, which the closure-gated unit test job already reports.
+  const direct = new Set(
+    isGlobal
+      ? allPackages
+      : files.flatMap((file) => {
+          const name = /^packages\/([^/]+)\//u.exec(file)?.[1];
+          return name && allPackages.includes(name) ? [name] : [];
+        }),
+  );
+
+  const affected = isGlobal
+    ? new Set(allPackages)
+    : expandDependents(direct, getDependentsMap(packagesMap));
+
+  // Both smoke scaffolds install every workspace package, so any package change
+  // runs every smoke job; only the e2e spec directories are target-specific.
+  const packagesTouched = affected.size > 0;
+  const smokeCli =
+    packagesTouched ||
+    files.some((file) => {
+      return (
+        matches(file, SMOKE_PATTERNS.cli) || matches(file, SMOKE_PATTERNS.both)
+      );
+    });
+  const smokeDocusaurus =
+    packagesTouched ||
+    files.some((file) => {
+      return (
+        matches(file, SMOKE_PATTERNS.docusaurus) ||
+        matches(file, SMOKE_PATTERNS.both)
+      );
+    });
+
+  const workflows = files.some((file) => {
+    return file.startsWith(".github/");
+  });
+
+  const sort = (names: Iterable<string>): string[] => {
+    return [...names].sort();
+  };
+
+  return {
+    code: packagesTouched,
+    packages: sort(affected),
+    direct_packages: sort(direct),
+    smoke: smokeCli || smokeDocusaurus,
+    smoke_cli: smokeCli,
+    smoke_docusaurus: smokeDocusaurus,
+    workflows,
+    docs_only: !packagesTouched && !smokeCli && !smokeDocusaurus && !workflows,
+  };
+};
+
+export { computeAffected, expandDependents, getDependentsMap };
+export type { AffectedOutputs, PackageMeta, PackagesMap };
+
+// When run directly, read the changed files from stdin and write the outputs to
+// $GITHUB_OUTPUT (falling back to stdout only, for local runs).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  // dependencies-utils chdir()s the process on import, so resolve $GITHUB_OUTPUT
+  // against the current working directory before importing it.
+  const outputFile = process.env.GITHUB_OUTPUT
+    ? resolve(process.cwd(), process.env.GITHUB_OUTPUT)
+    : undefined;
+
+  const { getWorkspacePackagesMap } =
+    (await import("../../packages/tooling-config/scripts/shared/dependencies-utils.mjs")) as {
+      getWorkspacePackagesMap: () => PackagesMap;
+    };
+
+  // Read stdin as a stream rather than readFileSync(0): a pipe can be opened
+  // non-blocking, and the synchronous read then fails with EAGAIN.
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  const changedFiles = Buffer.concat(chunks).toString("utf-8").split("\n");
+
+  const outputs = computeAffected(changedFiles, getWorkspacePackagesMap());
+
+  const report = Object.entries(outputs)
+    .map(([key, value]) => {
+      return `${key}=${typeof value === "boolean" ? value : JSON.stringify(value)}`;
+    })
+    .join("\n");
+
+  console.log(report);
+  if (outputFile) {
+    appendFileSync(outputFile, `${report}\n`);
+  }
+}

--- a/.github/scripts/affected-packages.mts
+++ b/.github/scripts/affected-packages.mts
@@ -8,6 +8,12 @@
 // GitHub counts as satisfied. So every matrix stays full width and the gating
 // happens through the outputs computed here.
 //
+// That same "skipped counts as satisfied" rule is why every caller guards its
+// jobs with `!cancelled()` and treats `needs.changes.result != 'success'` as
+// "run everything": a gate that errors must not skip the matrix into a green
+// PR. This script's fail-open branches cover git-level failures; the workflow
+// conditions cover the job failing around it.
+//
 // Usage: .github/scripts/changed-files.sh <base> | node affected-packages.mts
 //
 // Run directly by Node (>= 22.18) through type stripping, so it must stay

--- a/.github/scripts/affected-packages.mts
+++ b/.github/scripts/affected-packages.mts
@@ -50,6 +50,7 @@ const GLOBAL_PATTERNS = [
   /^packages\/tooling-config\//u,
   /^\.github\/actions\//u,
   /^\.github\/scripts\//u,
+  /^tests\/ci\//u,
 ];
 
 // Scoped deliberately rather than a blanket `\.md$`: `tests/e2e/__data__` holds
@@ -190,8 +191,11 @@ const computeAffected = (
       );
     });
 
+  // "CI tooling", not just workflow YAML: this drives the linter job's
+  // actionlint / shellcheck / `test:scripts` steps, and the gate's own suite
+  // lives under `tests/ci`.
   const workflows = files.some((file) => {
-    return file.startsWith(".github/");
+    return file.startsWith(".github/") || file.startsWith("tests/ci/");
   });
 
   const sort = (names: Iterable<string>): string[] => {

--- a/.github/scripts/changed-files.sh
+++ b/.github/scripts/changed-files.sh
@@ -9,8 +9,14 @@ set -euo pipefail
 
 BASE_REF="${1:?usage: changed-files.sh <base-ref>}"
 
+# Deliberately NOT `--depth=1`: the caller checks out with `fetch-depth: 0`, and
+# a shallow fetch into a complete repository writes a `.git/shallow` graft that
+# can hide the real merge base -- which would silently fail open to the full
+# matrix on every run.
 if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
-  git fetch --no-tags --depth=1 origin "${BASE_REF#origin/}" >/dev/null 2>&1 || true
+  BRANCH="${BASE_REF#origin/}"
+  git fetch --no-tags origin \
+    "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" >/dev/null 2>&1 || true
 fi
 
 if MERGE_BASE="$(git merge-base "$BASE_REF" HEAD 2>/dev/null)"; then

--- a/.github/scripts/changed-files.sh
+++ b/.github/scripts/changed-files.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Prints the files changed against a base ref, one per line.
+#
+# Fails open: if the base commit is unreachable (a shallow clone, a force-pushed
+# base, the very first commit on a branch), print a sentinel that
+# affected-packages.mjs treats as a global change, so CI runs everything rather
+# than silently skipping required jobs.
+set -euo pipefail
+
+BASE_REF="${1:?usage: changed-files.sh <base-ref>}"
+
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+  git fetch --no-tags --depth=1 origin "${BASE_REF#origin/}" >/dev/null 2>&1 || true
+fi
+
+if MERGE_BASE="$(git merge-base "$BASE_REF" HEAD 2>/dev/null)"; then
+  git diff --name-only "$MERGE_BASE" HEAD
+else
+  echo "Could not resolve base ref '$BASE_REF', assuming everything changed." >&2
+  echo "bun.lock"
+fi

--- a/.github/workflows/bot-approve-merge.yml
+++ b/.github/workflows/bot-approve-merge.yml
@@ -1,20 +1,30 @@
 name: Auto approve & merge PR
 
-on: pull_request_target
+# Without `types` this also fired on `labeled` (including the label it adds
+# itself), `edited`, `assigned` and friends, re-approving and re-merging each
+# time.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 env:
   PR_URL: ${{ github.event.pull_request.html_url }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: |
-      github.actor == 'dependabot[bot]' || 
-      github.actor == 'dependabot-preview[bot]' || 
-      github.actor == 'renovate[bot]' || 
-      github.actor == 'graphql-markdown-bot'
+    if: >-
+      github.repository == 'graphql-markdown/graphql-markdown'
+      && (github.actor == 'dependabot[bot]'
+        || github.actor == 'dependabot-preview[bot]'
+        || github.actor == 'renovate[bot]'
+        || github.actor == 'graphql-markdown-bot')
     env:
       GH_REPO: ${{ github.repository }}
       GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
@@ -23,14 +33,14 @@ jobs:
         run: gh pr review --approve "$PR_URL"
       - name: Add label "automerge"
         run: gh pr edit --add-label "automerge" "$PR_URL"
-        
+
   auto-merge:
     needs: auto-approve
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-    if: | 
+    if: |
       github.repository == 'graphql-markdown/graphql-markdown'
     env:
       GH_REPO: ${{ github.repository }}

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -1,0 +1,85 @@
+name: Changes
+
+# Shared gate: maps the files a PR (or a push to main) touches onto the CI work
+# that actually needs to run. Callers use the outputs in job-level `if:`
+# conditions rather than trigger-level `paths:` filters, because the
+# `main-checklist` ruleset requires ~32 named checks: a job skipped by an `if:`
+# still reports a `skipped` check run (which GitHub counts as satisfied), while
+# a workflow never started by a `paths:` filter reports nothing at all and
+# leaves the required check pending forever.
+
+on:
+  workflow_call:
+    outputs:
+      code:
+        description: At least one workspace package is affected
+        value: ${{ jobs.changes.outputs.code }}
+      packages:
+        description: JSON array of affected packages, including their dependents
+        value: ${{ jobs.changes.outputs.packages }}
+      direct_packages:
+        description: JSON array of packages changed directly, without dependents
+        value: ${{ jobs.changes.outputs.direct_packages }}
+      smoke:
+        description: At least one smoke target is affected
+        value: ${{ jobs.changes.outputs.smoke }}
+      smoke_cli:
+        description: The CLI smoke target is affected
+        value: ${{ jobs.changes.outputs.smoke_cli }}
+      smoke_docusaurus:
+        description: The Docusaurus smoke targets are affected
+        value: ${{ jobs.changes.outputs.smoke_docusaurus }}
+      workflows:
+        description: Something under .github/ changed
+        value: ${{ jobs.changes.outputs.workflows }}
+      docs_only:
+        description: Nothing outside documentation changed
+        value: ${{ jobs.changes.outputs.docs_only }}
+
+jobs:
+  changes:
+    name: Detect affected
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.affected.outputs.code }}
+      packages: ${{ steps.affected.outputs.packages }}
+      direct_packages: ${{ steps.affected.outputs.direct_packages }}
+      smoke: ${{ steps.affected.outputs.smoke }}
+      smoke_cli: ${{ steps.affected.outputs.smoke_cli }}
+      smoke_docusaurus: ${{ steps.affected.outputs.smoke_docusaurus }}
+      workflows: ${{ steps.affected.outputs.workflows }}
+      docs_only: ${{ steps.affected.outputs.docs_only }}
+    steps:
+      - name: Checkout Code Base
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Deep enough for the merge base of a normal PR; the diff step falls
+          # back to the full matrix if the base commit is still unreachable.
+          fetch-depth: 0
+          persist-credentials: false
+
+      # No `bun ci` here on purpose: the script only reads package.json files,
+      # so the gate stays a few seconds rather than a full toolchain install.
+      - name: Setup NodeJS LTS
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: "lts/*"
+
+      - name: Compute affected packages
+        id: affected
+        env:
+          BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || format('{0}^', github.sha) }}
+        run: .github/scripts/changed-files.sh "$BASE_REF" | node .github/scripts/affected-packages.mts
+
+      - name: Summary
+        run: |
+          {
+            echo "| Output | Value |"
+            echo "| --- | --- |"
+            echo "| packages | \`${{ steps.affected.outputs.packages }}\` |"
+            echo "| direct_packages | \`${{ steps.affected.outputs.direct_packages }}\` |"
+            echo "| smoke_cli | ${{ steps.affected.outputs.smoke_cli }} |"
+            echo "| smoke_docusaurus | ${{ steps.affected.outputs.smoke_docusaurus }} |"
+            echo "| workflows | ${{ steps.affected.outputs.workflows }} |"
+            echo "| docs_only | ${{ steps.affected.outputs.docs_only }} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,7 @@ on:
       - "*.mjs"
       - "*.mts"
       - "bun.lock"
+      - ".github/scripts/**"
       - ".github/workflows/codeql-analysis.yml"
   pull_request:
     # The branches below must be a subset of the branches above
@@ -34,6 +35,7 @@ on:
       - "*.mjs"
       - "*.mts"
       - "bun.lock"
+      - ".github/scripts/**"
       - ".github/workflows/codeql-analysis.yml"
   schedule:
     - cron: "19 6 * * 5"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,12 +11,30 @@
 #
 name: "CodeQL"
 
+# `Analyze` is not one of the ruleset's required checks, so a trigger-level
+# `paths:` filter is safe here (unlike test/mutation/smoke, where a workflow
+# that never starts would leave a required check pending forever). The weekly
+# cron keeps the code-scanning results fresh through a run of docs-only PRs.
 on:
   push:
     branches: [main]
+    paths:
+      - "packages/**"
+      - "tests/**"
+      - "*.mjs"
+      - "*.mts"
+      - "bun.lock"
+      - ".github/workflows/codeql-analysis.yml"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [main]
+    paths:
+      - "packages/**"
+      - "tests/**"
+      - "*.mjs"
+      - "*.mts"
+      - "bun.lock"
+      - ".github/workflows/codeql-analysis.yml"
   schedule:
     - cron: "19 6 * * 5"
 

--- a/.github/workflows/danger-js.yml
+++ b/.github/workflows/danger-js.yml
@@ -1,5 +1,11 @@
 name: "Danger JS"
-on: pull_request
+# Danger reviews PR hygiene (title, description, changed files), which applies
+# to docs PRs too, so this one stays unfiltered by path. It is restricted to the
+# events that actually change the diff: without `types` it also fired on
+# `labeled`, `edited`, `assigned` and friends.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 env:
   HUSKY: 0

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,6 +22,19 @@ jobs:
     needs: changes
     # The job itself always runs -- it is a required check -- but each step is
     # gated on the kind of change, so a docs-only PR reports green in seconds.
+    #
+    # `!cancelled()` drops the implicit "all needs succeeded" requirement, and
+    # both flags below fall open when the gate did not succeed: a skipped job
+    # reports a `skipped` check run, which the ruleset counts as satisfied, so
+    # a broken gate must run every check rather than silently pass the PR.
+    if: ${{ !cancelled() }}
+    env:
+      RUN_WORKFLOW_CHECKS: >-
+        ${{ needs.changes.result != 'success'
+          || needs.changes.outputs.workflows == 'true' }}
+      RUN_CODE_CHECKS: >-
+        ${{ needs.changes.result != 'success'
+          || needs.changes.outputs.code == 'true' }}
 
     steps:
       - name: Checkout Code Base
@@ -31,7 +44,7 @@ jobs:
           persist-credentials: false
 
       - name: Install actionlint
-        if: needs.changes.outputs.workflows == 'true'
+        if: env.RUN_WORKFLOW_CHECKS == 'true'
         run: |
           curl -fsSL -o actionlint.tar.gz "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
           tar xzf actionlint.tar.gz actionlint
@@ -39,43 +52,43 @@ jobs:
           rm actionlint.tar.gz
 
       - name: Run actionlint
-        if: needs.changes.outputs.workflows == 'true'
+        if: env.RUN_WORKFLOW_CHECKS == 'true'
         run: actionlint -color
 
       - name: Run shellcheck
-        if: needs.changes.outputs.workflows == 'true'
+        if: env.RUN_WORKFLOW_CHECKS == 'true'
         run: find .github/scripts website/scripts packages/tooling-config/scripts -name '*.sh' -exec shellcheck {} +
 
       - name: Setup environment
-        if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflows == 'true'
+        if: env.RUN_CODE_CHECKS == 'true' || env.RUN_WORKFLOW_CHECKS == 'true'
         uses: ./.github/actions/setup
 
       # The CI gate script decides which jobs the rest of the matrix skips, so
       # it is tested here, where the toolchain is already installed.
       - name: Test CI scripts
-        if: needs.changes.outputs.workflows == 'true'
+        if: env.RUN_WORKFLOW_CHECKS == 'true'
         run: bun run test:scripts
 
       - name: Run TS Check
-        if: needs.changes.outputs.code == 'true'
+        if: env.RUN_CODE_CHECKS == 'true'
         run: bun run ts:check
 
       - name: Run Prettier
-        if: needs.changes.outputs.code == 'true'
+        if: env.RUN_CODE_CHECKS == 'true'
         run: bun run prettier
 
       - name: Run ESLint
-        if: needs.changes.outputs.code == 'true'
+        if: env.RUN_CODE_CHECKS == 'true'
         run: bun run lint
 
       - name: Run knip
-        if: needs.changes.outputs.code == 'true'
+        if: env.RUN_CODE_CHECKS == 'true'
         run: bun run knip --no-config-hints --reporter github-actions
 
       - name: Fetch base branch for fallow
-        if: needs.changes.outputs.code == 'true'
+        if: env.RUN_CODE_CHECKS == 'true'
         run: git fetch --no-tags origin "${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
 
       - name: Run fallow
-        if: needs.changes.outputs.code == 'true'
+        if: env.RUN_CODE_CHECKS == 'true'
         run: bun run fallow -- audit --base "origin/${GITHUB_BASE_REF}"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,9 +12,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Changes
+    uses: ./.github/workflows/changes.yml
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: changes
+    # The job itself always runs -- it is a required check -- but each step is
+    # gated on the kind of change, so a docs-only PR reports green in seconds.
 
     steps:
       - name: Checkout Code Base
@@ -24,6 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Install actionlint
+        if: needs.changes.outputs.workflows == 'true'
         run: |
           curl -fsSL -o actionlint.tar.gz "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz"
           tar xzf actionlint.tar.gz actionlint
@@ -31,28 +39,43 @@ jobs:
           rm actionlint.tar.gz
 
       - name: Run actionlint
+        if: needs.changes.outputs.workflows == 'true'
         run: actionlint -color
 
       - name: Run shellcheck
+        if: needs.changes.outputs.workflows == 'true'
         run: find .github/scripts website/scripts packages/tooling-config/scripts -name '*.sh' -exec shellcheck {} +
 
       - name: Setup environment
+        if: needs.changes.outputs.code == 'true' || needs.changes.outputs.workflows == 'true'
         uses: ./.github/actions/setup
 
+      # The CI gate script decides which jobs the rest of the matrix skips, so
+      # it is tested here, where the toolchain is already installed.
+      - name: Test CI scripts
+        if: needs.changes.outputs.workflows == 'true'
+        run: bun run test:scripts
+
       - name: Run TS Check
+        if: needs.changes.outputs.code == 'true'
         run: bun run ts:check
 
       - name: Run Prettier
+        if: needs.changes.outputs.code == 'true'
         run: bun run prettier
 
       - name: Run ESLint
+        if: needs.changes.outputs.code == 'true'
         run: bun run lint
 
       - name: Run knip
+        if: needs.changes.outputs.code == 'true'
         run: bun run knip --no-config-hints --reporter github-actions
 
       - name: Fetch base branch for fallow
+        if: needs.changes.outputs.code == 'true'
         run: git fetch --no-tags origin "${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"
 
       - name: Run fallow
+        if: needs.changes.outputs.code == 'true'
         run: bun run fallow -- audit --base "origin/${GITHUB_BASE_REF}"

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -7,16 +7,41 @@ env:
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  # PRs only run the packages they change (see the `if` below), so the full
+  # matrix runs on a schedule to keep every Stryker dashboard module's score
+  # fresh. Weekly rather than per-merge: a quality dashboard does not need
+  # per-commit granularity, and per-merge would undo most of the PR savings.
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Changes
+    uses: ./.github/workflows/changes.yml
+
   mutation:
     name: Mutation tests package ${{matrix.package}}
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    needs: changes
+    # Stryker mutates a package's own `src/**/*.ts` and runs that same package's
+    # tests, so its score is a pure function of the two. An upstream change can
+    # only make the tests fail, which the Test job already reports -- hence
+    # `direct_packages` here rather than the dependency closure `test.yml` uses.
+    #
+    # Gated per step rather than per job: `matrix` is not available in a
+    # job-level `if:` (it is evaluated before the matrix expands). An unaffected
+    # package still starts a runner, but skips every step, so it finishes in
+    # seconds and still reports the check name the ruleset requires.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    env:
+      RUN_MUTATION: >-
+        ${{ github.event_name != 'pull_request'
+          || contains(fromJSON(needs.changes.outputs.direct_packages), matrix.package) }}
     strategy:
       fail-fast: false
       matrix:
@@ -36,27 +61,32 @@ jobs:
 
     steps:
       - name: Checkout Code Base
+        if: env.RUN_MUTATION == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Setup environment
+        if: env.RUN_MUTATION == 'true'
         uses: ./.github/actions/setup
 
       - name: Cache turbo build setup
+        if: env.RUN_MUTATION == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ hashFiles('bun.lock', 'packages/*/src/**', 'packages/*/tsconfig*.json', 'tsconfig.base.json') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
 
       - name: Build packages
+        if: env.RUN_MUTATION == 'true'
         run: bun run build
 
       - name: Run Mutations Tests
+        if: env.RUN_MUTATION == 'true'
         run: bun run --filter '@graphql-markdown/${{ matrix.package }}' stryker --allowEmpty --reporters dashboard,json --dashboard.module ${{matrix.package}}
 
       - name: Mutation summary
-        if: always()
+        if: always() && env.RUN_MUTATION == 'true'
         run: bun .github/scripts/mutation-summary.mjs ${{ matrix.package }} packages/${{ matrix.package }}/reports/mutation/mutation.json

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -37,11 +37,17 @@ jobs:
     # job-level `if:` (it is evaluated before the matrix expands). An unaffected
     # package still starts a runner, but skips every step, so it finishes in
     # seconds and still reports the check name the ruleset requires.
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # `!cancelled()` drops the implicit "all needs succeeded" requirement, so a
+    # broken gate runs the full matrix instead of skipping to green: a skipped
+    # job reports a `skipped` check run, which the ruleset counts as satisfied.
+    if: >-
+      !cancelled()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     env:
       RUN_MUTATION: >-
-        ${{ github.event_name != 'pull_request'
-          || contains(fromJSON(needs.changes.outputs.direct_packages), matrix.package) }}
+        ${{ needs.changes.result != 'success'
+          || github.event_name != 'pull_request'
+          || contains(fromJSON(needs.changes.outputs.direct_packages || '[]'), matrix.package) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -24,9 +24,13 @@ jobs:
     name: Build and pack workspace packages
     runs-on: ubuntu-latest
     needs: changes
+    # `!cancelled()` drops the implicit "all needs succeeded" requirement, so a
+    # broken gate runs the full matrix instead of skipping to green: a skipped
+    # job reports a `skipped` check run, which the ruleset counts as satisfied.
     if: >-
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
-      && needs.changes.outputs.smoke == 'true'
+      !cancelled()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (needs.changes.result != 'success' || needs.changes.outputs.smoke == 'true')
     steps:
       - name: Checkout Code Base
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -62,7 +66,13 @@ jobs:
     name: Smoke Tests on Docusaurus ${{ matrix.docusaurus }} with GraphQL ${{ matrix.graphql }}
     runs-on: ubuntu-latest
     needs: [changes, build-packages]
-    if: needs.changes.outputs.smoke_docusaurus == 'true'
+    # `build-packages` success is asserted explicitly: `!cancelled()` in this
+    # expression would otherwise let the smoke tests run without the packed
+    # tarballs they install.
+    if: >-
+      !cancelled() && needs.build-packages.result == 'success'
+      && (needs.changes.result != 'success'
+        || needs.changes.outputs.smoke_docusaurus == 'true')
     strategy:
       fail-fast: false
       matrix:
@@ -92,7 +102,13 @@ jobs:
     name: Smoke Tests on Docusaurus ${{ matrix.docusaurus }} build (${{ matrix.case.name }}) with GraphQL ${{ matrix.graphql }}
     runs-on: ubuntu-latest
     needs: [changes, build-packages]
-    if: needs.changes.outputs.smoke_docusaurus == 'true'
+    # `build-packages` success is asserted explicitly: `!cancelled()` in this
+    # expression would otherwise let the smoke tests run without the packed
+    # tarballs they install.
+    if: >-
+      !cancelled() && needs.build-packages.result == 'success'
+      && (needs.changes.result != 'success'
+        || needs.changes.outputs.smoke_docusaurus == 'true')
     strategy:
       fail-fast: false
       matrix:
@@ -126,7 +142,13 @@ jobs:
     name: Smoke Tests on CLI with GraphQL ${{ matrix.graphql }}
     runs-on: ubuntu-latest
     needs: [changes, build-packages]
-    if: needs.changes.outputs.smoke_cli == 'true'
+    # `build-packages` success is asserted explicitly: `!cancelled()` in this
+    # expression would otherwise let the smoke tests run without the packed
+    # tarballs they install.
+    if: >-
+      !cancelled() && needs.build-packages.result == 'success'
+      && (needs.changes.result != 'success'
+        || needs.changes.outputs.smoke_cli == 'true')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -10,29 +10,28 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "tests/**/*"
-      - "packages/**/*"
-      - "packages/tooling-config/**/*"
-      - "config/**/*"
-      - "*.json"
-      - "*.mjs"
-      - ".github/actions/**/*"
-      - ".github/scripts/**/*"
-      - ".github/workflows/smoke.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Changes
+    uses: ./.github/workflows/changes.yml
+
   build-packages:
     name: Build and pack workspace packages
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: changes
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && needs.changes.outputs.smoke == 'true'
     steps:
       - name: Checkout Code Base
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup environment
         uses: ./.github/actions/setup
@@ -41,7 +40,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ hashFiles('bun.lock', 'packages/*/src/**', 'packages/*/tsconfig*.json', 'tsconfig.base.json') }}
           restore-keys: |
             ${{ runner.os }}-turbo-
 
@@ -62,8 +61,8 @@ jobs:
   smoke-docusaurus-test:
     name: Smoke Tests on Docusaurus ${{ matrix.docusaurus }} with GraphQL ${{ matrix.graphql }}
     runs-on: ubuntu-latest
-    needs: build-packages
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: [changes, build-packages]
+    if: needs.changes.outputs.smoke_docusaurus == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -72,6 +71,8 @@ jobs:
     steps:
       - name: Checkout Code Base
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Scaffold Docusaurus project
         uses: ./.github/actions/scaffold-docusaurus
@@ -90,8 +91,8 @@ jobs:
   smoke-docusaurus-build:
     name: Smoke Tests on Docusaurus ${{ matrix.docusaurus }} build (${{ matrix.case.name }}) with GraphQL ${{ matrix.graphql }}
     runs-on: ubuntu-latest
-    needs: build-packages
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: [changes, build-packages]
+    if: needs.changes.outputs.smoke_docusaurus == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -107,6 +108,8 @@ jobs:
     steps:
       - name: Checkout Code Base
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Scaffold Docusaurus project
         uses: ./.github/actions/scaffold-docusaurus
@@ -122,8 +125,8 @@ jobs:
   smoke-cli:
     name: Smoke Tests on CLI with GraphQL ${{ matrix.graphql }}
     runs-on: ubuntu-latest
-    needs: build-packages
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    needs: [changes, build-packages]
+    if: needs.changes.outputs.smoke_cli == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -131,6 +134,8 @@ jobs:
     steps:
       - name: Checkout Code Base
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Scaffold CLI project
         uses: ./.github/actions/scaffold-cli

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,22 +9,26 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "packages/**/*"
-      - "packages/tooling-config/**/*"
-      - "config/**/*"
-      - "*.json"
-      - "*.mjs"
-      - ".github/workflows/test.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Changes
+    uses: ./.github/workflows/changes.yml
+
   test:
     name: Test ${{ matrix.package }}
     runs-on: ubuntu-latest
+    needs: changes
+    # Gated per step rather than per job: `matrix` is not available in a
+    # job-level `if:` (it is evaluated before the matrix expands). An unaffected
+    # package therefore still starts a runner, but every step is skipped, so it
+    # finishes in seconds and still reports the check name the ruleset requires.
+    env:
+      RUN_TESTS: ${{ contains(fromJSON(needs.changes.outputs.packages), matrix.package) }}
     strategy:
       fail-fast: false
       matrix:
@@ -44,15 +48,18 @@ jobs:
 
     steps:
       - name: Checkout Code Base
+        if: env.RUN_TESTS == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Setup environment
+        if: env.RUN_TESTS == 'true'
         uses: ./.github/actions/setup
 
       - name: Cache turbo build setup
+        if: env.RUN_TESTS == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .turbo
@@ -61,16 +68,21 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - name: Build packages
+        if: env.RUN_TESTS == 'true'
         run: bun run build -- --filter=@graphql-markdown/${{ matrix.package }}...
 
       - name: Run Tests
+        if: env.RUN_TESTS == 'true'
         run: |
           cd packages/${{ matrix.package }}
           bun test:ci -- --coverage --reporter=github-actions --reporter=default
 
       - name: SonarCloud Scan
         id: sonarcloud
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        if: >-
+          env.RUN_TESTS == 'true'
+          && (github.event_name != 'pull_request'
+            || github.event.pull_request.head.repo.full_name == github.repository)
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2
         with:
           projectBaseDir: ${{ github.workspace }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,18 @@ jobs:
     name: Test ${{ matrix.package }}
     runs-on: ubuntu-latest
     needs: changes
+    # `!cancelled()` drops the implicit "all needs succeeded" requirement, so a
+    # broken gate runs the full matrix instead of skipping to green: a skipped
+    # job reports a `skipped` check run, which the ruleset counts as satisfied.
+    if: ${{ !cancelled() }}
     # Gated per step rather than per job: `matrix` is not available in a
     # job-level `if:` (it is evaluated before the matrix expands). An unaffected
     # package therefore still starts a runner, but every step is skipped, so it
     # finishes in seconds and still reports the check name the ruleset requires.
     env:
-      RUN_TESTS: ${{ contains(fromJSON(needs.changes.outputs.packages), matrix.package) }}
+      RUN_TESTS: >-
+        ${{ needs.changes.result != 'success'
+          || contains(fromJSON(needs.changes.outputs.packages || '[]'), matrix.package) }}
     strategy:
       fail-fast: false
       matrix:

--- a/docs/advanced/custom-sections.md
+++ b/docs/advanced/custom-sections.md
@@ -14,7 +14,7 @@ keywords:
 
 Schemas often carry documentation-only metadata that has no natural home on a type page: the HTTP status codes an operation can return, the headers it expects, or a description of a `meta` object returned alongside the data.
 
-The option [`printTypeOptions.customSections`](/docs/settings#printtypeoptions) turns such a directive into its own top-level section of the type page, rendered by a callback you provide.
+The option [`printTypeOptions.customSections`](/docs/settings#printtypeoptions) turns such a directive into its own top-level section of the type page, rendered by a callback you provide. It is a map of directive names, in the same shape as [`customDirective`](/docs/advanced/custom-directive).
 
 :::info
 
@@ -45,11 +45,9 @@ type Query {
 
 ```js title="docusaurus.config.js"
 printTypeOptions: {
-  customSections: [
-    {
-      name: "httpResponses",
+  customSections: {
+    httpResponse: {
       title: "Responses",
-      directive: "httpResponse",
       position: { after: "metadata" },
       appliesTo: ["queries", "mutations"],
       render: (values) => {
@@ -60,7 +58,7 @@ printTypeOptions: {
         ].join("\n");
       },
     },
-  ],
+  },
 }
 ```
 
@@ -77,15 +75,15 @@ printTypeOptions: {
 
 ## Options
 
+Each key is the name of the schema directive carrying the section data, and is also the section key on the page. It must not be one of the built-in keys (see [Position](#position)).
+
 | Option      | Required | Description                                                                                   |
 | ----------- | -------- | --------------------------------------------------------------------------------------------- |
-| `name`      | yes      | Section key. Must be unique, and must not be one of the built-in keys (see [Position](#position)). |
-| `directive` | yes      | Name of the schema directive carrying the section data.                                         |
-| `render`    | yes      | Callback returning the section content as Markdown (see [Render](#render)).                     |
-| `title`     | no       | Section heading. Omit for an untitled section.                                                  |
-| `level`     | no       | Heading level, defaults to `3`.                                                                 |
-| `position`  | no       | Placement relative to another section (see [Position](#position)). Defaults to last.            |
-| `appliesTo` | no       | Restricts the section to some schema entities (see [appliesTo](#appliesto)). Defaults to all.   |
+| `render`    | yes      | Callback returning the section content as Markdown (see [Render](#render)).                   |
+| `title`     | no       | Section heading. Omit for an untitled section.                                                |
+| `level`     | no       | Heading level, defaults to `3`.                                                               |
+| `position`  | no       | Placement relative to another section (see [Position](#position)). Defaults to last.          |
+| `appliesTo` | no       | Restricts the section to some schema entities (see [appliesTo](#appliesto)). Defaults to all. |
 
 A section is skipped, and no heading is printed, when the directive is absent from the schema or from the type, or when `render` returns nothing.
 
@@ -108,7 +106,7 @@ Optional directive arguments that were omitted are absent from the record rather
 
 `tags`, `description`, `code`, `customDirectives`, `metadata`, `example`, `relations`
 
-Another custom section can also be named, as long as it is declared earlier. A section whose `position` names an unknown section is appended last.
+Another custom section can also be named, by its directive name, as long as it is declared earlier. A section whose `position` names an unknown section is appended last.
 
 :::note
 
@@ -143,14 +141,14 @@ directive @httpHeader(
 
 ```js
 {
-  name: "httpHeaders",
-  title: "Headers",
-  directive: "httpHeader",
-  position: { after: "metadata" },
-  render: (values) => {
-    return values
-      .map((value) => `- \`${value.name}\`${value.required ? " *(required)*" : ""}`)
-      .join("\n");
+  httpHeader: {
+    title: "Headers",
+    position: { after: "metadata" },
+    render: (values) => {
+      return values
+        .map((value) => `- \`${value.name}\`${value.required ? " *(required)*" : ""}`)
+        .join("\n");
+    },
   },
 }
 ```
@@ -165,13 +163,13 @@ directive @meta(type: String!) on FIELD_DEFINITION
 
 ```js
 {
-  name: "meta",
-  title: "Meta",
-  directive: "meta",
-  position: { after: "code" },
-  render: ([value], options) => {
-    const slug = String(value.type).toLowerCase();
-    return `Returned alongside the data: [\`${value.type}\`](${options.basePath}/objects/${slug}).`;
+  meta: {
+    title: "Meta",
+    position: { after: "code" },
+    render: ([value], options) => {
+      const slug = String(value.type).toLowerCase();
+      return `Returned alongside the data: [\`${value.type}\`](${options.basePath}/objects/${slug}).`;
+    },
   },
 }
 ```

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "smoke": ".github/scripts/e2e/run-smoke.sh",
     "test": "turbo run test",
     "test:all": "vitest run --passWithNoTests",
+    "test:scripts": "vitest run --config tests/ci/vitest.config.mjs",
     "test:unit": "turbo run test:unit",
     "test:integration": "turbo run test:integration",
     "test:ci": "turbo run test:ci",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -27,6 +27,7 @@ import type {
   ConfigOptions,
   ConfigPrintTypeOptions,
   CustomDirective,
+  CustomSections,
   DirectiveName,
   GroupByDirectiveOptions,
   Maybe,
@@ -678,78 +679,68 @@ const RESERVED_SECTION_NAMES: readonly string[] = [
 /**
  * Validates the custom sections option.
  *
- * Each entry must declare a unique `name` that is neither a built-in section key
- * nor `__proto__`, a `directive` name, and a `render` callback. An invalid entry is a configuration
- * error rather than something to silently drop, as it would otherwise produce a
- * page missing a section without any indication why.
+ * The option is keyed by directive name, which is also the section key: it must
+ * be neither a built-in section key nor `__proto__`, and each entry must declare
+ * a `render` callback. An invalid entry is a configuration error rather than
+ * something to silently drop, as it would otherwise produce a page missing a
+ * section without any indication why.
  *
  * @param customSections - the custom sections declared in the config file.
  *
  * @returns the validated custom sections, or `undefined` when none is declared.
  *
- * @throws Error if an entry is malformed, duplicated, or claims a built-in section name.
+ * @throws Error if an entry is malformed or claims a built-in section name.
  *
  * @example
  * ```js
- * getCustomSectionsOption([
- *   {
- *     name: "httpResponses",
+ * getCustomSectionsOption({
+ *   httpResponse: {
  *     title: "Responses",
- *     directive: "httpResponse",
  *     position: { after: "metadata" },
  *     render: (values) => values.map((v) => `- \`${v.code}\` ${v.description}`).join("\n"),
  *   },
- * ]);
+ * });
  * ```
  */
 export const getCustomSectionsOption = (
-  customSections: Maybe<TypeCustomSectionOption[]>,
-): Maybe<TypeCustomSectionOption[]> => {
+  customSections: Maybe<CustomSections>,
+): Maybe<CustomSections> => {
   // Only an absent option selects the default: a configuration file is runtime
-  // JavaScript, so a falsy non-list such as `false` or `""` is a mistake worth
+  // JavaScript, so a falsy non-object such as `false` or `""` is a mistake worth
   // reporting rather than a silent way to disable the sections.
   if (customSections === null || customSections === undefined) {
     return DEFAULT_OPTIONS.printTypeOptions.customSections;
   }
 
-  if (!Array.isArray(customSections)) {
+  if (typeof customSections !== "object" || Array.isArray(customSections)) {
     throw new TypeError(
-      "Option 'printTypeOptions.customSections' must be a list.",
+      "Option 'printTypeOptions.customSections' must be a map of directive names.",
     );
   }
 
-  const names = new Set<string>();
+  // `Object.entries` skips the `__proto__` key of an object literal, which never
+  // becomes an own property, so a section cannot claim it here either.
+  Object.entries(customSections).forEach(
+    ([name, section]: [string, Maybe<TypeCustomSectionOption>]): void => {
+      if (name.length === 0) {
+        throw new TypeError(
+          "Option 'printTypeOptions.customSections' requires a directive name for each section.",
+        );
+      }
 
-  customSections.forEach((section: Maybe<TypeCustomSectionOption>): void => {
-    if (typeof section?.name !== "string" || section.name.length === 0) {
-      throw new TypeError(
-        "Option 'printTypeOptions.customSections' requires a 'name' for each section.",
-      );
-    }
+      if (RESERVED_SECTION_NAMES.includes(name)) {
+        throw new Error(
+          `Custom section name '${name}' is reserved, please use another name.`,
+        );
+      }
 
-    if (RESERVED_SECTION_NAMES.includes(section.name)) {
-      throw new Error(
-        `Custom section name '${section.name}' is reserved, please use another name.`,
-      );
-    }
-
-    if (names.has(section.name)) {
-      throw new Error(`Custom section name '${section.name}' is duplicated.`);
-    }
-    names.add(section.name);
-
-    if (typeof section.directive !== "string" || !section.directive) {
-      throw new TypeError(
-        `Custom section '${section.name}' requires a 'directive' name.`,
-      );
-    }
-
-    if (typeof section.render !== "function") {
-      throw new TypeError(
-        `Custom section '${section.name}' requires a 'render' function.`,
-      );
-    }
-  });
+      if (typeof section?.render !== "function") {
+        throw new TypeError(
+          `Custom section '${name}' requires a 'render' function.`,
+        );
+      }
+    },
+  );
 
   return customSections;
 };

--- a/packages/core/tests/unit/config.test.ts
+++ b/packages/core/tests/unit/config.test.ts
@@ -3,12 +3,12 @@ import type {
   CliOptions,
   ConfigOptions,
   CustomDirective,
+  CustomSections,
   DirectiveName,
   ExtensionProjectConfig,
   GraphQLDirective,
   Maybe,
   PackageName,
-  TypeCustomSectionOption,
   TypeDeprecatedOption,
   TypeDiffMethod,
   TypeHierarchyType,
@@ -817,8 +817,6 @@ describe("config", () => {
 
   describe("getCustomSectionsOption", () => {
     const section = {
-      name: "httpResponses",
-      directive: "httpResponse",
       render: (): string => {
         return "content";
       },
@@ -834,17 +832,15 @@ describe("config", () => {
     );
 
     test.each([false, 0, ""])(
-      "throws a type error if the option is the falsy non-list %p",
+      "throws a type error if the option is the falsy non-object %p",
       (value) => {
         expect.assertions(1);
 
         expect(() => {
-          getCustomSectionsOption(
-            value as unknown as TypeCustomSectionOption[],
-          );
+          getCustomSectionsOption(value as unknown as CustomSections);
         }).toThrow(
           new TypeError(
-            "Option 'printTypeOptions.customSections' must be a list.",
+            "Option 'printTypeOptions.customSections' must be a map of directive names.",
           ),
         );
       },
@@ -853,82 +849,63 @@ describe("config", () => {
     test("returns the sections if valid", () => {
       expect.assertions(1);
 
-      expect(getCustomSectionsOption([section])).toStrictEqual([section]);
+      expect(
+        getCustomSectionsOption({ httpResponse: section } as CustomSections),
+      ).toStrictEqual({ httpResponse: section });
     });
 
-    test("throws a type error if not a list", () => {
+    test("throws a type error if the option is a list", () => {
       expect.assertions(1);
 
       expect(() => {
-        getCustomSectionsOption(
-          section as unknown as TypeCustomSectionOption[],
-        );
+        getCustomSectionsOption([section] as unknown as CustomSections);
       }).toThrow(
         new TypeError(
-          "Option 'printTypeOptions.customSections' must be a list.",
+          "Option 'printTypeOptions.customSections' must be a map of directive names.",
         ),
       );
     });
 
-    test("throws a type error if a section has no name", () => {
+    test("throws a type error if a section has no directive name", () => {
       expect.assertions(1);
 
       expect(() => {
-        getCustomSectionsOption([
-          { ...section, name: "" },
-        ] as TypeCustomSectionOption[]);
+        getCustomSectionsOption({ "": section } as CustomSections);
       }).toThrow(
         new TypeError(
-          "Option 'printTypeOptions.customSections' requires a 'name' for each section.",
+          "Option 'printTypeOptions.customSections' requires a directive name for each section.",
         ),
       );
     });
 
-    test.each(["metadata", "__proto__"])(
-      "throws an error if a section name is reserved (%s)",
-      (name) => {
-        expect.assertions(1);
-
-        expect(() => {
-          getCustomSectionsOption([{ ...section, name }]);
-        }).toThrow(
-          `Custom section name '${name}' is reserved, please use another name.`,
-        );
-      },
-    );
-
-    test("throws an error if a section name is duplicated", () => {
+    test("throws an error if a section name is reserved", () => {
       expect.assertions(1);
 
       expect(() => {
-        getCustomSectionsOption([section, { ...section, title: "Other" }]);
-      }).toThrow("Custom section name 'httpResponses' is duplicated.");
+        getCustomSectionsOption({ metadata: section } as CustomSections);
+      }).toThrow(
+        "Custom section name 'metadata' is reserved, please use another name.",
+      );
     });
 
-    test("throws a type error if a section has no directive", () => {
+    test("ignores a section named '__proto__', which is not an own property", () => {
       expect.assertions(1);
 
-      expect(() => {
-        getCustomSectionsOption([
-          { ...section, directive: "" },
-        ] as TypeCustomSectionOption[]);
-      }).toThrow(
-        new TypeError(
-          "Custom section 'httpResponses' requires a 'directive' name.",
-        ),
-      );
+      expect(
+        getCustomSectionsOption({ __proto__: section } as CustomSections),
+      ).toStrictEqual({});
     });
 
     test("throws a type error if a section has no render function", () => {
       expect.assertions(1);
 
       expect(() => {
-        getCustomSectionsOption([
-          { ...section, render: {} },
-        ] as unknown as TypeCustomSectionOption[]);
+        getCustomSectionsOption({
+          httpResponse: { render: {} },
+        } as unknown as CustomSections);
       }).toThrow(
         new TypeError(
-          "Custom section 'httpResponses' requires a 'render' function.",
+          "Custom section 'httpResponse' requires a 'render' function.",
         ),
       );
     });

--- a/packages/printer-legacy/src/custom-section.ts
+++ b/packages/printer-legacy/src/custom-section.ts
@@ -48,14 +48,20 @@ export type SectionValuesResolver = (
 ) => Maybe<Record<string, unknown>[]>;
 
 /**
- * A custom section, optionally resolving its own values.
+ * A custom section, resolved from its declaration.
  *
- * The `resolve` callback is internal: a section declared through
- * `printTypeOptions.customSections` always reads directive occurrences.
+ * `printTypeOptions.customSections` is keyed by directive name, which is also
+ * the section key: both are carried here so the section can be printed on its
+ * own. The `resolve` callback is internal, as a declared section always reads
+ * directive occurrences.
  *
  * @internal
  */
 export type SectionDefinition = TypeCustomSectionOption & {
+  /** Section key, injected into the page sections map. */
+  name: string;
+  /** Name of the schema directive carrying the section data. */
+  directive: string;
   resolve?: SectionValuesResolver;
 };
 
@@ -287,10 +293,11 @@ export const printCustomSection = (
 /**
  * Returns the custom sections to build, in declaration order.
  *
- * Sections claiming a reserved name are dropped, and a name is kept only once:
- * the printer is reachable directly through its public API, bypassing the
- * configuration validation, and a repeated name would otherwise render the same
- * section twice on the page.
+ * The declaration is a map of directive name to section options, so the
+ * directive name is both the section key and the directive read off the type.
+ * Sections claiming a reserved name are dropped: the printer is reachable
+ * directly through its public API, bypassing the configuration validation, and
+ * such a section would otherwise overwrite a built-in one.
  *
  * @internal
  *
@@ -301,23 +308,20 @@ export const printCustomSection = (
  */
 const getDeclaredSections = (
   options: PrintTypeOptions,
-): TypeCustomSectionOption[] => {
-  if (!Array.isArray(options.customSections)) {
+): SectionDefinition[] => {
+  const customSections = options.customSections;
+
+  if (typeof customSections !== "object" || customSections === null) {
     return [];
   }
 
-  const names = new Set<string>();
-
-  return options.customSections.filter((section): boolean => {
-    if (
-      RESERVED_SECTION_NAMES.includes(section.name) ||
-      names.has(section.name)
-    ) {
-      return false;
-    }
-    names.add(section.name);
-    return true;
-  });
+  return Object.entries(customSections)
+    .filter(([name]): boolean => {
+      return !RESERVED_SECTION_NAMES.includes(name);
+    })
+    .map(([name, section]): SectionDefinition => {
+      return { ...section, name, directive: name };
+    });
 };
 
 /**
@@ -339,7 +343,8 @@ export const printCustomSections = (
 ): PageSections => {
   // Null-prototype map: a section named `__proto__` would otherwise reach the
   // prototype setter of an object literal and never become an own property.
-  // Configuration rejects that name, but the printer is also reachable directly.
+  // An object literal cannot declare that key, but the printer is also reachable
+  // directly, with a declaration built any other way.
   const sections = Object.create(null) as PageSections;
 
   getDeclaredSections(options).forEach((section): void => {
@@ -355,7 +360,6 @@ export const printCustomSections = (
  * A section is placed after or before the section named by its `position`, and
  * appended last when `position` is absent or names an unknown section. Sections
  * are placed in declaration order, so a section may target a previously placed one.
- * A repeated name is placed once, at its first declaration.
  *
  * @param sectionOrder - the built-in section order.
  * @param options - the print options in effect.
@@ -368,7 +372,7 @@ export const getCustomSectionsOrder = (
   options: PrintTypeOptions,
 ): string[] => {
   return getDeclaredSections(options).reduce(
-    (order: string[], section: TypeCustomSectionOption): string[] => {
+    (order: string[], section: SectionDefinition): string[] => {
       const position = section.position;
       const anchor =
         position && typeof position === "object"

--- a/packages/printer-legacy/tests/unit/custom-section.test.ts
+++ b/packages/printer-legacy/tests/unit/custom-section.test.ts
@@ -1,12 +1,11 @@
 import { buildSchema } from "graphql/utilities";
 
-import type {
-  PrintTypeOptions,
-  TypeCustomSectionOption,
-} from "@graphql-markdown/types";
+import type { CustomSections, PrintTypeOptions } from "@graphql-markdown/types";
 
 import { DEFAULT_OPTIONS } from "../../src/const/options";
 import { Printer } from "../../src/printer";
+
+import type { SectionDefinition } from "../../src/custom-section";
 
 import {
   getCustomSectionsOrder,
@@ -48,10 +47,10 @@ describe("custom-section", () => {
     schema,
   } as PrintTypeOptions;
 
-  const httpResponses: TypeCustomSectionOption = {
-    name: "httpResponses",
-    title: "Responses",
+  const httpResponses: SectionDefinition = {
+    name: "httpResponse",
     directive: "httpResponse",
+    title: "Responses",
     render: (values) => {
       return values
         .map((value) => {
@@ -229,44 +228,41 @@ describe("custom-section", () => {
   });
 
   describe("printCustomSections()", () => {
+    const declaration = { title: "Responses", render: httpResponses.render };
+
     test("returns an entry per declared section, including empty ones", () => {
       expect.assertions(2);
 
       const sections = printCustomSections(type, {
         ...options,
-        customSections: [
-          httpResponses,
-          { ...httpResponses, name: "absent", directive: "unknown" },
-        ],
+        customSections: {
+          httpResponse: declaration,
+          unknown: declaration,
+        } as CustomSections,
       });
 
-      expect(Object.keys(sections)).toStrictEqual(["httpResponses", "absent"]);
-      expect(sections["absent"]).toBeUndefined();
-    });
-
-    test("keeps a repeated section name only once", () => {
-      expect.assertions(1);
-
-      const sections = printCustomSections(type, {
-        ...options,
-        customSections: [httpResponses, { ...httpResponses, title: "Other" }],
-      });
-
-      expect(sections["httpResponses"]).toMatchObject({ title: "Responses" });
+      expect(Object.keys(sections)).toStrictEqual(["httpResponse", "unknown"]);
+      expect(sections["unknown"]).toBeUndefined();
     });
 
     test("keeps a section named __proto__ as an own entry", () => {
       expect.assertions(2);
 
+      // An object literal never makes `__proto__` an own property, so the name
+      // only reaches the printer when defined explicitly, bypassing the
+      // configuration validation.
+      const customSections = Object.defineProperty({}, "__proto__", {
+        value: declaration,
+        enumerable: true,
+      }) as CustomSections;
+
       const sections = printCustomSections(type, {
         ...options,
-        customSections: [{ ...httpResponses, name: "__proto__" }],
+        customSections,
       });
 
       expect(Object.hasOwn(sections, "__proto__")).toBe(true);
-      expect({ ...sections }["__proto__"]).toMatchObject({
-        title: "Responses",
-      });
+      expect({ ...sections }["__proto__"]).toBeUndefined();
     });
 
     test("drops sections claiming a reserved name", () => {
@@ -274,7 +270,7 @@ describe("custom-section", () => {
 
       const sections = printCustomSections(type, {
         ...options,
-        customSections: [{ ...httpResponses, name: "code" }],
+        customSections: { code: declaration } as CustomSections,
       });
 
       expect(Object.keys(sections)).toStrictEqual([]);
@@ -288,7 +284,7 @@ describe("custom-section", () => {
         Object.keys(
           printCustomSections(type, {
             ...options,
-            customSections: {} as unknown as TypeCustomSectionOption[],
+            customSections: {} as CustomSections,
           }),
         ),
       ).toStrictEqual([]);
@@ -381,12 +377,13 @@ describe("custom-section", () => {
 
       await Printer.init(schema, "schema", "/", {
         printTypeOptions: {
-          customSections: [
-            {
-              ...httpResponses,
+          customSections: {
+            httpResponse: {
+              title: httpResponses.title,
+              render: httpResponses.render,
               position: { after: "code" },
             },
-          ],
+          },
         },
       });
 
@@ -428,6 +425,7 @@ describe("custom-section", () => {
 
   describe("getCustomSectionsOrder()", () => {
     const order = ["description", "code", "metadata", "relations"];
+    const declaration = { title: "Responses", render: httpResponses.render };
 
     test("appends a section without position", () => {
       expect.assertions(1);
@@ -435,9 +433,9 @@ describe("custom-section", () => {
       expect(
         getCustomSectionsOrder(order, {
           ...options,
-          customSections: [httpResponses],
+          customSections: { httpResponse: declaration } as CustomSections,
         }),
-      ).toStrictEqual([...order, "httpResponses"]);
+      ).toStrictEqual([...order, "httpResponse"]);
     });
 
     test("inserts a section after the named one", () => {
@@ -446,15 +444,15 @@ describe("custom-section", () => {
       expect(
         getCustomSectionsOrder(order, {
           ...options,
-          customSections: [
-            { ...httpResponses, position: { after: "metadata" } },
-          ],
+          customSections: {
+            httpResponse: { ...declaration, position: { after: "metadata" } },
+          } as CustomSections,
         }),
       ).toStrictEqual([
         "description",
         "code",
         "metadata",
-        "httpResponses",
+        "httpResponse",
         "relations",
       ]);
     });
@@ -465,14 +463,14 @@ describe("custom-section", () => {
       expect(
         getCustomSectionsOrder(order, {
           ...options,
-          customSections: [
-            { ...httpResponses, position: { before: "metadata" } },
-          ],
+          customSections: {
+            httpResponse: { ...declaration, position: { before: "metadata" } },
+          } as CustomSections,
         }),
       ).toStrictEqual([
         "description",
         "code",
-        "httpResponses",
+        "httpResponse",
         "metadata",
         "relations",
       ]);
@@ -484,9 +482,11 @@ describe("custom-section", () => {
       expect(
         getCustomSectionsOrder(order, {
           ...options,
-          customSections: [{ ...httpResponses, position: { after: "nope" } }],
+          customSections: {
+            httpResponse: { ...declaration, position: { after: "nope" } },
+          } as CustomSections,
         }),
-      ).toStrictEqual([...order, "httpResponses"]);
+      ).toStrictEqual([...order, "httpResponse"]);
     });
 
     test("places sections in declaration order, so one can target another", () => {
@@ -495,40 +495,19 @@ describe("custom-section", () => {
       expect(
         getCustomSectionsOrder(order, {
           ...options,
-          customSections: [
-            { ...httpResponses, position: { after: "code" } },
-            {
-              ...httpResponses,
-              name: "httpHeaders",
-              position: { after: "httpResponses" },
+          customSections: {
+            httpResponse: { ...declaration, position: { after: "code" } },
+            httpHeader: {
+              ...declaration,
+              position: { after: "httpResponse" },
             },
-          ],
+          } as CustomSections,
         }),
       ).toStrictEqual([
         "description",
         "code",
-        "httpResponses",
-        "httpHeaders",
-        "metadata",
-        "relations",
-      ]);
-    });
-
-    test("places a repeated section name once, at its first declaration", () => {
-      expect.assertions(1);
-
-      expect(
-        getCustomSectionsOrder(order, {
-          ...options,
-          customSections: [
-            { ...httpResponses, position: { after: "code" } },
-            { ...httpResponses, position: { after: "relations" } },
-          ],
-        }),
-      ).toStrictEqual([
-        "description",
-        "code",
-        "httpResponses",
+        "httpResponse",
+        "httpHeader",
         "metadata",
         "relations",
       ]);
@@ -541,7 +520,7 @@ describe("custom-section", () => {
       expect(
         getCustomSectionsOrder(order, {
           ...options,
-          customSections: {} as unknown as TypeCustomSectionOption[],
+          customSections: {} as CustomSections,
         }),
       ).toStrictEqual(order);
     });

--- a/packages/types/src/core.d.ts
+++ b/packages/types/src/core.d.ts
@@ -255,14 +255,10 @@ export type CustomSectionPosition =
  * Custom section configuration options.
  *
  * Declares a directive-driven, top-level section of a type page. The section is
- * rendered when the configured directive is present on the type being printed,
+ * rendered when the directive naming it is present on the type being printed,
  * and is skipped otherwise.
  */
 export interface TypeCustomSectionOption {
-  /** Section key, injected into the page sections map. Must not collide with a built-in section. */
-  name: string;
-  /** Name of the schema directive carrying the section data. */
-  directive: string;
   /** Optional heading for the section. Omit for an untitled section. */
   title?: Maybe<string>;
   /** Optional heading level, defaults to `3`. */
@@ -274,6 +270,15 @@ export interface TypeCustomSectionOption {
   /** Callback rendering the section content from the directive occurrences. */
   render: CustomSectionRenderer;
 }
+
+/**
+ * Map of directive names to their custom section options.
+ *
+ * The directive name is both the schema directive carrying the section data and
+ * the section key injected into the page sections map, so it must not collide
+ * with a built-in section.
+ */
+export type CustomSections = Record<DirectiveName, TypeCustomSectionOption>;
 
 export type DiffMethodName = string & { _opaque: typeof DIFF_METHOD_NAME };
 // eslint-disable-next-line @typescript-eslint/no-unused-vars -- used in opaque type pattern
@@ -342,7 +347,7 @@ export interface ConfigPrintTypeOptions {
   /** How to handle deprecated items */
   deprecated?: TypeDeprecatedOption;
   /** Configuration for directive-driven custom sections */
-  customSections?: TypeCustomSectionOption[];
+  customSections?: Maybe<CustomSections>;
   /** Configuration for example sections */
   exampleSection?: TypeExampleSectionOption;
   /** Documentation hierarchy structure */
@@ -352,7 +357,6 @@ export interface ConfigPrintTypeOptions {
   /** Whether to show type badges */
   typeBadges?: boolean;
 }
-
 
 /**
  * Command line interface options.
@@ -405,7 +409,6 @@ export interface CliOptions {
   /** Temporary directory */
   tmp?: string;
 }
-
 
 /**
  * Core options type that combines config options with required fields.

--- a/packages/types/src/printer.d.ts
+++ b/packages/types/src/printer.d.ts
@@ -1,9 +1,9 @@
 import type {
   CollapsibleOption,
   ConfigPrintTypeOptions,
+  CustomSections,
   FrontMatterOptions,
   MetaInfo,
-  TypeCustomSectionOption,
   TypeDeprecatedOption,
   TypeExampleSectionOption,
   TypeHierarchyObjectType,
@@ -103,7 +103,6 @@ export interface IPrintTypeEvent extends ICancellableEvent {
   output: Maybe<MDXString>;
 }
 
-
 /**
  * Data payload for compose page type events.
  */
@@ -202,7 +201,7 @@ export interface AdmonitionType {
  * Configuration options for printing type documentation
  */
 export interface PrinterConfigPrintTypeOptions {
-  customSections?: TypeCustomSectionOption[];
+  customSections?: CustomSections;
   deprecated?: TypeDeprecatedOption;
   exampleSection?: TypeExampleSectionOption;
   hierarchy?: TypeHierarchyObjectType;
@@ -218,7 +217,7 @@ export type PrintTypeOptions = Partial<Formatter> & {
   basePath: string;
   collapsible?: Maybe<CollapsibleOption>;
   customDirectives?: Maybe<CustomDirectiveMap>;
-  customSections?: Maybe<TypeCustomSectionOption[]>;
+  customSections?: Maybe<CustomSections>;
   deprecated?: Maybe<TypeDeprecatedOption>;
   /** The schema entity kind being printed, when known by the caller. */
   entity?: Maybe<SchemaEntity>;
@@ -364,10 +363,7 @@ export abstract class IPrinter {
    * @param options - Combined printer configuration and options
    * @returns Markdown string containing the code representation
    */
-  static printCode(
-    type: unknown,
-    options: PrintTypeOptions,
-  ): string;
+  static printCode(type: unknown, options: PrintTypeOptions): string;
 
   /**
    * Prints custom directives associated with a type

--- a/tests/ci/affected-packages.test.mts
+++ b/tests/ci/affected-packages.test.mts
@@ -24,23 +24,7 @@ const packagesMap: PackagesMap = {
 
 const allPackages = ["cli", "core", "graphql", "logger", "utils"];
 
-describe("computeAffected()", () => {
-  test("returns nothing to run for a documentation-only change", () => {
-    expect(
-      computeAffected(
-        ["docs/settings.md", "README.md", "api/index.md", "website/src/app.js"],
-        packagesMap,
-      ),
-    ).toMatchObject({
-      code: false,
-      packages: [],
-      direct_packages: [],
-      smoke: false,
-      workflows: false,
-      docs_only: true,
-    });
-  });
-
+describe("computeAffected() dependency closure", () => {
   test("expands a package change into its transitive dependents", () => {
     const outputs = computeAffected(
       ["packages/utils/src/string.ts"],
@@ -67,22 +51,20 @@ describe("computeAffected()", () => {
     // upstream change must not re-run every dependent's Stryker job.
     expect(outputs.direct_packages).toStrictEqual(["utils"]);
   });
+});
 
+describe("computeAffected() global fail-open", () => {
+  // Runtime tier: these change what a package's own tests execute, so they
+  // widen mutation testing as well as the dependency closure.
   test.each([
     ["bun.lock"],
     ["package.json"],
     ["tsconfig.base.json"],
     ["turbo.json"],
     ["vitest.config.mjs"],
-    ["packages/types/src/core.d.ts"],
     ["packages/tooling-config/stryker/stryker.conf.mjs"],
     [".github/actions/setup/action.yml"],
-    [".github/scripts/affected-packages.mts"],
-    // This very file: the gate must invalidate itself, or a change to its own
-    // tests would report `docs_only` and never run them.
-    ["tests/ci/affected-packages.test.mts"],
-    ["tests/ci/vitest.config.mjs"],
-  ])("fails open to the whole matrix for %s", (file) => {
+  ])("runs the whole matrix, mutation included, for %s", (file) => {
     const outputs = computeAffected([file], packagesMap);
 
     expect(outputs.packages).toStrictEqual(allPackages);
@@ -90,15 +72,43 @@ describe("computeAffected()", () => {
     expect(outputs.smoke).toBe(true);
   });
 
-  test("ignores documentation shipped inside a package", () => {
-    expect(
-      computeAffected(
-        ["packages/utils/docs/api.md", "packages/utils/README.md"],
-        packagesMap,
-      ),
-    ).toMatchObject({ code: false, packages: [], docs_only: true });
+  // Static tier: type definitions are erased before a mutant runs and CI
+  // tooling is not part of any package, so neither can move a Stryker score.
+  test.each([
+    ["packages/types/src/core.d.ts"],
+    [".github/scripts/affected-packages.mts"],
+    // This very file: the gate must invalidate itself, or a change to its own
+    // tests would report `docs_only` and never run them.
+    ["tests/ci/affected-packages.test.mts"],
+    ["tests/ci/vitest.config.mjs"],
+  ])("runs the whole test matrix but no extra mutation job for %s", (file) => {
+    const outputs = computeAffected([file], packagesMap);
+
+    expect(outputs.packages).toStrictEqual(allPackages);
+    expect(outputs.smoke).toBe(true);
   });
 
+  test("keeps mutation on the touched packages for a types-only change", () => {
+    // The shape of nearly every public API PR: a `.d.ts` edit alongside the
+    // packages implementing it. The closure still covers everything, but
+    // Stryker only runs where the sources actually changed.
+    const outputs = computeAffected(
+      ["packages/types/src/core.d.ts", "packages/core/src/config.ts"],
+      packagesMap,
+    );
+
+    expect(outputs.packages).toStrictEqual(allPackages);
+    expect(outputs.direct_packages).toStrictEqual(["core"]);
+  });
+
+  test("runs no mutation job for a CI-only change", () => {
+    expect(
+      computeAffected([".github/scripts/changed-files.sh"], packagesMap),
+    ).toHaveProperty("direct_packages", []);
+  });
+});
+
+describe("computeAffected() smoke targets", () => {
   test("runs every smoke target when any package changes", () => {
     expect(
       computeAffected(["packages/logger/src/index.ts"], packagesMap),
@@ -119,6 +129,33 @@ describe("computeAffected()", () => {
     expect(outputs.smoke_docusaurus).toBe(docusaurus);
     // e2e specs are outside every Stryker `mutate` glob.
     expect(outputs.direct_packages).toStrictEqual([]);
+  });
+});
+
+describe("computeAffected() documentation and tooling", () => {
+  test("returns nothing to run for a documentation-only change", () => {
+    expect(
+      computeAffected(
+        ["docs/settings.md", "README.md", "api/index.md", "website/src/app.js"],
+        packagesMap,
+      ),
+    ).toMatchObject({
+      code: false,
+      packages: [],
+      direct_packages: [],
+      smoke: false,
+      workflows: false,
+      docs_only: true,
+    });
+  });
+
+  test("ignores documentation shipped inside a package", () => {
+    expect(
+      computeAffected(
+        ["packages/utils/docs/api.md", "packages/utils/README.md"],
+        packagesMap,
+      ),
+    ).toMatchObject({ code: false, packages: [], docs_only: true });
   });
 
   test("flags its own test suite so the linter job runs it", () => {

--- a/tests/ci/affected-packages.test.mts
+++ b/tests/ci/affected-packages.test.mts
@@ -78,6 +78,10 @@ describe("computeAffected()", () => {
     ["packages/tooling-config/stryker/stryker.conf.mjs"],
     [".github/actions/setup/action.yml"],
     [".github/scripts/affected-packages.mts"],
+    // This very file: the gate must invalidate itself, or a change to its own
+    // tests would report `docs_only` and never run them.
+    ["tests/ci/affected-packages.test.mts"],
+    ["tests/ci/vitest.config.mjs"],
   ])("fails open to the whole matrix for %s", (file) => {
     const outputs = computeAffected([file], packagesMap);
 
@@ -115,6 +119,12 @@ describe("computeAffected()", () => {
     expect(outputs.smoke_docusaurus).toBe(docusaurus);
     // e2e specs are outside every Stryker `mutate` glob.
     expect(outputs.direct_packages).toStrictEqual([]);
+  });
+
+  test("flags its own test suite so the linter job runs it", () => {
+    expect(
+      computeAffected(["tests/ci/affected-packages.test.mts"], packagesMap),
+    ).toMatchObject({ workflows: true, docs_only: false });
   });
 
   test("flags workflow changes so actionlint and shellcheck still run", () => {

--- a/tests/ci/affected-packages.test.mts
+++ b/tests/ci/affected-packages.test.mts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "vitest";
+
+import { computeAffected } from "../../.github/scripts/affected-packages.mts";
+import type { PackagesMap } from "../../.github/scripts/affected-packages.mts";
+
+// A miniature stand-in for the real workspace, so the expectations stay
+// readable and do not churn every time a package gains a dependency.
+const packagesMap: PackagesMap = {
+  "@graphql-markdown/utils": {},
+  "@graphql-markdown/logger": {},
+  "@graphql-markdown/graphql": {
+    dependencies: { "@graphql-markdown/utils": "workspace:*" },
+  },
+  "@graphql-markdown/core": {
+    dependencies: {
+      "@graphql-markdown/graphql": "workspace:*",
+      "@graphql-markdown/logger": "workspace:*",
+    },
+  },
+  "@graphql-markdown/cli": {
+    peerDependencies: { "@graphql-markdown/core": "workspace:*" },
+  },
+};
+
+const allPackages = ["cli", "core", "graphql", "logger", "utils"];
+
+describe("computeAffected()", () => {
+  test("returns nothing to run for a documentation-only change", () => {
+    expect(
+      computeAffected(
+        ["docs/settings.md", "README.md", "api/index.md", "website/src/app.js"],
+        packagesMap,
+      ),
+    ).toMatchObject({
+      code: false,
+      packages: [],
+      direct_packages: [],
+      smoke: false,
+      workflows: false,
+      docs_only: true,
+    });
+  });
+
+  test("expands a package change into its transitive dependents", () => {
+    const outputs = computeAffected(
+      ["packages/utils/src/string.ts"],
+      packagesMap,
+    );
+
+    expect(outputs.packages).toStrictEqual(["cli", "core", "graphql", "utils"]);
+    expect(outputs.code).toBe(true);
+  });
+
+  test("follows peerDependencies as well as dependencies", () => {
+    expect(
+      computeAffected(["packages/core/src/index.ts"], packagesMap),
+    ).toHaveProperty("packages", ["cli", "core"]);
+  });
+
+  test("keeps mutation scoped to the packages changed directly", () => {
+    const outputs = computeAffected(
+      ["packages/utils/src/string.ts"],
+      packagesMap,
+    );
+
+    // Mutation score is a function of a package's own src + tests, so an
+    // upstream change must not re-run every dependent's Stryker job.
+    expect(outputs.direct_packages).toStrictEqual(["utils"]);
+  });
+
+  test.each([
+    ["bun.lock"],
+    ["package.json"],
+    ["tsconfig.base.json"],
+    ["turbo.json"],
+    ["vitest.config.mjs"],
+    ["packages/types/src/core.d.ts"],
+    ["packages/tooling-config/stryker/stryker.conf.mjs"],
+    [".github/actions/setup/action.yml"],
+    [".github/scripts/affected-packages.mts"],
+  ])("fails open to the whole matrix for %s", (file) => {
+    const outputs = computeAffected([file], packagesMap);
+
+    expect(outputs.packages).toStrictEqual(allPackages);
+    expect(outputs.direct_packages).toStrictEqual(allPackages);
+    expect(outputs.smoke).toBe(true);
+  });
+
+  test("ignores documentation shipped inside a package", () => {
+    expect(
+      computeAffected(
+        ["packages/utils/docs/api.md", "packages/utils/README.md"],
+        packagesMap,
+      ),
+    ).toMatchObject({ code: false, packages: [], docs_only: true });
+  });
+
+  test("runs every smoke target when any package changes", () => {
+    expect(
+      computeAffected(["packages/logger/src/index.ts"], packagesMap),
+    ).toMatchObject({ smoke_cli: true, smoke_docusaurus: true });
+  });
+
+  test.each([
+    ["tests/e2e/cli/specs/cli.spec.mjs", true, false],
+    ["tests/e2e/docusaurus/specs/cli.spec.mjs", false, true],
+    // Markdown under tests/ is generator input, not documentation.
+    ["tests/e2e/__data__/anilist.md", true, true],
+    ["tests/e2e/helpers/cli.mjs", true, true],
+    [".github/workflows/smoke.yml", true, true],
+  ])("scopes %s to the smoke targets it exercises", (file, cli, docusaurus) => {
+    const outputs = computeAffected([file], packagesMap);
+
+    expect(outputs.smoke_cli).toBe(cli);
+    expect(outputs.smoke_docusaurus).toBe(docusaurus);
+    // e2e specs are outside every Stryker `mutate` glob.
+    expect(outputs.direct_packages).toStrictEqual([]);
+  });
+
+  test("flags workflow changes so actionlint and shellcheck still run", () => {
+    expect(
+      computeAffected([".github/workflows/test.yml"], packagesMap),
+    ).toMatchObject({ code: false, workflows: true, docs_only: false });
+  });
+
+  test("ignores blank lines from the git diff output", () => {
+    expect(computeAffected(["", "  ", ""], packagesMap)).toMatchObject({
+      docs_only: true,
+    });
+  });
+});

--- a/tests/ci/vitest.config.mjs
+++ b/tests/ci/vitest.config.mjs
@@ -1,0 +1,17 @@
+// @ts-check
+
+import { defineConfig } from "vitest/config";
+
+/**
+ * Standalone project for the repository tooling under `.github/scripts`. These
+ * scripts are not part of a workspace package, so they cannot ride the
+ * per-package configs, but they gate the whole CI matrix and need coverage.
+ */
+export default defineConfig({
+  test: {
+    name: "CI Scripts",
+    root: import.meta.dirname,
+    environment: "node",
+    include: ["**/*.test.mts"],
+  },
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -12,6 +12,6 @@ import { defineConfig } from "vitest/config";
  */
 export default defineConfig({
   test: {
-    projects: ["packages/*/vitest.config.mjs"],
+    projects: ["packages/*/vitest.config.mjs", "tests/ci/vitest.config.mjs"],
   },
 });


### PR DESCRIPTION
# Description

`printTypeOptions.customSections` was a list of sections, each carrying its own `name` and `directive`. It is now a map of directive name to section options, in the same shape as `customDirective`:

```js
// before
customSections: [
  { name: "httpResponses", directive: "httpResponse", title: "Responses", render },
]

// after
customSections: {
  httpResponse: { title: "Responses", render },
}
```

The map key is both the schema directive read off the type and the section key on the page, so `name` and `directive` drop out of the entry and uniqueness comes from the object itself. `position` references a custom section by its directive name.

The option was added in #3275 and has not been released, so there is no deprecated alias — this is a breaking change only against `main`.

- **types** — `TypeCustomSectionOption` loses `name` and `directive`; new `CustomSections = Record<DirectiveName, TypeCustomSectionOption>`.
- **core** — validation checks an object rather than a list; the duplicate-name and missing-name checks are gone, as object keys are unique and carry the directive name. An object literal never makes `__proto__` an own property, so that key no longer needs rejecting explicitly.
- **printer-legacy** — `getDeclaredSections` maps the declaration entries to section definitions. The internal `SectionDefinition` keeps `name` and `directive`, as the built-in example section has a section key and directive name that differ.

Stacked on `ci/path-filtered-workflows`.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)