### PR TITLE
♻️ Code review cleanup: dead code, public API leaks, DRY

### DIFF
--- a/packages/core/docs/event-emitter.md
+++ b/packages/core/docs/event-emitter.md
@@ -2,9 +2,115 @@
 
 ## Events
 
+### CancellableEventEmitter
+
+Defined in: [packages/core/src/event-emitter.ts:34](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/event-emitter.ts#L34)
+
+Custom EventEmitter that supports cancellable events with sequential handler execution.
+
+Features:
+
+- Executes async handlers sequentially (one after another)
+- Collects errors without stopping handler execution
+- Supports stopPropagation to halt handler chain
+- Returns execution results to emitters
+
+#### Extends
+
+- `EventEmitter`
+
+#### Constructors
+
+##### Constructor
+
+```ts
+new CancellableEventEmitter(options?): CancellableEventEmitter;
+```
+
+Defined in: node_modules/.bun/@types+node@26.4.1/node_modules/@types/node/events.d.ts:54
+
+###### Parameters
+
+###### options?
+
+`EventEmitterOptions`
+
+###### Returns
+
+[`CancellableEventEmitter`](#cancellableeventemitter)
+
+###### Inherited from
+
+```ts
+EventEmitter.constructor;
+```
+
+#### Methods
+
+##### emitAsync()
+
+```ts
+emitAsync(eventName, event): Promise<EmitResult>;
+```
+
+Defined in: [packages/core/src/event-emitter.ts:77](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/event-emitter.ts#L77)
+
+Emit an event asynchronously with cancellable event support.
+
+Handlers are executed sequentially in registration order.
+If a handler throws an error, it's collected but execution continues.
+If event.propagationStopped becomes true, remaining handlers are skipped.
+
+After all handlers execute, if the event has a defaultAction function and
+preventDefault() was not called, the default action is automatically executed.
+
+###### Parameters
+
+###### eventName
+
+`string`
+
+Name of the event to emit
+
+###### event
+
+`ICancellableEvent`
+
+Cancellable event object with preventDefault() and stopPropagation() methods
+
+###### Returns
+
+`Promise`&lt;[`EmitResult`](#emitresult)&gt;
+
+Promise resolving to EmitResult with errors and cancellation status
+
+###### Example
+
+```typescript
+const events = getEvents();
+const event = new SchemaLoadEvent({
+  schemaLocation: "/path/to/schema",
+  defaultAction: async () => {
+    // This runs automatically if not prevented
+    await loadSchema("/path/to/schema");
+  },
+});
+
+const { errors, defaultPrevented } = await events.emitAsync(
+  "beforeLoadSchema",
+  event,
+);
+
+if (errors.length > 0) {
+  console.error("Errors occurred:", errors);
+}
+```
+
+---
+
 ### EmitResult
 
-Defined in: [core/src/event-emitter.ts:9](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/event-emitter.ts#L9)
+Defined in: [packages/core/src/event-emitter.ts:9](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/event-emitter.ts#L9)
 
 Result object returned when emitting a cancellable event.
 
@@ -16,7 +122,7 @@ Result object returned when emitting a cancellable event.
 defaultPrevented: boolean;
 ```
 
-Defined in: [core/src/event-emitter.ts:20](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/event-emitter.ts#L20)
+Defined in: [packages/core/src/event-emitter.ts:20](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/event-emitter.ts#L20)
 
 Whether any handler called preventDefault() on the event.
 Only applicable if the event is cancellable.
@@ -27,7 +133,7 @@ Only applicable if the event is cancellable.
 errors: Error[];
 ```
 
-Defined in: [core/src/event-emitter.ts:14](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/event-emitter.ts#L14)
+Defined in: [packages/core/src/event-emitter.ts:14](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/event-emitter.ts#L14)
 
 Array of errors that occurred during handler execution.
 Handlers continue executing even if previous handlers throw errors.
@@ -40,7 +146,7 @@ Handlers continue executing even if previous handlers throw errors.
 function getEvents(): CancellableEventEmitter;
 ```
 
-Defined in: [core/src/event-emitter.ts:172](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/event-emitter.ts#L172)
+Defined in: [packages/core/src/event-emitter.ts:172](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/event-emitter.ts#L172)
 
 Get the singleton event emitter instance.
 
@@ -49,7 +155,7 @@ This ensures all parts of the application share the same event bus.
 
 #### Returns
 
-`CancellableEventEmitter`
+[`CancellableEventEmitter`](#cancellableeventemitter)
 
 The singleton CancellableEventEmitter instance
 
@@ -73,7 +179,7 @@ await events.emitAsync("beforeLoadSchema", event);
 function resetEvents(): void;
 ```
 
-Defined in: [core/src/event-emitter.ts:196](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/event-emitter.ts#L196)
+Defined in: [packages/core/src/event-emitter.ts:196](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/event-emitter.ts#L196)
 
 Reset the event emitter singleton.
 
@@ -92,6 +198,6 @@ The next call to getEvents() will create a fresh instance.
 // In test setup
 afterEach(() => {
   resetEvents();
-  vi.restoreAllMocks();
+  jest.restoreAllMocks();
 });
 ```

--- a/packages/core/docs/graphql-config.md
+++ b/packages/core/docs/graphql-config.md
@@ -5,6 +5,38 @@ GraphQL Markdown configuration utilities
 This module provides utilities for loading and processing GraphQL configuration
 using the graphql-config package.
 
+## Interfaces
+
+### ThrowOptions
+
+Defined in: [packages/core/src/graphql-config.ts:58](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/graphql-config.ts#L58)
+
+Options for controlling throw behavior when loading configuration.
+
+ThrowOptions
+
+#### Properties
+
+##### throwOnEmpty?
+
+```ts
+optional throwOnEmpty?: boolean;
+```
+
+Defined in: [packages/core/src/graphql-config.ts:60](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/graphql-config.ts#L60)
+
+Whether to throw when the config is empty.
+
+##### throwOnMissing?
+
+```ts
+optional throwOnMissing?: boolean;
+```
+
+Defined in: [packages/core/src/graphql-config.ts:59](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/graphql-config.ts#L59)
+
+Whether to throw when the config file is missing.
+
 ## Variables
 
 ### graphQLConfigExtension
@@ -13,7 +45,7 @@ using the graphql-config package.
 const graphQLConfigExtension: GraphQLExtensionDeclaration;
 ```
 
-Defined in: [core/src/graphql-config.ts:48](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/graphql-config.ts#L48)
+Defined in: [packages/core/src/graphql-config.ts:47](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/graphql-config.ts#L47)
 
 GraphQL extension declaration for graphql-config.
 
@@ -42,7 +74,7 @@ function loadConfiguration(
 ): Promise<Maybe<Readonly<ExtensionProjectConfig>>>;
 ```
 
-Defined in: [core/src/graphql-config.ts:146](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/graphql-config.ts#L146)
+Defined in: [packages/core/src/graphql-config.ts:144](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/graphql-config.ts#L144)
 
 Loads the GraphQL Markdown configuration from graphql-config.
 
@@ -66,7 +98,7 @@ Optional package options to apply.
 
 ##### throwOptions?
 
-`ThrowOptions` = `DEFAULT_THROW_OPTIONS`
+[`ThrowOptions`](#throwoptions) = `DEFAULT_THROW_OPTIONS`
 
 Options for controlling throw behavior.
 
@@ -103,7 +135,7 @@ const config = await loadConfiguration(
 function setLoaderOptions(loaders, options): LoaderOption;
 ```
 
-Defined in: [core/src/graphql-config.ts:98](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/graphql-config.ts#L98)
+Defined in: [packages/core/src/graphql-config.ts:96](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/graphql-config.ts#L96)
 
 Sets loader options for GraphQL Markdown loaders.
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -469,6 +469,14 @@ export const getDiffMethod = (diff: TypeDiffMethod): TypeDiffMethod => {
   return getNormalizedDiffMethod(diff);
 };
 
+// Used only by unit tests for direct whitebox coverage; not part of the production public API.
+export const parseDeprecatedDocOptions = (
+  _cliOpts?: Maybe<CliOptions>,
+  _configOptions?: Maybe<ConfigDocOptions>,
+): Record<string, never> => {
+  return {};
+};
+
 /**
  * Builds the document options by merging CLI options, config file options, and defaults.
  * Handles index generation flag and front matter configuration.
@@ -494,6 +502,7 @@ export const getDocOptions = (
   cliOpts?: Maybe<CliOptions>,
   configOptions?: Maybe<ConfigDocOptions>,
 ): Required<ConfigDocOptions> => {
+  const deprecated = parseDeprecatedDocOptions(cliOpts, configOptions);
   const cliIndex =
     typeof cliOpts?.index === "boolean" ? cliOpts.index : undefined;
   const configIndex =
@@ -508,6 +517,7 @@ export const getDocOptions = (
   return {
     categorySort: configOptions?.categorySort,
     frontMatter: {
+      ...deprecated,
       ...configOptions?.frontMatter,
     },
     // the framework name and version are set by the framework plugin, and are
@@ -607,6 +617,14 @@ export const parseDeprecatedFormatterOption = (
   return (
     cliOpts?.formatter ?? legacyCli ?? configOptions?.formatter ?? legacyConfig
   );
+};
+
+// Used only by unit tests for direct whitebox coverage; not part of the production public API.
+export const parseDeprecatedPrintTypeOptions = (
+  _cliOpts?: Maybe<CliOptions>,
+  _configOptions?: Maybe<ConfigPrintTypeOptions>,
+): Record<string, never> => {
+  return {};
 };
 
 /**
@@ -879,6 +897,11 @@ export const buildConfig = async (
   cliOpts ??= {};
 
   const graphqlConfig = await loadConfiguration(id);
+
+  parseDeprecatedPrintTypeOptions(cliOpts, {
+    ...(graphqlConfig as Maybe<ConfigOptions>)?.printTypeOptions,
+    ...configFileOpts?.printTypeOptions,
+  });
 
   const config = deepmerge()(
     { ...DEFAULT_OPTIONS, ...graphqlConfig },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -497,6 +497,27 @@ export const parseDeprecatedDocOptions = (
  * // }
  * ```
  */
+/**
+ * Resolves a boolean option that defaults to `true` and can only be turned off,
+ * either via a CLI negation flag (e.g. `--noParentType`) or an explicit `false`
+ * in the config file.
+ *
+ * @param cliNegated - the CLI negation flag value (e.g. `cliOpts.noParentType`)
+ * @param configValue - the corresponding config file option value
+ * @param defaultValue - the value used when neither source turns the option off
+ * @returns the resolved boolean value
+ */
+const resolveNegatableOption = (
+  cliNegated: Maybe<boolean>,
+  configValue: Maybe<boolean>,
+  defaultValue: boolean,
+): boolean => {
+  if (cliNegated === true) {
+    return false;
+  }
+  return typeof configValue === "boolean" ? configValue : defaultValue;
+};
+
 // Used only by unit tests for direct whitebox coverage; not part of the production public API.
 export const getDocOptions = (
   cliOpts?: Maybe<CliOptions>,
@@ -508,12 +529,11 @@ export const getDocOptions = (
   const configIndex =
     typeof configOptions?.index === "boolean" ? configOptions.index : undefined;
   const index = cliIndex ?? configIndex ?? DEFAULT_OPTIONS.docOptions!.index;
-  const configSectionHeaderId =
-    typeof configOptions?.sectionHeaderId === "boolean"
-      ? configOptions.sectionHeaderId
-      : DEFAULT_OPTIONS.docOptions!.sectionHeaderId;
-  const sectionHeaderId =
-    cliOpts?.noSectionId === true ? false : configSectionHeaderId;
+  const sectionHeaderId = resolveNegatableOption(
+    cliOpts?.noSectionId,
+    configOptions?.sectionHeaderId,
+    DEFAULT_OPTIONS.docOptions!.sectionHeaderId!,
+  );
   return {
     categorySort: configOptions?.categorySort,
     frontMatter: {
@@ -759,12 +779,16 @@ const getPrintTypeOptions = (
     exampleSection:
       configOptions?.exampleSection ??
       DEFAULT_OPTIONS.printTypeOptions.exampleSection,
-    parentTypePrefix:
-      (!cliOpts?.noParentType && configOptions?.parentTypePrefix) ??
+    parentTypePrefix: resolveNegatableOption(
+      cliOpts?.noParentType,
+      configOptions?.parentTypePrefix,
       DEFAULT_OPTIONS.printTypeOptions.parentTypePrefix,
-    typeBadges:
-      (!cliOpts?.noTypeBadges && configOptions?.typeBadges) ??
+    ),
+    typeBadges: resolveNegatableOption(
+      cliOpts?.noTypeBadges,
+      configOptions?.typeBadges,
       DEFAULT_OPTIONS.printTypeOptions.typeBadges,
+    ),
     hierarchy: getTypeHierarchyOption(
       cliOpts?.hierarchy,
       configOptions?.hierarchy,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -469,14 +469,6 @@ export const getDiffMethod = (diff: TypeDiffMethod): TypeDiffMethod => {
   return getNormalizedDiffMethod(diff);
 };
 
-// Used only by unit tests for direct whitebox coverage; not part of the production public API.
-export const parseDeprecatedDocOptions = (
-  _cliOpts?: Maybe<CliOptions>,
-  _configOptions?: Maybe<ConfigDocOptions>,
-): Record<string, never> => {
-  return {};
-};
-
 /**
  * Builds the document options by merging CLI options, config file options, and defaults.
  * Handles index generation flag and front matter configuration.
@@ -502,7 +494,6 @@ export const getDocOptions = (
   cliOpts?: Maybe<CliOptions>,
   configOptions?: Maybe<ConfigDocOptions>,
 ): Required<ConfigDocOptions> => {
-  const deprecated = parseDeprecatedDocOptions(cliOpts, configOptions);
   const cliIndex =
     typeof cliOpts?.index === "boolean" ? cliOpts.index : undefined;
   const configIndex =
@@ -517,7 +508,6 @@ export const getDocOptions = (
   return {
     categorySort: configOptions?.categorySort,
     frontMatter: {
-      ...deprecated,
       ...configOptions?.frontMatter,
     },
     // the framework name and version are set by the framework plugin, and are
@@ -617,14 +607,6 @@ export const parseDeprecatedFormatterOption = (
   return (
     cliOpts?.formatter ?? legacyCli ?? configOptions?.formatter ?? legacyConfig
   );
-};
-
-// Used only by unit tests for direct whitebox coverage; not part of the production public API.
-export const parseDeprecatedPrintTypeOptions = (
-  _cliOpts?: Maybe<CliOptions>,
-  _configOptions?: Maybe<ConfigPrintTypeOptions>,
-): Record<string, never> => {
-  return {};
 };
 
 /**
@@ -897,11 +879,6 @@ export const buildConfig = async (
   cliOpts ??= {};
 
   const graphqlConfig = await loadConfiguration(id);
-
-  parseDeprecatedPrintTypeOptions(cliOpts, {
-    ...(graphqlConfig as Maybe<ConfigOptions>)?.printTypeOptions,
-    ...configFileOpts?.printTypeOptions,
-  });
 
   const config = deepmerge()(
     { ...DEFAULT_OPTIONS, ...graphqlConfig },

--- a/packages/core/src/event-emitter.ts
+++ b/packages/core/src/event-emitter.ts
@@ -31,7 +31,7 @@ export interface EmitResult {
  *
  * @category Events
  */
-class CancellableEventEmitter extends EventEmitter {
+export class CancellableEventEmitter extends EventEmitter {
   private static toError(error: unknown): Error {
     return error instanceof Error ? error : new Error(String(error));
   }

--- a/packages/core/src/events/schema-load.ts
+++ b/packages/core/src/events/schema-load.ts
@@ -4,7 +4,7 @@
  * @packageDocumentation
  */
 
-import type { GraphQLSchema, Maybe, SchemaMap } from "@graphql-markdown/types";
+import type { GraphQLSchema, SchemaMap } from "@graphql-markdown/types";
 import type { CancellableEventOptions } from "@graphql-markdown/utils";
 import { DataEvent } from "@graphql-markdown/utils";
 
@@ -15,14 +15,14 @@ import { DataEvent } from "@graphql-markdown/utils";
  */
 export class SchemaEvent extends DataEvent<{
   schemaLocation?: string;
-  schema?: Maybe<GraphQLSchema>;
-  rootTypes?: Maybe<SchemaMap>;
+  schema?: GraphQLSchema | null;
+  rootTypes?: SchemaMap;
 }> {
   constructor(
     data: {
       schemaLocation?: string;
-      schema?: Maybe<GraphQLSchema>;
-      rootTypes?: Maybe<SchemaMap>;
+      schema?: GraphQLSchema | null;
+      rootTypes?: SchemaMap;
     },
     options?: CancellableEventOptions,
   ) {

--- a/packages/core/src/graphql-config.ts
+++ b/packages/core/src/graphql-config.ts
@@ -55,7 +55,7 @@ export const graphQLConfigExtension: GraphQLExtensionDeclaration = () => {
  * @property throwOnMissing Whether to throw when the config file is missing.
  * @property throwOnEmpty Whether to throw when the config is empty.
  */
-interface ThrowOptions {
+export interface ThrowOptions {
   throwOnMissing?: boolean;
   throwOnEmpty?: boolean;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,7 +1,6 @@
 /**
  * @primaryExport
  */
-/* istanbul ignore file */
 
 export { generateDocFromSchema } from "./generator";
 export { buildConfig } from "./config";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,12 @@ export { generateDocFromSchema } from "./generator";
 export { buildConfig } from "./config";
 
 // Event system exports
-export { getEvents, resetEvents, type EmitResult } from "./event-emitter";
+export {
+  getEvents,
+  resetEvents,
+  type CancellableEventEmitter,
+  type EmitResult,
+} from "./event-emitter";
 export { registerMDXEventHandlers } from "./event-handlers";
 export { EVENT_CALLBACK_MAP } from "./event-map";
 

--- a/packages/core/tests/unit/config.test.ts
+++ b/packages/core/tests/unit/config.test.ts
@@ -31,7 +31,9 @@ import {
   getSkipDocDirectives,
   getTypeHierarchyOption,
   getVisibilityDirectives,
+  parseDeprecatedDocOptions,
   parseDeprecatedFormatterOption,
+  parseDeprecatedPrintTypeOptions,
   parseGroupByOption,
   parseHomepageOption,
   TypeHierarchy,
@@ -1144,6 +1146,20 @@ describe("config", () => {
         parseDeprecatedFormatterOption({ mdxParser: null }, {}),
       ).toBeUndefined();
       expect(log).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("parseDeprecatedPrintTypeOptions", () => {
+    test("returns empty object", () => {
+      expect.hasAssertions();
+      expect(parseDeprecatedPrintTypeOptions({}, undefined)).toStrictEqual({});
+    });
+  });
+
+  describe("parseDeprecatedDocOptions", () => {
+    test("returns empty object", () => {
+      expect.hasAssertions();
+      expect(parseDeprecatedDocOptions({}, undefined)).toStrictEqual({});
     });
   });
 

--- a/packages/core/tests/unit/config.test.ts
+++ b/packages/core/tests/unit/config.test.ts
@@ -31,9 +31,7 @@ import {
   getSkipDocDirectives,
   getTypeHierarchyOption,
   getVisibilityDirectives,
-  parseDeprecatedDocOptions,
   parseDeprecatedFormatterOption,
-  parseDeprecatedPrintTypeOptions,
   parseGroupByOption,
   parseHomepageOption,
   TypeHierarchy,
@@ -1146,20 +1144,6 @@ describe("config", () => {
         parseDeprecatedFormatterOption({ mdxParser: null }, {}),
       ).toBeUndefined();
       expect(log).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("parseDeprecatedPrintTypeOptions", () => {
-    test("returns empty object", () => {
-      expect.hasAssertions();
-      expect(parseDeprecatedPrintTypeOptions({}, undefined)).toStrictEqual({});
-    });
-  });
-
-  describe("parseDeprecatedDocOptions", () => {
-    test("returns empty object", () => {
-      expect.hasAssertions();
-      expect(parseDeprecatedDocOptions({}, undefined)).toStrictEqual({});
     });
   });
 

--- a/packages/core/tests/unit/graphql-config.test.ts
+++ b/packages/core/tests/unit/graphql-config.test.ts
@@ -359,81 +359,29 @@ describe("config", () => {
       );
     });
 
-    test("loads configuration with throwOnMissing and throwOnEmpty both true", async () => {
-      expect.hasAssertions();
+    test.each([
+      { throwOnMissing: true, throwOnEmpty: true },
+      { throwOnMissing: false, throwOnEmpty: false },
+      { throwOnMissing: true, throwOnEmpty: false },
+      { throwOnMissing: false, throwOnEmpty: true },
+    ])(
+      "returns undefined for throwOnMissing=$throwOnMissing and throwOnEmpty=$throwOnEmpty",
+      async ({ throwOnMissing, throwOnEmpty }) => {
+        expect.hasAssertions();
 
-      (GraphQLConfig.loadConfig as Mock).mockResolvedValueOnce({
-        config: { id: "test-project" },
-      });
+        (GraphQLConfig.loadConfig as Mock).mockResolvedValueOnce({
+          config: { id: "test-project" },
+        });
 
-      const result = await CoreGraphQLConfig.loadConfiguration(
-        "test",
-        {},
-        {
-          throwOnMissing: true,
-          throwOnEmpty: true,
-        },
-      );
+        const result = await CoreGraphQLConfig.loadConfiguration(
+          "test",
+          {},
+          { throwOnMissing, throwOnEmpty },
+        );
 
-      expect(result).toBeUndefined();
-    });
-
-    test("loads configuration with throwOnMissing and throwOnEmpty both false", async () => {
-      expect.hasAssertions();
-
-      (GraphQLConfig.loadConfig as Mock).mockResolvedValueOnce({
-        config: { id: "test-project" },
-      });
-
-      const result = await CoreGraphQLConfig.loadConfiguration(
-        "test",
-        {},
-        {
-          throwOnMissing: false,
-          throwOnEmpty: false,
-        },
-      );
-
-      expect(result).toBeUndefined();
-    });
-
-    test("handles throwOnMissing true and throwOnEmpty false", async () => {
-      expect.hasAssertions();
-
-      (GraphQLConfig.loadConfig as Mock).mockResolvedValueOnce({
-        config: { id: "test-project" },
-      });
-
-      const result = await CoreGraphQLConfig.loadConfiguration(
-        "test",
-        {},
-        {
-          throwOnMissing: true,
-          throwOnEmpty: false,
-        },
-      );
-
-      expect(result).toBeUndefined();
-    });
-
-    test("handles throwOnMissing false and throwOnEmpty true", async () => {
-      expect.hasAssertions();
-
-      (GraphQLConfig.loadConfig as Mock).mockResolvedValueOnce({
-        config: { id: "test-project" },
-      });
-
-      const result = await CoreGraphQLConfig.loadConfiguration(
-        "test",
-        {},
-        {
-          throwOnMissing: false,
-          throwOnEmpty: true,
-        },
-      );
-
-      expect(result).toBeUndefined();
-    });
+        expect(result).toBeUndefined();
+      },
+    );
 
     test("returns undefined when id is numeric value", async () => {
       expect.hasAssertions();

--- a/packages/core/tests/unit/renderer.test.ts
+++ b/packages/core/tests/unit/renderer.test.ts
@@ -2320,7 +2320,7 @@ describe("renderer", () => {
         expect(pos4).toBeLessThanOrEqual(3);
       });
 
-      test("automatically prefixes when categorySort is set", async () => {
+      test("still applies root-category prefixes when categorySort is not set", async () => {
         expect.assertions(2);
 
         const renderer = await getRenderer(

--- a/packages/docusaurus/docs/index-1.md
+++ b/packages/docusaurus/docs/index-1.md
@@ -10,7 +10,7 @@ Docusaurus integration for running GraphQL-Markdown and wiring CLI commands.
 function default(_, options): Promise<Plugin>;
 ```
 
-Defined in: [docusaurus/src/index.ts:28](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/docusaurus/src/index.ts#L28)
+Defined in: [docusaurus/src/index.ts:61](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/docusaurus/src/index.ts#L61)
 
 Docusaurus plugin wrapper that wires GraphQL-Markdown into the build,
 optionally running the CLI during `docusaurus build` and registering

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -17,6 +17,39 @@ const LOGGER_MODULE = "@docusaurus/logger" as const;
 const MDX_PACKAGE = "@graphql-markdown/docusaurus/mdx" as const;
 
 /**
+ * Minimal shape `extendCli`'s CLI command must satisfy at runtime.
+ *
+ * \@graphql-markdown/cli builds its command with commander v15, while
+ * \@docusaurus/types types `extendCli`'s parameter with commander v5's
+ * `Command`. The two are structurally compatible at runtime, but not
+ * assignable under TypeScript due to dual-version resolution — this type
+ * (and the guard below) narrows the unsafe cast to a single checked field.
+ */
+interface CommanderCompatibleCommand {
+  name: () => string;
+}
+
+const isCommanderCompatibleCommand = (
+  value: unknown,
+): value is CommanderCompatibleCommand => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { name?: unknown }).name === "function"
+  );
+};
+
+const assertCommanderCompatibleCommand: (
+  value: unknown,
+) => asserts value is CommanderCompatibleCommand = (value) => {
+  if (!isCommanderCompatibleCommand(value)) {
+    throw new TypeError(
+      "GraphQL-Markdown CLI command is not compatible with Docusaurus commander interface.",
+    );
+  }
+};
+
+/**
  * Docusaurus plugin wrapper that wires GraphQL-Markdown into the build,
  * optionally running the CLI during `docusaurus build` and registering
  * the `graphql-to-doc` command on the local CLI.
@@ -43,22 +76,21 @@ export default async function pluginGraphQLDocGenerator(
      * @returns void
      */
     extendCli(cli): void {
-      // @graphql-markdown/cli uses commander v15; @docusaurus/types types extendCli
-      // with commander v5's Command. The two are structurally compatible at runtime
-      // but TypeScript sees them as different types due to dual-version resolution.
-      cli.addCommand(
-        getGraphQLMarkdownCli(
-          {
-            ...options,
-            docOptions: {
-              generatorFrameworkName: "docusaurus",
-              generatorFrameworkVersion: DOCUSAURUS_VERSION,
-              ...options.docOptions,
-            },
+      const command = getGraphQLMarkdownCli(
+        {
+          ...options,
+          docOptions: {
+            generatorFrameworkName: "docusaurus",
+            generatorFrameworkVersion: DOCUSAURUS_VERSION,
+            ...options.docOptions,
           },
-          LOGGER_MODULE,
-          options.formatter ?? options.mdxParser ?? MDX_PACKAGE, // NOSONAR typescript:S1874
-        ) as unknown as Parameters<typeof cli.addCommand>[0],
+        },
+        LOGGER_MODULE,
+        options.formatter ?? MDX_PACKAGE,
+      );
+      assertCommanderCompatibleCommand(command);
+      cli.addCommand(
+        command as unknown as Parameters<typeof cli.addCommand>[0],
       );
     },
   };

--- a/packages/docusaurus/src/index.ts
+++ b/packages/docusaurus/src/index.ts
@@ -3,7 +3,6 @@
  *
  * @packageDocumentation
  */
-/* istanbul ignore file */
 import type { LoadContext, Plugin, PluginOptions } from "@docusaurus/types";
 import type { GraphQLMarkdownCliOptions } from "@graphql-markdown/types";
 

--- a/packages/docusaurus/tests/unit/index.test.ts
+++ b/packages/docusaurus/tests/unit/index.test.ts
@@ -4,7 +4,13 @@ import pluginGraphQLDocGenerator from "../../src/index";
 
 vi.mock("@graphql-markdown/cli", () => {
   return {
-    getGraphQLMarkdownCli: vi.fn(),
+    getGraphQLMarkdownCli: vi.fn(() => {
+      return {
+        name: () => {
+          return "graphql-to-doc";
+        },
+      };
+    }),
   };
 });
 import { getGraphQLMarkdownCli } from "@graphql-markdown/cli";
@@ -114,6 +120,21 @@ describe("pluginGraphQLDocGenerator", () => {
         }),
         "@docusaurus/logger",
         "@graphql-markdown/docusaurus/mdx",
+      );
+    });
+
+    test("throws when the CLI command is not commander-compatible", async () => {
+      vi.mocked(getGraphQLMarkdownCli).mockReturnValueOnce({} as never);
+
+      const plugin = await pluginGraphQLDocGenerator(
+        {} as LoadContext,
+        mockOptions,
+      );
+
+      expect(() => {
+        plugin.extendCli!(mockCli);
+      }).toThrow(
+        "GraphQL-Markdown CLI command is not compatible with Docusaurus commander interface.",
       );
     });
   });

--- a/packages/formatters/docs/defaults.md
+++ b/packages/formatters/docs/defaults.md
@@ -13,7 +13,7 @@ Individual formatters import what they need and override only what differs.
 function formatMDXAdmonition(admonition, _meta): MDXString;
 ```
 
-Defined in: [defaults.ts:42](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L42)
+Defined in: [defaults.ts:45](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L45)
 
 Formats an admonition as an HTML `<fieldset>` element with `gqlmd-mdx-admonition-*` CSS classes.
 
@@ -45,7 +45,7 @@ Formatted admonition string
 function formatMDXBadge(badge): MDXString;
 ```
 
-Defined in: [defaults.ts:32](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L32)
+Defined in: [defaults.ts:35](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L35)
 
 Formats a badge using an HTML `<mark>` element with a `gqlmd-mdx-badge` CSS class.
 
@@ -71,7 +71,7 @@ Formatted badge string
 function formatMDXBullet(text?): MDXString;
 ```
 
-Defined in: [defaults.ts:54](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L54)
+Defined in: [defaults.ts:57](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L57)
 
 Formats a bullet point separator using a `<span>` with a `gqlmd-mdx-bullet` CSS class.
 
@@ -97,7 +97,7 @@ Formatted bullet string
 function formatMDXDetails(option): MDXString;
 ```
 
-Defined in: [defaults.ts:64](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L64)
+Defined in: [defaults.ts:67](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L67)
 
 Formats a collapsible block as an HTML `<details>` element with a `gqlmd-mdx-details` CSS class.
 The summary label is uppercase; the close label is rendered as `<em>`.
@@ -118,13 +118,49 @@ Formatted details element string
 
 ---
 
+### formatMDXEscapedPermalink()
+
+```ts
+function formatMDXEscapedPermalink(id): MDXString;
+```
+
+Defined in: [defaults.ts:159](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L159)
+
+Formats a permalink for a section header using the classic `{#id}` syntax,
+escaped so that it stays valid MDX.
+
+MDX parses an unescaped `{` as the start of an expression, and `{#id}` is not
+a valid one, so presets generating `.mdx` pages must use this variant.
+
+#### Parameters
+
+##### id
+
+`string`
+
+The ID of the section header
+
+#### Returns
+
+`MDXString`
+
+Formatted permalink string
+
+#### Example
+
+```js
+formatMDXEscapedPermalink("my-id"); // \{#my-id\}
+```
+
+---
+
 ### formatMDXFrontmatter()
 
 ```ts
 function formatMDXFrontmatter(_props, formatted): MDXString;
 ```
 
-Defined in: [defaults.ts:77](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L77)
+Defined in: [defaults.ts:80](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L80)
 
 Formats YAML front matter wrapped in `---` delimiters.
 
@@ -150,13 +186,46 @@ Formatted front matter block, or empty string if no lines provided
 
 ---
 
+### formatMDXFrontmatterTitleOnly()
+
+```ts
+function formatMDXFrontmatterTitleOnly(formatted, trailingEol?): MDXString;
+```
+
+Defined in: [defaults.ts:98](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L98)
+
+Formats the page title as a visible H1 heading, for frameworks that render
+YAML front matter as literal page content and so must suppress it entirely.
+
+#### Parameters
+
+##### formatted
+
+`Maybe`&lt;`string`[]&gt;
+
+Pre-formatted front matter lines
+
+##### trailingEol?
+
+`boolean` = `false`
+
+Whether to append a trailing end-of-line after the heading
+
+#### Returns
+
+`MDXString`
+
+`# Title` heading, or empty string if no title is available
+
+---
+
 ### formatMDXLink()
 
 ```ts
 function formatMDXLink(link): TypeLink;
 ```
 
-Defined in: [defaults.ts:93](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L93)
+Defined in: [defaults.ts:114](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L114)
 
 Formats a type link — returns the link unchanged (identity passthrough).
 
@@ -182,7 +251,7 @@ The unmodified `TypeLink` object
 function formatMDXNameEntity(name, parentType?): MDXString;
 ```
 
-Defined in: [defaults.ts:103](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L103)
+Defined in: [defaults.ts:124](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L124)
 
 Formats a named entity using `<span>` and `<code>` elements with `gqlmd-mdx-entity-*` CSS classes.
 
@@ -208,13 +277,43 @@ Formatted entity reference string
 
 ---
 
+### formatMDXPermalink()
+
+```ts
+function formatMDXPermalink(id): MDXString;
+```
+
+Defined in: [defaults.ts:173](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L173)
+
+Formats a permalink for a section header using the classic `{#id}` syntax.
+
+This is the syntax supported by most Markdown-based generators (Hugo,
+mdBook, DocFX, MkDocs with `attr_list`). Presets targeting a framework that
+expects another syntax override this function.
+
+#### Parameters
+
+##### id
+
+`string`
+
+The ID of the section header
+
+#### Returns
+
+`MDXString`
+
+Formatted permalink string
+
+---
+
 ### formatMDXSpecifiedByLink()
 
 ```ts
 function formatMDXSpecifiedByLink(url): MDXString;
 ```
 
-Defined in: [defaults.ts:119](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L119)
+Defined in: [defaults.ts:140](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/defaults.ts#L140)
 
 Formats a "specified by" link as an HTML `<span>` with a `gqlmd-mdx-specifiedby` CSS class
 containing an anchor that opens in a new tab.

--- a/packages/formatters/docs/hugo.md
+++ b/packages/formatters/docs/hugo.md
@@ -14,7 +14,7 @@ strips file extensions from internal links to match Hugo's URL routing.
 const beforeGenerateIndexMetafileHook: GenerateIndexMetafileHook;
 ```
 
-Defined in: [hugo/index.ts:179](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L179)
+Defined in: [hugo/index.ts:178](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L178)
 
 Lifecycle hook that generates a Hugo-compatible `_index.md` section index file.
 The file is (re)created on every run with YAML frontmatter:
@@ -37,7 +37,7 @@ Hook event whose `data` contains `dirPath` (target directory) and `category` (se
 const mdxExtension: ".md";
 ```
 
-Defined in: [hugo/index.ts:169](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L169)
+Defined in: [hugo/index.ts:168](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L168)
 
 File extension used for generated pages — Hugo uses standard Markdown (.md) files.
 
@@ -49,7 +49,7 @@ File extension used for generated pages — Hugo uses standard Markdown (.md) fi
 function createMDXFormatter(_meta?): Formatter;
 ```
 
-Defined in: [hugo/index.ts:155](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L155)
+Defined in: [hugo/index.ts:153](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L153)
 
 Creates a Hugo formatter.
 
@@ -72,21 +72,21 @@ A complete Formatter implementation for Hugo output
 ### formatMDXAdmonition()
 
 ```ts
-function formatMDXAdmonition(text, _meta): MDXString;
+function formatMDXAdmonition(admonition, _meta): MDXString;
 ```
 
-Defined in: [hugo/index.ts:77](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L77)
+Defined in: [hugo/index.ts:76](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L76)
 
 Formats an admonition using Hugo GitHub-style alert syntax (`> [!TYPE]`).
 Requires Hugo 0.132 or later.
 
 #### Parameters
 
-##### text
+##### admonition
 
 `AdmonitionType`
 
-The admonition body text
+Admonition data with text, optional title, and type (e.g. `note`, `warning`, `danger`) mapped via ALERT_TYPE_MAP
 
 ##### \_meta
 
@@ -108,7 +108,7 @@ Formatted blockquote alert string
 function formatMDXBadge(badge): MDXString;
 ```
 
-Defined in: [hugo/index.ts:64](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L64)
+Defined in: [hugo/index.ts:65](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L65)
 
 Formats a badge as a styled span element.
 
@@ -131,20 +131,20 @@ HTML `<span>` string with the `gqlmd-badge` class
 ### formatMDXDetails()
 
 ```ts
-function formatMDXDetails(dataOpen): MDXString;
+function formatMDXDetails(option): MDXString;
 ```
 
-Defined in: [hugo/index.ts:92](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L92)
+Defined in: [hugo/index.ts:90](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L90)
 
 Formats a collapsible block as an HTML `<details>` element.
 
 #### Parameters
 
-##### dataOpen
+##### option
 
 `CollapsibleOption`
 
-Label shown when the section is collapsed (used as `<summary>` text)
+Configuration for open/close label text
 
 #### Returns
 
@@ -160,7 +160,7 @@ HTML `<details>`/`<summary>` block string
 function formatMDXFrontmatter(props, formatted): MDXString;
 ```
 
-Defined in: [hugo/index.ts:108](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L108)
+Defined in: [hugo/index.ts:106](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L106)
 
 Formats YAML front matter wrapped in `---` delimiters, with page title rendered as H1 heading.
 Falls back to serializing `props` via formatFrontMatterObject when `formatted` is not provided.
@@ -192,21 +192,21 @@ Formatted front matter block with H1 title heading, or empty string if no data
 ### formatMDXLink()
 
 ```ts
-function formatMDXLink(text): TypeLink;
+function formatMDXLink(link): TypeLink;
 ```
 
-Defined in: [hugo/index.ts:137](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L137)
+Defined in: [hugo/index.ts:134](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/hugo/index.ts#L134)
 
 Strips the `.md` extension from internal links.
 Hugo serves pages at extensionless URLs — links with `.md` would 404 in the built site.
 
 #### Parameters
 
-##### text
+##### link
 
 `TypeLink`
 
-Display text for the link
+Link data with text and URL; `.md` extension is removed from the URL if present
 
 #### Returns
 

--- a/packages/formatters/docs/mdbook.md
+++ b/packages/formatters/docs/mdbook.md
@@ -15,7 +15,7 @@ Exports `afterRenderFilesHook` to build `SUMMARY.md` after all pages are written
 const afterRenderFilesHook: RenderFilesHook;
 ```
 
-Defined in: [mdbook/index.ts:222](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mdbook/index.ts#L222)
+Defined in: [mdbook/index.ts:208](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mdbook/index.ts#L208)
 
 Builds `src/SUMMARY.md` after all pages have been written.
 
@@ -31,7 +31,7 @@ by top-level section (Operations / Types) and category, then writes the file.
 const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook;
 ```
 
-Defined in: [mdbook/index.ts:162](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mdbook/index.ts#L162)
+Defined in: [mdbook/index.ts:163](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mdbook/index.ts#L163)
 
 Rewrites absolute generated doc links to page-relative `.md` paths after each page is rendered.
 
@@ -62,7 +62,7 @@ mdBook expects `.md` files; override the default `.mdx` extension.
 function createMDXFormatter(_meta?): Formatter;
 ```
 
-Defined in: [mdbook/index.ts:189](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mdbook/index.ts#L189)
+Defined in: [mdbook/index.ts:174](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mdbook/index.ts#L174)
 
 Creates an mdBook formatter.
 
@@ -88,7 +88,7 @@ A complete Formatter implementation for mdBook output
 function formatMDXAdmonition(admonition, _meta): MDXString;
 ```
 
-Defined in: [mdbook/index.ts:62](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mdbook/index.ts#L62)
+Defined in: [mdbook/index.ts:63](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mdbook/index.ts#L63)
 
 Formats an admonition using mdBook's native admonition syntax (`> [!TYPE]`).
 Uses `type` for the admonition tag and `title` as an optional override label.
@@ -121,7 +121,7 @@ Formatted admonition string
 function formatMDXBadge(badge): MDXString;
 ```
 
-Defined in: [mdbook/index.ts:51](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mdbook/index.ts#L51)
+Defined in: [mdbook/index.ts:52](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mdbook/index.ts#L52)
 
 Formats a badge as Markdown bold text — mdBook has no badge component.
 
@@ -147,7 +147,7 @@ Formatted bold text string
 function formatMDXDetails(option): MDXString;
 ```
 
-Defined in: [mdbook/index.ts:83](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mdbook/index.ts#L83)
+Defined in: [mdbook/index.ts:84](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mdbook/index.ts#L84)
 
 Renders a deprecated section as a bold inline label.
 
@@ -180,7 +180,7 @@ Bold label + split marker
 function formatMDXFrontmatter(_props, formatted): MDXString;
 ```
 
-Defined in: [mdbook/index.ts:95](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mdbook/index.ts#L95)
+Defined in: [mdbook/index.ts:96](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mdbook/index.ts#L96)
 
 Replaces front matter with an H1 title heading.
 mdBook renders `---` YAML blocks as literal content, so front matter is

--- a/packages/formatters/docs/mkdocs.md
+++ b/packages/formatters/docs/mkdocs.md
@@ -13,7 +13,7 @@ and visible page headings.
 const __default: object;
 ```
 
-Defined in: [mkdocs/index.ts:34](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L34)
+Defined in: [mkdocs/index.ts:35](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L35)
 
 #### Type Declaration
 
@@ -61,6 +61,32 @@ The `TypeLink` object to format
 
 The unmodified `TypeLink` object
 
+##### formatMDXPermalink
+
+```ts
+formatMDXPermalink: (id) => MDXString;
+```
+
+Formats a permalink for a section header using the classic `{#id}` syntax.
+
+This is the syntax supported by most Markdown-based generators (Hugo,
+mdBook, DocFX, MkDocs with `attr_list`). Presets targeting a framework that
+expects another syntax override this function.
+
+###### Parameters
+
+###### id
+
+`string`
+
+The ID of the section header
+
+###### Returns
+
+`MDXString`
+
+Formatted permalink string
+
 ---
 
 ### afterRenderTypeEntitiesHook
@@ -69,7 +95,7 @@ The unmodified `TypeLink` object
 const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook;
 ```
 
-Defined in: [mkdocs/index.ts:154](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L154)
+Defined in: [mkdocs/index.ts:155](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L155)
 
 Lifecycle hook that rewrites generated absolute GraphQL-Markdown links
 into page-relative `.md` links compatible with MkDocs validation.
@@ -88,7 +114,7 @@ Hook payload containing the current file path and renderer output context
 const mdxExtension: ".md";
 ```
 
-Defined in: [mkdocs/index.ts:147](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L147)
+Defined in: [mkdocs/index.ts:148](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L148)
 
 File extension used for generated pages — MkDocs uses standard Markdown (.md) files.
 
@@ -100,7 +126,7 @@ File extension used for generated pages — MkDocs uses standard Markdown (.md) 
 function createMDXFormatter(_meta?): Formatter;
 ```
 
-Defined in: [mkdocs/index.ts:183](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L183)
+Defined in: [mkdocs/index.ts:168](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L168)
 
 Creates an MkDocs Material formatter.
 
@@ -126,7 +152,7 @@ A complete Formatter implementation for MkDocs Material output
 function formatMDXAdmonition(admonition, _meta): MDXString;
 ```
 
-Defined in: [mkdocs/index.ts:88](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L88)
+Defined in: [mkdocs/index.ts:90](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L90)
 
 Formats an admonition using MkDocs Material `!!!` block syntax.
 Content is indented by 4 spaces as required by the spec.
@@ -159,7 +185,7 @@ Formatted admonition string
 function formatMDXBadge(badge): MDXString;
 ```
 
-Defined in: [mkdocs/index.ts:77](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L77)
+Defined in: [mkdocs/index.ts:79](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L79)
 
 Formats a badge as an inline HTML mark element.
 
@@ -185,7 +211,7 @@ Formatted badge string
 function formatMDXDetails(option): MDXString;
 ```
 
-Defined in: [mkdocs/index.ts:102](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L102)
+Defined in: [mkdocs/index.ts:104](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L104)
 
 Formats a collapsible block as an HTML `<details>` element.
 
@@ -211,7 +237,7 @@ Formatted collapsible string
 function formatMDXFrontmatter(_props, formatted): MDXString;
 ```
 
-Defined in: [mkdocs/index.ts:115](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L115)
+Defined in: [mkdocs/index.ts:117](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L117)
 
 Formats page title as a visible H1 heading.
 
@@ -243,7 +269,7 @@ Visible heading string, or empty string if no title is available
 function formatMDXNameEntity(name, parentType?): MDXString;
 ```
 
-Defined in: [mkdocs/index.ts:129](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L129)
+Defined in: [mkdocs/index.ts:130](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L130)
 
 Formats a named entity as a backtick code span.
 
@@ -275,7 +301,7 @@ Formatted entity reference string
 function formatMDXSpecifiedByLink(url): MDXString;
 ```
 
-Defined in: [mkdocs/index.ts:142](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L142)
+Defined in: [mkdocs/index.ts:143](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/formatters/src/mkdocs/index.ts#L143)
 
 Formats a "specified by" link as a standard Markdown link.
 

--- a/packages/formatters/src/defaults.ts
+++ b/packages/formatters/src/defaults.ts
@@ -17,7 +17,10 @@ import type {
   MetaInfo,
   TypeLink,
 } from "@graphql-markdown/types";
-import { formatMarkdownFrontmatter } from "@graphql-markdown/helpers";
+import {
+  extractFrontmatterTitle,
+  formatMarkdownFrontmatter,
+} from "@graphql-markdown/helpers";
 import {
   FRONT_MATTER_DELIMITER,
   MARKDOWN_EOL,
@@ -83,6 +86,24 @@ export const formatMDXFrontmatter = (
     FRONT_MATTER_DELIMITER,
     MARKDOWN_EOL,
   ) as MDXString;
+};
+
+/**
+ * Formats the page title as a visible H1 heading, for frameworks that render
+ * YAML front matter as literal page content and so must suppress it entirely.
+ * @param formatted - Pre-formatted front matter lines
+ * @param trailingEol - Whether to append a trailing end-of-line after the heading
+ * @returns `# Title` heading, or empty string if no title is available
+ */
+export const formatMDXFrontmatterTitleOnly = (
+  formatted: Maybe<string[]>,
+  trailingEol = false,
+): MDXString => {
+  const title = extractFrontmatterTitle(formatted);
+  if (!title) {
+    return "" as MDXString;
+  }
+  return `# ${title}${trailingEol ? MARKDOWN_EOL : ""}` as MDXString;
 };
 
 /**

--- a/packages/formatters/src/docfx/index.ts
+++ b/packages/formatters/src/docfx/index.ts
@@ -231,8 +231,8 @@ const rewriteInternalLinks = (
       pos = urlStart;
       continue;
     }
-    out.push(content.slice(pos, markerPos));
     out.push(
+      content.slice(pos, markerPos),
       resolveLink(
         match.urlWithHash,
         filePath,
@@ -424,7 +424,10 @@ export const afterRenderTypeEntitiesHook: RenderTypeEntitiesHook = async (
     return;
   }
 
-  const withUid = content.replace(/^(\s*)uid:.*$/m, `$1uid: ${uid}`);
+  // [ \t]* rather than \s* keeps the match within a single line: \s also
+  // matches newlines, which would overlap with the `m`-flag line anchors and
+  // cause polynomial backtracking when no "uid:" line is present.
+  const withUid = content.replace(/^([ \t]*)uid:.*$/m, `$1uid: ${uid}`);
   const rewritten = rewriteInternalLinks(withUid, filePath, outputDir, baseURL);
 
   if (rewritten !== content) {

--- a/packages/formatters/src/hugo/index.ts
+++ b/packages/formatters/src/hugo/index.ts
@@ -69,9 +69,7 @@ export const formatMDXBadge = ({ text }: Badge): MDXString => {
 /**
  * Formats an admonition using Hugo GitHub-style alert syntax (`> [!TYPE]`).
  * Requires Hugo 0.132 or later.
- * @param text - The admonition body text
- * @param title - Optional title rendered as bold text after the alert type line
- * @param type - Admonition type (e.g. `note`, `warning`, `danger`) mapped via {@link ALERT_TYPE_MAP}
+ * @param admonition - Admonition data with text, optional title, and type (e.g. `note`, `warning`, `danger`) mapped via {@link ALERT_TYPE_MAP}
  * @param _meta - Unused metadata parameter
  * @returns Formatted blockquote alert string
  */
@@ -86,8 +84,7 @@ export const formatMDXAdmonition = (
 
 /**
  * Formats a collapsible block as an HTML `<details>` element.
- * @param dataOpen - Label shown when the section is collapsed (used as `<summary>` text)
- * @param dataClose - Label shown inside the expanded section
+ * @param option - Configuration for open/close label text
  * @returns HTML `<details>`/`<summary>` block string
  */
 export const formatMDXDetails = ({
@@ -131,8 +128,7 @@ export const formatMDXFrontmatter = (
 /**
  * Strips the `.md` extension from internal links.
  * Hugo serves pages at extensionless URLs — links with `.md` would 404 in the built site.
- * @param text - Display text for the link
- * @param url - Link target URL, with `.md` extension removed if present
+ * @param link - Link data with text and URL; `.md` extension is removed from the URL if present
  * @returns Link object with the cleaned URL
  */
 export const formatMDXLink = ({ text, url }: TypeLink): TypeLink => {

--- a/packages/formatters/src/mdbook/index.ts
+++ b/packages/formatters/src/mdbook/index.ts
@@ -27,7 +27,6 @@ import type {
 } from "@graphql-markdown/types";
 import {
   appendExtensionToAbsolutePathWithoutExtension,
-  extractFrontmatterTitle,
   quoteMarkdownLines,
 } from "@graphql-markdown/helpers";
 import {
@@ -38,6 +37,7 @@ import {
 } from "@graphql-markdown/utils";
 import {
   formatMDXBullet,
+  formatMDXFrontmatterTitleOnly,
   formatMDXNameEntity,
   formatMDXPermalink,
   formatMDXSpecifiedByLink,
@@ -97,8 +97,7 @@ export const formatMDXFrontmatter = (
   _props: Maybe<FrontMatterOptions>,
   formatted: Maybe<string[]>,
 ): MDXString => {
-  const title = extractFrontmatterTitle(formatted);
-  return (title ? `# ${title}${MARKDOWN_EOL}` : "") as MDXString;
+  return formatMDXFrontmatterTitleOnly(formatted, true);
 };
 
 /** mdBook expects `.md` files; override the default `.mdx` extension. */

--- a/packages/formatters/src/mkdocs/index.ts
+++ b/packages/formatters/src/mkdocs/index.ts
@@ -18,10 +18,7 @@ import type {
   MetaInfo,
   RenderTypeEntitiesHook,
 } from "@graphql-markdown/types";
-import {
-  extractFrontmatterTitle,
-  indentMarkdownLines,
-} from "@graphql-markdown/helpers";
+import { indentMarkdownLines } from "@graphql-markdown/helpers";
 import {
   MARKDOWN_EOL,
   MARKDOWN_EOP,
@@ -29,6 +26,7 @@ import {
 } from "@graphql-markdown/utils";
 import {
   formatMDXBullet,
+  formatMDXFrontmatterTitleOnly,
   formatMDXLink,
   formatMDXPermalink,
 } from "../defaults";
@@ -120,8 +118,7 @@ export const formatMDXFrontmatter = (
   _props: Maybe<FrontMatterOptions>,
   formatted: Maybe<string[]>,
 ): MDXString => {
-  const title = extractFrontmatterTitle(formatted);
-  return title ? (`# ${title}` as MDXString) : ("" as MDXString);
+  return formatMDXFrontmatterTitleOnly(formatted);
 };
 
 /**

--- a/packages/graphql/docs/loader.md
+++ b/packages/graphql/docs/loader.md
@@ -2,6 +2,32 @@
 
 Library for GraphQL schema loading and `loaders` config processing.
 
+## Interfaces
+
+### LoadSchemaConfig
+
+Defined in: [packages/graphql/src/loader.ts:20](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/graphql/src/loader.ts#L20)
+
+#### Extends
+
+- `LoadSchemaOptions`
+
+#### Indexable
+
+```ts
+[key: string]: any
+```
+
+#### Properties
+
+##### rootTypes?
+
+```ts
+optional rootTypes?: Partial<Record<OperationTypeNode, string>>;
+```
+
+Defined in: [packages/graphql/src/loader.ts:21](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/graphql/src/loader.ts#L21)
+
 ## Functions
 
 ### getDocumentLoaders()
@@ -40,7 +66,7 @@ Defined in: [packages/graphql/src/loader.ts:48](https://github.com/graphql-markd
 
 ##### options
 
-`LoadSchemaConfig`
+[`LoadSchemaConfig`](#loadschemaconfig)
 
 #### Returns
 

--- a/packages/graphql/src/introspection.ts
+++ b/packages/graphql/src/introspection.ts
@@ -363,7 +363,7 @@ export const getTypeDirectiveValuesList = (
       return getDirectiveValues(directive, { directives: [directiveNode] });
     })
     .filter((values): values is Record<string, unknown> => {
-      return typeof values !== "undefined";
+      return values !== undefined;
     });
 };
 

--- a/packages/graphql/src/loader.ts
+++ b/packages/graphql/src/loader.ts
@@ -17,7 +17,7 @@ import type {
   PackageOptionsConfig,
 } from "@graphql-markdown/types";
 
-interface LoadSchemaConfig extends LoadSchemaOptions {
+export interface LoadSchemaConfig extends LoadSchemaOptions {
   rootTypes?: Partial<Record<OperationTypeNode, string>>;
 }
 

--- a/packages/graphql/tests/unit/introspection.test.ts
+++ b/packages/graphql/tests/unit/introspection.test.ts
@@ -203,28 +203,16 @@ describe("introspection", () => {
   });
 
   describe("getTypeName()", () => {
-    test("returns type name for object", () => {
+    test.each([
+      { kind: "object", typeName: "Tweet" },
+      { kind: "interface", typeName: "Node" },
+      { kind: "scalar", typeName: "ID" },
+    ])("returns type name for $kind", ({ typeName }) => {
       expect.hasAssertions();
 
-      const name = getTypeName(schema.getType("Tweet")!);
+      const name = getTypeName(schema.getType(typeName)!);
 
-      expect(name).toBe("Tweet");
-    });
-
-    test("returns type name for interface", () => {
-      expect.hasAssertions();
-
-      const name = getTypeName(schema.getType("Node")!);
-
-      expect(name).toBe("Node");
-    });
-
-    test("returns type name for scalar", () => {
-      expect.hasAssertions();
-
-      const name = getTypeName(schema.getType("ID")!);
-
-      expect(name).toBe("ID");
+      expect(name).toBe(typeName);
     });
 
     test("returns default name for unknown", () => {

--- a/packages/tooling-config/scripts/docs-api.mjs
+++ b/packages/tooling-config/scripts/docs-api.mjs
@@ -19,6 +19,7 @@ import { once } from "node:events";
 
 const API_DIR = "./api";
 const WORKSPACE = "@graphql-markdown";
+const CATEGORY_MAX_DEPTH = 3;
 
 const TYPEDOC_OPTIONS_PATH = fileURLToPath(
   import.meta.resolve("../typedoc/api.mjs"),
@@ -166,7 +167,11 @@ async function createCategoryFiles(
 async function writeAllCategoryFiles() {
   for (const entry of await readdir(API_DIR, { withFileTypes: true })) {
     if (entry.isDirectory()) {
-      await createCategoryFiles(join(API_DIR, entry.name), 1, 3);
+      await createCategoryFiles(
+        join(API_DIR, entry.name),
+        1,
+        CATEGORY_MAX_DEPTH,
+      );
     }
   }
 }

--- a/packages/types/src/graphql.d.ts
+++ b/packages/types/src/graphql.d.ts
@@ -201,7 +201,7 @@ export interface RelationOf<T> {
  * @typeParam T - Type to make writeable
  * @internal
  */
-type Writeable<T> = {
+export type Writeable<T> = {
   -readonly [P in keyof T]: T[P];
 };
 

--- a/packages/types/src/logger.d.ts
+++ b/packages/types/src/logger.d.ts
@@ -1,5 +1,5 @@
 /** Represents the available logging levels */
-type LogLevel = "debug" | "error" | "info" | "log" | "success" | "warn";
+export type LogLevel = "debug" | "error" | "info" | "log" | "success" | "warn";
 
 /** Interface for logger implementation */
 export interface LoggerType {

--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -27,6 +27,16 @@ const normalizeRelativePath = (path: string): string => {
     : `./${normalizedPath}`;
 };
 
+// Manual scan instead of a trailing `\/+$` regex, which is unanchored at the
+// start and so retries at every position with polynomial worst-case time.
+const stripTrailingSlashes = (value: string): string => {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") {
+    end--;
+  }
+  return value.slice(0, end);
+};
+
 /**
  * Converts a generated absolute GraphQL-Markdown doc URL into a page-relative file path.
  * Returns `undefined` when the target URL does not belong to the configured `baseURL`.
@@ -38,9 +48,9 @@ export const toRelativeGeneratedDocLink = ({
   outputDir,
   targetUrlPath,
 }: RelativeGeneratedDocLinkOptions): string | undefined => {
-  const normalizedBaseURL = baseURL
-    .replaceAll(/^\/+/g, "")
-    .replaceAll(/\/+$/g, "");
+  const normalizedBaseURL = stripTrailingSlashes(
+    baseURL.replaceAll(/^\/+/g, ""),
+  );
   const basePrefix = `/${normalizedBaseURL}/`;
 
   if (!targetUrlPath.startsWith(basePrefix)) {


### PR DESCRIPTION
# Description

Fixes from a full-codebase review focused on dead code, public API coherence, and duplication — plus repo-wide SonarCloud findings and GitHub AI code-review findings addressed while the branch was open.

## Code review fixes
- **Public API leaks** — `CancellableEventEmitter`, `LoadSchemaConfig`, `ThrowOptions`, `Writeable` and `LogLevel` were referenced in the signatures of exported functions/interfaces (`getEvents`, `loadSchema`, `loadConfiguration`, `ExtensionProjectConfig`, `LoggerType`) without being exported themselves, leaving consumers unable to name the types they were handed. All five are now exported.
- **Boolean-flag resolution duplication** — `sectionHeaderId`, `parentTypePrefix` and `typeBadges` each re-implemented the same "`--noX` CLI flag disables, else config, else default" logic with a different expression. Extracted `resolveNegatableOption()` in `packages/core/src/config.ts` so all three share one implementation (behavior unchanged, verified against the existing test suite).
- **Formatter duplication** — `mdbook` and `mkdocs` each hand-rolled the same "suppress front matter, render the title as a bare H1" behavior. Extracted `formatMDXFrontmatterTitleOnly()` into `packages/formatters/src/defaults.ts` alongside the other shared formatter baselines.
- Regenerated TypeDoc output for the modules touched above, and fixed pre-existing JSDoc/param-name mismatches in `hugo/index.ts` that were causing 4 TypeDoc warnings.

`parseDeprecatedPrintTypeOptions`/`parseDeprecatedDocOptions` (no-op stubs) were intentionally left in place — they're scaffolding for the ongoing config-setting rename initiative, not dead code to remove.

## SonarCloud findings (repo-wide, not just this branch's diff)
- `introspection.ts` — compare with `undefined` directly instead of `typeof` (S7741)
- `docfx/index.ts` — merged consecutive `Array#push` calls (S7778); narrowed a frontmatter-rewrite regex from `\s*` to `[ \t]*` so it can't span lines and cause polynomial backtracking (S8786)
- `utils/url.ts` — replaced an unanchored trailing-slash regex with a linear manual scan (S8786)
- `core/events/schema-load.ts` — dropped a redundant `Maybe<T>` wrapper on already-optional fields, keeping `| null` where a caller relies on it (S4782)
- `graphql-config.test.ts` / `introspection.test.ts` — parameterized two sets of near-identical tests into `test.each` (S5976)
- `renderer.test.ts` — renamed a duplicate test title; the two tests were actually distinct, and the duplicate's title didn't match its own body (S8754)

**Not addressed here:** `renderer.ts`'s `Renderer` constructor and `getRenderer()` factory both took 8 parameters (Sonar S107, max 7). That's fixed in the stacked follow-up PR #3302 instead — consolidating into an options object touches ~70 call sites, larger and riskier than the rest of this cleanup.

## GitHub AI code-review findings
- `docusaurus/index.ts`: dropped `options.mdxParser` from a silent fallback that bypassed the deprecation warning the CLI/config-file paths already surface; replaced a blind `as unknown as` cast with a runtime type guard (`isCommanderCompatibleCommand`/`assertCommanderCompatibleCommand`) that throws a clear error instead of silently miscasting.
- `docs-api.mjs`: named the magic number `3` as `CATEGORY_MAX_DEPTH`.
- (6 of the 9 findings were already resolved on `main` from an earlier PR; nothing to do there.)

## SonarCloud quality gate fix
- `docusaurus/index.ts` and `core/index.ts` carried a stale `/* istanbul ignore file */` comment — Jest/Istanbul syntax this project's Vitest `v8` coverage provider doesn't recognize. It silently dropped these files from the coverage report instead of properly excluding them, and since SonarCloud has no config-level exclusion for them either, missing data read as 0% on every line. That was invisible while `docusaurus/index.ts` was thin wiring, but the new type guard above pushed `new_coverage` to 0% and failed the quality gate (required: 80%). Removed the comment from both files — the docusaurus file already had full test coverage once measured (100% line/branch), and the core file is a pure re-export barrel with zero coverable statements either way. `cli/src/main.ts` keeps its ignore comment: it's the actual CLI binary entry point with a real side-effecting top-level IIFE that no test imports, so removing it there would trade nothing for a future gate risk.

Verified with `fallow dead-code --private-type-leaks` (clean before/after comparison) and a full `turbo run test:unit ts:check lint` across the workspace (41/41 tasks passing) after every commit.

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)