### PR TITLE
♻️ Renderer/getRenderer: consolidate params into an options object

### DIFF
--- a/packages/core/docs/generator.md
+++ b/packages/core/docs/generator.md
@@ -19,7 +19,7 @@ function checkSchemaDifferences(
 ): Promise<boolean>;
 ```
 
-Defined in: [core/src/generator.ts:270](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/generator.ts#L270)
+Defined in: [packages/core/src/generator.ts:270](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/generator.ts#L270)
 
 Checks if there are differences in the GraphQL schema compared to a previous version.
 
@@ -68,7 +68,7 @@ When no changes are detected, a log message is generated indicating that the sch
 function generateDocFromSchema(options): Promise<void>;
 ```
 
-Defined in: [core/src/generator.ts:344](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/generator.ts#L344)
+Defined in: [packages/core/src/generator.ts:343](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/generator.ts#L343)
 
 Main entry point for generating Markdown documentation from a GraphQL schema.
 
@@ -105,7 +105,7 @@ function getFormatterFromMDXModule(
 ): Partial<Formatter> | undefined;
 ```
 
-Defined in: [core/src/generator.ts:173](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/generator.ts#L173)
+Defined in: [packages/core/src/generator.ts:174](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/generator.ts#L174)
 
 **`Internal`**
 
@@ -144,7 +144,7 @@ A partial Formatter with the found functions, or undefined if none found
 function getMDXModuleProperty<T>(mdxModule, propertyName): T | undefined;
 ```
 
-Defined in: [core/src/generator.ts:136](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/generator.ts#L136)
+Defined in: [packages/core/src/generator.ts:137](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/generator.ts#L137)
 
 **`Internal`**
 
@@ -189,7 +189,7 @@ function loadGraphqlSchema(
 ): Promise<Maybe<GraphQLSchema>>;
 ```
 
-Defined in: [core/src/generator.ts:237](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/generator.ts#L237)
+Defined in: [packages/core/src/generator.ts:238](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/generator.ts#L238)
 
 **`Internal`**
 
@@ -226,7 +226,7 @@ A promise that resolves to the loaded GraphQL schema, or undefined if:
 function loadMDXModule(mdxParser): Promise<unknown>;
 ```
 
-Defined in: [core/src/generator.ts:95](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/generator.ts#L95)
+Defined in: [packages/core/src/generator.ts:95](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/generator.ts#L95)
 
 **`Internal`**
 
@@ -261,7 +261,7 @@ function resolveSkipAndOnlyDirectives(
 ): GraphQLDirective[][];
 ```
 
-Defined in: [core/src/generator.ts:303](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/generator.ts#L303)
+Defined in: [packages/core/src/generator.ts:302](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/generator.ts#L302)
 
 Resolves and retrieves GraphQL directive objects from the schema based on their names.
 

--- a/packages/core/docs/renderer.md
+++ b/packages/core/docs/renderer.md
@@ -4,7 +4,7 @@
 
 ### Renderer
 
-Defined in: [core/src/renderer.ts:342](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L342)
+Defined in: [packages/core/src/renderer.ts:376](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L376)
 
 Core renderer class responsible for generating documentation files from GraphQL schema entities.
 Handles the conversion of schema types to markdown/MDX documentation with proper organization.
@@ -27,63 +27,20 @@ Each level has its own CategoryPositionManager that restarts numbering at 1.
 ##### Constructor
 
 ```ts
-new Renderer(
-   printer,
-   outputDir,
-   baseURL,
-   group,
-   prettify,
-   docOptions,
-   mdxExtension): Renderer;
+new Renderer(options): Renderer;
 ```
 
-Defined in: [core/src/renderer.ts:366](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L366)
+Defined in: [packages/core/src/renderer.ts:395](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L395)
 
 Creates a new Renderer instance.
 
 ###### Parameters
 
-###### printer
+###### options
 
-_typeof_ `IPrinter`
+[`RendererOptions`](#rendereroptions-1)
 
-The printer instance used to convert GraphQL types to markdown
-
-###### outputDir
-
-`string`
-
-Directory where documentation will be generated
-
-###### baseURL
-
-`string`
-
-Base URL for the documentation
-
-###### group
-
-`Maybe`&lt;`Partial`&lt;`Record`&lt;`SchemaEntity`, `Record`&lt;`string`, `Maybe`&lt;`string`&gt;&gt;&gt;&gt;&gt;
-
-Optional grouping configuration for schema entities
-
-###### prettify
-
-`boolean`
-
-Whether to format the generated markdown
-
-###### docOptions
-
-`Maybe`&lt;`RendererDocOptions`&gt;
-
-Additional documentation options
-
-###### mdxExtension
-
-`string`
-
-Optional MDX file extension to use
+Renderer construction options
 
 ###### Returns
 
@@ -103,7 +60,7 @@ Optional MDX file extension to use
 readonly baseURL: string;
 ```
 
-Defined in: [core/src/renderer.ts:345](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L345)
+Defined in: [packages/core/src/renderer.ts:379](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L379)
 
 ##### group
 
@@ -111,7 +68,7 @@ Defined in: [core/src/renderer.ts:345](https://github.com/graphql-markdown/graph
 readonly group: Maybe<Partial<Record<SchemaEntity, Record<string, Maybe<string>>>>>;
 ```
 
-Defined in: [core/src/renderer.ts:343](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L343)
+Defined in: [packages/core/src/renderer.ts:377](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L377)
 
 ##### mdxExtension
 
@@ -119,7 +76,7 @@ Defined in: [core/src/renderer.ts:343](https://github.com/graphql-markdown/graph
 readonly mdxExtension: string;
 ```
 
-Defined in: [core/src/renderer.ts:348](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L348)
+Defined in: [packages/core/src/renderer.ts:382](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L382)
 
 ##### options
 
@@ -127,7 +84,15 @@ Defined in: [core/src/renderer.ts:348](https://github.com/graphql-markdown/graph
 readonly options: Maybe<RendererDocOptions>;
 ```
 
-Defined in: [core/src/renderer.ts:347](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L347)
+Defined in: [packages/core/src/renderer.ts:381](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L381)
+
+##### outputAdapter
+
+```ts
+readonly outputAdapter: OutputAdapter;
+```
+
+Defined in: [packages/core/src/renderer.ts:383](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L383)
 
 ##### outputDir
 
@@ -135,7 +100,7 @@ Defined in: [core/src/renderer.ts:347](https://github.com/graphql-markdown/graph
 readonly outputDir: string;
 ```
 
-Defined in: [core/src/renderer.ts:344](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L344)
+Defined in: [packages/core/src/renderer.ts:378](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L378)
 
 ##### prettify
 
@@ -143,7 +108,7 @@ Defined in: [core/src/renderer.ts:344](https://github.com/graphql-markdown/graph
 readonly prettify: boolean;
 ```
 
-Defined in: [core/src/renderer.ts:346](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L346)
+Defined in: [packages/core/src/renderer.ts:380](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L380)
 
 #### Methods
 
@@ -153,10 +118,11 @@ Defined in: [core/src/renderer.ts:346](https://github.com/graphql-markdown/graph
 generateCategoryMetafileType(
    type,
    name,
-   rootTypeName): Promise<string>;
+   rootTypeName
+): Promise<string>;
 ```
 
-Defined in: [core/src/renderer.ts:469](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L469)
+Defined in: [packages/core/src/renderer.ts:500](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L500)
 
 Generates the directory path and metafiles for a specific schema entity type.
 Creates the appropriate directory structure based on configuration options.
@@ -199,10 +165,11 @@ The generated directory path
 generateIndexMetafile(
    dirPath,
    category,
-   options?): Promise<void>;
+   options?
+): Promise<void>;
 ```
 
-Defined in: [core/src/renderer.ts:414](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L414)
+Defined in: [packages/core/src/renderer.ts:445](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L445)
 
 Generates an index metafile for a category directory if MDX support is available.
 
@@ -247,7 +214,7 @@ await renderer.generateIndexMetafile("docs/types", "Types", {
 preCollectCategories(rootTypeNames): void;
 ```
 
-Defined in: [core/src/renderer.ts:759](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L759)
+Defined in: [packages/core/src/renderer.ts:796](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L796)
 
 Pre-collects all category names that will be generated during rendering.
 This allows the position manager to assign consistent positions before
@@ -283,7 +250,7 @@ Array of root type names from the schema
 renderHomepage(homepageLocation): Promise<void>;
 ```
 
-Defined in: [core/src/renderer.ts:809](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L809)
+Defined in: [packages/core/src/renderer.ts:846](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L846)
 
 Renders the homepage for the documentation from a template file.
 Replaces placeholders in the template with actual values.
@@ -314,7 +281,7 @@ Promise that resolves when the homepage is rendered
 renderRootTypes(rootTypeName, type): Promise<Maybe<Maybe<Category>[]>>;
 ```
 
-Defined in: [core/src/renderer.ts:553](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L553)
+Defined in: [packages/core/src/renderer.ts:584](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L584)
 
 Renders all types within a root type category (e.g., all Query types).
 
@@ -351,10 +318,12 @@ renderTypeEntities(
    dirPath,
    name,
    type,
-   operationNamespaceParts?): Promise<Maybe<Category>>;
+   operationNamespaceParts?,
+   entity?
+): Promise<Maybe<Category>>;
 ```
 
-Defined in: [core/src/renderer.ts:620](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L620)
+Defined in: [packages/core/src/renderer.ts:654](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L654)
 
 Renders documentation for a specific type entity and saves it to a file.
 
@@ -382,6 +351,14 @@ The type entity to render
 
 `string`[]
 
+The namespace parts for a namespaced operation
+
+###### entity?
+
+`SchemaEntity`
+
+The schema entity kind being rendered, e.g. `queries`
+
 ###### Returns
 
 `Promise`&lt;`Maybe`&lt;`Category`&gt;&gt;
@@ -398,7 +375,7 @@ The category information for the rendered entity or undefined
 
 ### CategoryMetafileOptions
 
-Defined in: [core/src/renderer.ts:223](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L223)
+Defined in: [packages/core/src/renderer.ts:221](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L221)
 
 Configuration options for category metafiles in the documentation.
 These options control the appearance and behavior of category sections in the sidebar.
@@ -424,7 +401,7 @@ const options: CategoryMetafileOptions = {
 optional collapsed?: boolean;
 ```
 
-Defined in: [core/src/renderer.ts:225](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L225)
+Defined in: [packages/core/src/renderer.ts:223](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L223)
 
 Whether the category should be initially collapsed
 
@@ -434,7 +411,7 @@ Whether the category should be initially collapsed
 optional collapsible?: boolean;
 ```
 
-Defined in: [core/src/renderer.ts:224](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L224)
+Defined in: [packages/core/src/renderer.ts:222](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L222)
 
 Whether the category should be collapsible in the sidebar
 
@@ -444,7 +421,7 @@ Whether the category should be collapsible in the sidebar
 optional sidebarPosition?: number;
 ```
 
-Defined in: [core/src/renderer.ts:226](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L226)
+Defined in: [packages/core/src/renderer.ts:224](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L224)
 
 Custom position in the sidebar (lower numbers appear first)
 
@@ -454,9 +431,99 @@ Custom position in the sidebar (lower numbers appear first)
 optional styleClass?: string;
 ```
 
-Defined in: [core/src/renderer.ts:227](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L227)
+Defined in: [packages/core/src/renderer.ts:225](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L225)
 
 CSS class to apply to the category for styling
+
+---
+
+### RendererOptions
+
+Defined in: [packages/core/src/renderer.ts:344](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L344)
+
+Constructor options for [Renderer](#renderer), and input to [getRenderer](#getrenderer).
+
+#### Properties
+
+##### baseURL
+
+```ts
+baseURL: string;
+```
+
+Defined in: [packages/core/src/renderer.ts:350](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L350)
+
+Base URL for the documentation
+
+##### docOptions
+
+```ts
+docOptions: Maybe<RendererDocOptions>;
+```
+
+Defined in: [packages/core/src/renderer.ts:356](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L356)
+
+Additional documentation options
+
+##### group
+
+```ts
+group: Maybe<Partial<Record<SchemaEntity, Record<string, Maybe<string>>>>>;
+```
+
+Defined in: [packages/core/src/renderer.ts:352](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L352)
+
+Optional grouping configuration for schema entities
+
+##### mdxExtension
+
+```ts
+mdxExtension: string;
+```
+
+Defined in: [packages/core/src/renderer.ts:358](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L358)
+
+Optional MDX file extension to use
+
+##### outputAdapter?
+
+```ts
+optional outputAdapter?: Maybe<OutputAdapter>;
+```
+
+Defined in: [packages/core/src/renderer.ts:360](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L360)
+
+Destination for generated pages; defaults to the local filesystem
+
+##### outputDir
+
+```ts
+outputDir: string;
+```
+
+Defined in: [packages/core/src/renderer.ts:348](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L348)
+
+Directory where documentation will be generated
+
+##### prettify
+
+```ts
+prettify: boolean;
+```
+
+Defined in: [packages/core/src/renderer.ts:354](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L354)
+
+Whether to format the generated markdown
+
+##### printer
+
+```ts
+printer: typeof IPrinter;
+```
+
+Defined in: [packages/core/src/renderer.ts:346](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L346)
+
+The printer instance used to convert GraphQL types to markdown
 
 ## Variables
 
@@ -466,7 +533,7 @@ CSS class to apply to the category for styling
 const API_GROUPS: Required<ApiGroupOverrideType>;
 ```
 
-Defined in: [core/src/renderer.ts:126](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L126)
+Defined in: [packages/core/src/renderer.ts:125](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L125)
 
 Default group names for API types and non-API types.
 This constant provides the base folder structure for organizing GraphQL schema entities.
@@ -495,7 +562,7 @@ const customGroups = { ...API_GROUPS, operations: "queries-and-mutations" };
 function getApiGroupFolder(type, groups?): string;
 ```
 
-Defined in: [core/src/renderer.ts:149](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L149)
+Defined in: [packages/core/src/renderer.ts:147](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L147)
 
 Determines the appropriate folder for a GraphQL schema entity based on its type.
 
@@ -534,65 +601,21 @@ const folder = getApiGroupFolder(objectType, { operations: "queries" }); // Retu
 ### getRenderer()
 
 ```ts
-function getRenderer(
-  printer,
-  outputDir,
-  baseURL,
-  group,
-  prettify,
-  docOptions,
-  mdxExtension,
-): Promise<Renderer>;
+function getRenderer(options): Promise<Renderer>;
 ```
 
-Defined in: [core/src/renderer.ts:1041](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L1041)
+Defined in: [packages/core/src/renderer.ts:1094](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L1094)
 
 Factory function to create and initialize a Renderer instance.
 Creates the output directory and returns a configured renderer.
 
 #### Parameters
 
-##### printer
+##### options
 
-_typeof_ `IPrinter`
+[`RendererOptions`](#rendereroptions-1)
 
-The printer instance to use for rendering types
-
-##### outputDir
-
-`string`
-
-The output directory for generated documentation
-
-##### baseURL
-
-`string`
-
-The base URL for the documentation
-
-##### group
-
-`Maybe`&lt;`Partial`&lt;`Record`&lt;`SchemaEntity`, `Record`&lt;`string`, `Maybe`&lt;`string`&gt;&gt;&gt;&gt;&gt;
-
-Optional grouping configuration
-
-##### prettify
-
-`boolean`
-
-Whether to prettify the output markdown
-
-##### docOptions
-
-`Maybe`&lt;`RendererDocOptions`&gt;
-
-Additional documentation options
-
-##### mdxExtension
-
-`string`
-
-Extension to use for MDX files
+Renderer construction options
 
 #### Returns
 
@@ -603,12 +626,46 @@ A configured Renderer instance
 #### Example
 
 ```typescript
-const renderer = await getRenderer(
-  myPrinter,
-  "./docs",
-  "/api",
-  groupConfig,
-  true,
-  { force: true, index: true },
-);
+const renderer = await getRenderer({
+  printer: myPrinter,
+  outputDir: "./docs",
+  baseURL: "/api",
+  group: groupConfig,
+  prettify: true,
+  docOptions: { force: true, index: true },
+  mdxExtension: ".mdx",
+});
 ```
+
+---
+
+### logHandlerErrors()
+
+```ts
+function logHandlerErrors(eventName, errors): void;
+```
+
+Defined in: [packages/core/src/renderer.ts:335](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L335)
+
+Reports errors thrown by event handlers.
+
+Handler errors are collected rather than thrown, so without this they are
+dropped and the formatter's post-processing silently does nothing.
+
+#### Parameters
+
+##### eventName
+
+`string`
+
+Name of the emitted event
+
+##### errors
+
+`Error`[]
+
+Errors collected from the handlers
+
+#### Returns
+
+`void`

--- a/packages/core/docs/renderer.md
+++ b/packages/core/docs/renderer.md
@@ -488,7 +488,7 @@ Optional MDX file extension to use
 ##### outputAdapter?
 
 ```ts
-optional outputAdapter?: Maybe<OutputAdapter>;
+optional outputAdapter?: OutputAdapter | null;
 ```
 
 Defined in: [packages/core/src/renderer.ts:360](https://github.com/graphql-markdown/graphql-markdown/blob/main/packages/core/src/renderer.ts#L360)

--- a/packages/core/src/generator.ts
+++ b/packages/core/src/generator.ts
@@ -481,13 +481,13 @@ export const generateDocFromSchema = async ({
     mdxExtension = FILE_EXTENSION.MD;
   }
 
-  const renderer = await getRenderer(
+  const renderer = await getRenderer({
     printer,
     outputDir,
     baseURL,
-    groups,
+    group: groups,
     prettify,
-    {
+    docOptions: {
       ...docOptions,
       deprecated: printTypeOptions?.deprecated,
       force,
@@ -495,7 +495,7 @@ export const generateDocFromSchema = async ({
     },
     mdxExtension,
     outputAdapter,
-  );
+  });
 
   // Pre-collect all categories before rendering to ensure consistent positions
   renderer.preCollectCategories(Object.keys(rootTypes));

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -339,6 +339,28 @@ export const logHandlerErrors = (eventName: string, errors: Error[]): void => {
 };
 
 /**
+ * Constructor options for {@link Renderer}, and input to {@link getRenderer}.
+ */
+export interface RendererOptions {
+  /** The printer instance used to convert GraphQL types to markdown */
+  printer: typeof IPrinter;
+  /** Directory where documentation will be generated */
+  outputDir: string;
+  /** Base URL for the documentation */
+  baseURL: string;
+  /** Optional grouping configuration for schema entities */
+  group: Maybe<SchemaEntitiesGroupMap>;
+  /** Whether to format the generated markdown */
+  prettify: boolean;
+  /** Additional documentation options */
+  docOptions: Maybe<RendererDocOptions>;
+  /** Optional MDX file extension to use */
+  mdxExtension: string;
+  /** Destination for generated pages; defaults to the local filesystem */
+  outputAdapter?: Maybe<OutputAdapter>;
+}
+
+/**
  * Core renderer class responsible for generating documentation files from GraphQL schema entities.
  * Handles the conversion of schema types to markdown/MDX documentation with proper organization.
  *
@@ -367,26 +389,19 @@ export class Renderer {
   /**
    * Creates a new Renderer instance.
    *
-   * @param printer - The printer instance used to convert GraphQL types to markdown
-   * @param outputDir - Directory where documentation will be generated
-   * @param baseURL - Base URL for the documentation
-   * @param group - Optional grouping configuration for schema entities
-   * @param prettify - Whether to format the generated markdown
-   * @param docOptions - Additional documentation options
-   * @param mdxExtension - Optional MDX file extension to use
-   * @param outputAdapter - Destination for generated pages; defaults to the local filesystem
+   * @param options - Renderer construction options
    * @example
    */
-  constructor(
-    printer: typeof IPrinter,
-    outputDir: string,
-    baseURL: string,
-    group: Maybe<SchemaEntitiesGroupMap>,
-    prettify: boolean,
-    docOptions: Maybe<RendererDocOptions>,
-    mdxExtension: string,
-    outputAdapter: Maybe<OutputAdapter> = undefined,
-  ) {
+  constructor({
+    printer,
+    outputDir,
+    baseURL,
+    group,
+    prettify,
+    docOptions,
+    mdxExtension,
+    outputAdapter = undefined,
+  }: RendererOptions) {
     this.printer = printer;
 
     this.group = group;
@@ -1060,42 +1075,37 @@ export class Renderer {
  * Factory function to create and initialize a Renderer instance.
  * Creates the output directory and returns a configured renderer.
  *
- * @param printer - The printer instance to use for rendering types
- * @param outputDir - The output directory for generated documentation
- * @param baseURL - The base URL for the documentation
- * @param group - Optional grouping configuration
- * @param prettify - Whether to prettify the output markdown
- * @param docOptions - Additional documentation options
- * @param mdxExtension - Extension to use for MDX files
+ * @param options - Renderer construction options
  * @returns A configured Renderer instance
  *
  * @example
  * ```typescript
- * const renderer = await getRenderer(
- *   myPrinter,
- *   './docs',
- *   '/api',
- *   groupConfig,
- *   true,
- *   { force: true, index: true }
- * );
+ * const renderer = await getRenderer({
+ *   printer: myPrinter,
+ *   outputDir: './docs',
+ *   baseURL: '/api',
+ *   group: groupConfig,
+ *   prettify: true,
+ *   docOptions: { force: true, index: true },
+ *   mdxExtension: '.mdx',
+ * });
  * ```
  */
-export const getRenderer = async (
-  printer: typeof IPrinter,
-  outputDir: string,
-  baseURL: string,
-  group: Maybe<SchemaEntitiesGroupMap>,
-  prettify: boolean,
-  docOptions: Maybe<RendererDocOptions>,
-  mdxExtension: string,
-  outputAdapter: Maybe<OutputAdapter> = undefined,
-): Promise<InstanceType<typeof Renderer>> => {
+export const getRenderer = async ({
+  printer,
+  outputDir,
+  baseURL,
+  group,
+  prettify,
+  docOptions,
+  mdxExtension,
+  outputAdapter = undefined,
+}: RendererOptions): Promise<InstanceType<typeof Renderer>> => {
   const adapter = outputAdapter ?? fsOutputAdapter;
   // Optional on the interface: a destination with no directory concept (an
   // object store, a CMS collection) has nothing to prepare.
   await adapter.ensureDir?.(outputDir, { forceEmpty: docOptions?.force });
-  return new Renderer(
+  return new Renderer({
     printer,
     outputDir,
     baseURL,
@@ -1103,6 +1113,6 @@ export const getRenderer = async (
     prettify,
     docOptions,
     mdxExtension,
-    adapter,
-  );
+    outputAdapter: adapter,
+  });
 };

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -357,7 +357,7 @@ export interface RendererOptions {
   /** Optional MDX file extension to use */
   mdxExtension: string;
   /** Destination for generated pages; defaults to the local filesystem */
-  outputAdapter?: Maybe<OutputAdapter>;
+  outputAdapter?: OutputAdapter | null;
 }
 
 /**

--- a/packages/core/tests/unit/generator.test.ts
+++ b/packages/core/tests/unit/generator.test.ts
@@ -218,20 +218,21 @@ describe("generator", () => {
           undefined,
           expect.anything(), // event emitter
         );
-        expect(rendererSpy).toHaveBeenCalledWith(
-          {},
-          options.outputDir,
-          options.baseURL,
-          undefined,
-          options.prettify,
-          {
+        expect(rendererSpy).toHaveBeenCalledWith({
+          printer: {},
+          outputDir: options.outputDir,
+          baseURL: options.baseURL,
+          group: undefined,
+          prettify: options.prettify,
+          docOptions: {
             ...options.docOptions,
             deprecated: options.printTypeOptions!.deprecated,
             hierarchy: options.printTypeOptions!.hierarchy,
           },
-          ".md",
-          undefined, // outputAdapter: unset, so the renderer falls back to the filesystem
-        );
+          mdxExtension: ".md",
+          // outputAdapter: unset, so the renderer falls back to the filesystem
+          outputAdapter: undefined,
+        });
       },
     );
 
@@ -623,7 +624,7 @@ describe("generator", () => {
       });
 
       // Verify the last argument (mdxExtension) is .mdx
-      expect(rendererSpy.mock.calls[0]![6]).toBe(".mdx");
+      expect(rendererSpy.mock.calls[0]![0].mdxExtension).toBe(".mdx");
     });
 
     test("uses custom mdxExtension from mdxModule when provided", async () => {
@@ -648,7 +649,7 @@ describe("generator", () => {
       });
 
       // Verify the last argument (mdxExtension) is the custom extension
-      expect(rendererSpy.mock.calls[0]![6]).toBe(".custom");
+      expect(rendererSpy.mock.calls[0]![0].mdxExtension).toBe(".custom");
     });
 
     test("does not use mdxDeclaration as file extension (regression test)", async () => {
@@ -677,7 +678,7 @@ describe("generator", () => {
       });
 
       // Should use mdxExtension (.mdx), not mdxDeclaration (the import statement)
-      expect(rendererSpy.mock.calls[0]![6]).toBe(".mdx");
+      expect(rendererSpy.mock.calls[0]![0].mdxExtension).toBe(".mdx");
     });
 
     test("calls resolveSkipAndOnlyDirectives with directive options and schema", async () => {

--- a/packages/core/tests/unit/renderer.generateCategoryMetafileType.spec.ts
+++ b/packages/core/tests/unit/renderer.generateCategoryMetafileType.spec.ts
@@ -83,14 +83,14 @@ describe("generateCategoryMetafileType - focused tests", () => {
   test("throws when outputDir is empty", async () => {
     expect.assertions(1);
 
-    const renderer: any = await getRenderer(
-      Printer as unknown as typeof IPrinter,
-      "/output",
-      baseURL,
-      undefined,
-      false,
-      DEFAULT_RENDERER_OPTIONS,
-    );
+    const renderer: any = await getRenderer({
+      printer: Printer as unknown as typeof IPrinter,
+      outputDir: "/output",
+      baseURL: baseURL,
+      group: undefined,
+      prettify: false,
+      docOptions: DEFAULT_RENDERER_OPTIONS,
+    });
     replaceProperty(renderer, "outputDir", "");
 
     await expect(
@@ -103,18 +103,18 @@ describe("generateCategoryMetafileType - focused tests", () => {
 
     const mockGenerateIndexMetafile = vi.fn();
     mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
-    const renderer: any = await getRenderer(
-      Printer as unknown as typeof IPrinter,
-      "/output",
-      baseURL,
-      undefined,
-      false,
-      {
+    const renderer: any = await getRenderer({
+      printer: Printer as unknown as typeof IPrinter,
+      outputDir: "/output",
+      baseURL: baseURL,
+      group: undefined,
+      prettify: false,
+      docOptions: {
         ...DEFAULT_RENDERER_OPTIONS,
         hierarchy: { [TypeHierarchy.FLAT]: {} },
       },
-      undefined, // mdxModule not needed - using event system
-    );
+      mdxExtension: undefined, // mdxModule not needed - using event system
+    });
 
     const dir = await renderer.generateCategoryMetafileType(
       {},
@@ -131,15 +131,15 @@ describe("generateCategoryMetafileType - focused tests", () => {
 
     const mockGenerateIndexMetafile = vi.fn();
     mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
-    const renderer: any = await getRenderer(
-      Printer as unknown as typeof IPrinter,
-      "/output",
-      baseURL,
-      undefined,
-      false,
-      DEFAULT_RENDERER_OPTIONS,
-      undefined, // mdxModule not needed - using event system
-    );
+    const renderer: any = await getRenderer({
+      printer: Printer as unknown as typeof IPrinter,
+      outputDir: "/output",
+      baseURL: baseURL,
+      group: undefined,
+      prettify: false,
+      docOptions: DEFAULT_RENDERER_OPTIONS,
+      mdxExtension: undefined, // mdxModule not needed - using event system
+    });
 
     // enable MDX forwarding
     renderer.mdxModuleIndexFileSupport = true;
@@ -162,19 +162,19 @@ describe("generateCategoryMetafileType - focused tests", () => {
 
     const mockGenerateIndexMetafile = vi.fn();
     mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
-    const renderer: any = await getRenderer(
-      Printer as unknown as typeof IPrinter,
-      "/output",
-      baseURL,
-      undefined,
-      false,
-      {
+    const renderer: any = await getRenderer({
+      printer: Printer as unknown as typeof IPrinter,
+      outputDir: "/output",
+      baseURL: baseURL,
+      group: undefined,
+      prettify: false,
+      docOptions: {
         ...DEFAULT_RENDERER_OPTIONS,
         deprecated: "group",
         hierarchy: { [TypeHierarchy.ENTITY]: {} },
       },
-      undefined, // mdxModule not needed - using event system
-    );
+      mdxExtension: undefined, // mdxModule not needed - using event system
+    });
 
     renderer.mdxModuleIndexFileSupport = true;
     vi.spyOn(GraphQL, "isDeprecated").mockReturnValueOnce(true);
@@ -193,19 +193,19 @@ describe("generateCategoryMetafileType - focused tests", () => {
 
     const mockGenerateIndexMetafile = vi.fn();
     mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
-    const renderer: any = await getRenderer(
-      Printer as unknown as typeof IPrinter,
-      "/output",
-      baseURL,
-      undefined,
-      false,
-      {
+    const renderer: any = await getRenderer({
+      printer: Printer as unknown as typeof IPrinter,
+      outputDir: "/output",
+      baseURL: baseURL,
+      group: undefined,
+      prettify: false,
+      docOptions: {
         ...DEFAULT_RENDERER_OPTIONS,
         index: false,
         hierarchy: { [TypeHierarchy.ENTITY]: {} },
       },
-      undefined, // mdxModule not needed - using event system
-    );
+      mdxExtension: undefined, // mdxModule not needed - using event system
+    });
 
     renderer.mdxModuleIndexFileSupport = true;
 

--- a/packages/core/tests/unit/renderer.test.ts
+++ b/packages/core/tests/unit/renderer.test.ts
@@ -111,15 +111,15 @@ describe("renderer", () => {
     const baseURL: string = "graphql";
 
     beforeEach(async () => {
-      rendererInstance = await getRenderer(
-        Printer as unknown as typeof IPrinter,
-        "/output",
-        baseURL,
-        undefined,
-        DEFAULT_OPTIONS.pretty!,
-        DEFAULT_RENDERER_OPTIONS,
-        ".mdx",
-      );
+      rendererInstance = await getRenderer({
+        printer: Printer as unknown as typeof IPrinter,
+        outputDir: "/output",
+        baseURL: baseURL,
+        group: undefined,
+        prettify: DEFAULT_OPTIONS.pretty!,
+        docOptions: DEFAULT_RENDERER_OPTIONS,
+        mdxExtension: ".mdx",
+      });
 
       // silent console
       vi.spyOn(globalThis.console, "warn").mockImplementation(() => {});
@@ -325,18 +325,21 @@ describe("renderer", () => {
           },
         };
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          group as unknown as Record<SchemaEntity, Record<string, string>>,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: group as unknown as Record<
+            SchemaEntity,
+            Record<string, string>
+          >,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
           },
-          ".mdx",
-        );
+          mdxExtension: ".mdx",
+        });
 
         // Generator pre-collects categories before rendering.
         renderer.preCollectCategories(["queries", "objects"]);
@@ -367,19 +370,19 @@ describe("renderer", () => {
       test("formats category folders by registration scope and falls back to slugify for unknown names", async () => {
         expect.assertions(4);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          ".mdx",
-        );
+          mdxExtension: ".mdx",
+        });
 
         renderer["rootLevelPositionManager"].registerCategories(["Query"]);
         renderer["rootLevelPositionManager"].computePositions();
@@ -1335,15 +1338,15 @@ describe("renderer", () => {
 
         const ensureDirSpy = vi.mocked(Utils.fsOutputAdapter.ensureDir!);
 
-        await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          "graphql",
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: "graphql",
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         expect(ensureDirSpy).toHaveBeenCalledWith("/output", {
           forceEmpty: undefined,
@@ -1355,15 +1358,15 @@ describe("renderer", () => {
 
         const ensureDirSpy = vi.mocked(Utils.fsOutputAdapter.ensureDir!);
 
-        await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          "graphql",
-          undefined,
-          false,
-          { ...DEFAULT_RENDERER_OPTIONS, force: true },
-          "mdx",
-        );
+        await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: "graphql",
+          group: undefined,
+          prettify: false,
+          docOptions: { ...DEFAULT_RENDERER_OPTIONS, force: true },
+          mdxExtension: "mdx",
+        });
 
         expect(ensureDirSpy).toHaveBeenCalledWith("/output", {
           forceEmpty: true,
@@ -1391,16 +1394,16 @@ describe("renderer", () => {
           const fsEnsureDir = vi.mocked(Utils.fsOutputAdapter.ensureDir!);
           fsEnsureDir.mockClear();
 
-          await getRenderer(
-            Printer as unknown as typeof IPrinter,
-            "/output",
-            "graphql",
-            undefined,
-            false,
-            { ...DEFAULT_RENDERER_OPTIONS, force: true },
-            ".mdx",
-            adapter,
-          );
+          await getRenderer({
+            printer: Printer as unknown as typeof IPrinter,
+            outputDir: "/output",
+            baseURL: "graphql",
+            group: undefined,
+            prettify: false,
+            docOptions: { ...DEFAULT_RENDERER_OPTIONS, force: true },
+            mdxExtension: ".mdx",
+            outputAdapter: adapter,
+          });
 
           expect(adapter.ensureDir).toHaveBeenCalledWith("/output", {
             forceEmpty: true,
@@ -1418,16 +1421,16 @@ describe("renderer", () => {
           const fsWriteFile = vi.mocked(Utils.fsOutputAdapter.writeFile);
           fsWriteFile.mockClear();
 
-          const renderer = await getRenderer(
-            Printer as unknown as typeof IPrinter,
-            "/output",
-            "graphql",
-            undefined,
-            false,
-            DEFAULT_RENDERER_OPTIONS,
-            ".mdx",
-            adapter,
-          );
+          const renderer = await getRenderer({
+            printer: Printer as unknown as typeof IPrinter,
+            outputDir: "/output",
+            baseURL: "graphql",
+            group: undefined,
+            prettify: false,
+            docOptions: DEFAULT_RENDERER_OPTIONS,
+            mdxExtension: ".mdx",
+            outputAdapter: adapter,
+          });
           await renderer.renderTypeEntities(
             "/output/foobar",
             "FooBar",
@@ -1452,16 +1455,16 @@ describe("renderer", () => {
           );
 
           const adapter = makeAdapter();
-          const renderer = await getRenderer(
-            Printer as unknown as typeof IPrinter,
-            "/output",
-            "graphql",
-            undefined,
-            true,
-            DEFAULT_RENDERER_OPTIONS,
-            ".mdx",
-            adapter,
-          );
+          const renderer = await getRenderer({
+            printer: Printer as unknown as typeof IPrinter,
+            outputDir: "/output",
+            baseURL: "graphql",
+            group: undefined,
+            prettify: true,
+            docOptions: DEFAULT_RENDERER_OPTIONS,
+            mdxExtension: ".mdx",
+            outputAdapter: adapter,
+          });
           await renderer.renderTypeEntities(
             "/output/foobar",
             "FooBar",
@@ -1485,16 +1488,16 @@ describe("renderer", () => {
           // collection - omits ensureDir entirely.
           const adapter = { writeFile: vi.fn() } as unknown as OutputAdapter;
 
-          const renderer = await getRenderer(
-            Printer as unknown as typeof IPrinter,
-            "/output",
-            "graphql",
-            undefined,
-            false,
-            { ...DEFAULT_RENDERER_OPTIONS, force: true },
-            ".mdx",
-            adapter,
-          );
+          const renderer = await getRenderer({
+            printer: Printer as unknown as typeof IPrinter,
+            outputDir: "/output",
+            baseURL: "graphql",
+            group: undefined,
+            prettify: false,
+            docOptions: { ...DEFAULT_RENDERER_OPTIONS, force: true },
+            mdxExtension: ".mdx",
+            outputAdapter: adapter,
+          });
           await renderer.renderTypeEntities(
             "/output/foobar",
             "FooBar",
@@ -1515,16 +1518,16 @@ describe("renderer", () => {
           );
           const adapter = makeAdapter();
 
-          const renderer = await getRenderer(
-            Printer as unknown as typeof IPrinter,
-            "/output",
-            "graphql",
-            undefined,
-            false,
-            DEFAULT_RENDERER_OPTIONS,
-            ".mdx",
-            adapter,
-          );
+          const renderer = await getRenderer({
+            printer: Printer as unknown as typeof IPrinter,
+            outputDir: "/output",
+            baseURL: "graphql",
+            group: undefined,
+            prettify: false,
+            docOptions: DEFAULT_RENDERER_OPTIONS,
+            mdxExtension: ".mdx",
+            outputAdapter: adapter,
+          });
           await renderer.renderHomepage("/assets/homepage.md");
 
           expect(adapter.writeFile).toHaveBeenCalledWith(
@@ -1539,15 +1542,15 @@ describe("renderer", () => {
       test("initializes renderer with correct parameters", async () => {
         expect.assertions(1);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/custom-output",
-          "custom-base-url",
-          { objects: { TestType: "test-group" } },
-          true,
-          DEFAULT_RENDERER_OPTIONS,
-          "@graphql-markdown/mdx-parser" as PackageName,
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/custom-output",
+          baseURL: "custom-base-url",
+          group: { objects: { TestType: "test-group" } },
+          prettify: true,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "@graphql-markdown/mdx-parser" as PackageName,
+        });
 
         expect(renderer).toMatchObject({
           printer: Printer,
@@ -1566,15 +1569,15 @@ describe("renderer", () => {
 
         const mockGenerateIndexMetafile = vi.fn();
         mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         // Pre-register all categories before generating files
         // This simulates knowing all categories upfront
@@ -1622,18 +1625,18 @@ describe("renderer", () => {
 
         const mockGenerateIndexMetafile = vi.fn();
         mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Pre-register categories
         renderer["categoryPositionManager"].registerCategories([
@@ -1673,18 +1676,18 @@ describe("renderer", () => {
           return b.localeCompare(a);
         };
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: customSort,
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Pre-register categories
         renderer["categoryPositionManager"].registerCategories([
@@ -1730,15 +1733,15 @@ describe("renderer", () => {
 
         const mockGenerateIndexMetafile = vi.fn();
         mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         // Provide explicit position (like for deprecated categories)
         await renderer.generateIndexMetafile("/output/special", "special", {
@@ -1759,15 +1762,15 @@ describe("renderer", () => {
 
         const mockGenerateIndexMetafile = vi.fn();
         mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         // Pre-register categories to ensure consistent positions
         renderer["categoryPositionManager"].registerCategories([
@@ -1814,19 +1817,19 @@ describe("renderer", () => {
       test("prefixes folder names with order numbers when categorySort is set", async () => {
         expect.assertions(3);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Pre-register categories
         renderer["rootLevelPositionManager"].registerCategories([
@@ -1862,19 +1865,19 @@ describe("renderer", () => {
       test("does not prefix folder names when categorySort is not set", async () => {
         expect.assertions(3);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             // categorySort not set - no prefixing should happen
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Pre-register categories
         renderer["categoryPositionManager"].registerCategories([
@@ -1914,19 +1917,19 @@ describe("renderer", () => {
           return b.localeCompare(a); // reverse alphabetical
         };
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: customSort,
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Pre-register categories
         renderer["rootLevelPositionManager"].registerCategories([
@@ -1963,19 +1966,19 @@ describe("renderer", () => {
       test("works correctly with groupByDirective when categorySort is set", async () => {
         expect.assertions(6);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          { objects: { Foo: "api-operations", Bar: "api-types" } },
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: { objects: { Foo: "api-operations", Bar: "api-types" } },
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Pre-register group categories
         renderer["rootLevelPositionManager"].registerCategories([
@@ -2010,19 +2013,19 @@ describe("renderer", () => {
       test("respects hierarchy with categorySort set", async () => {
         expect.assertions(3);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Pre-register the root type categories at ROOT level (entity hierarchy with no custom groups)
         renderer["rootLevelPositionManager"].registerCategories([
@@ -2059,19 +2062,19 @@ describe("renderer", () => {
       test("automatically prefixes when categorySort is set", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          { objects: { Foo: "custom-group" } },
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: { objects: { Foo: "custom-group" } },
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         renderer["categoryPositionManager"].registerCategories([
           "custom-group",
@@ -2092,19 +2095,19 @@ describe("renderer", () => {
       test("handles single category correctly with categorySort set", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Register only one category
         renderer["rootLevelPositionManager"].registerCategories(["single"]);
@@ -2124,19 +2127,19 @@ describe("renderer", () => {
       test("handles many categories (10+) with correct padding in prefixes", async () => {
         expect.assertions(4);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         const categories = [
           "alpha",
@@ -2192,19 +2195,19 @@ describe("renderer", () => {
           return b.localeCompare(a);
         };
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: reverseSort,
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         const categories = ["alpha", "beta", "gamma"];
         renderer["rootLevelPositionManager"].registerCategories(categories);
@@ -2235,20 +2238,20 @@ describe("renderer", () => {
       test("deprecated folder gets last position when categorySort is set", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             deprecated: "group",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "md",
-        );
+          mdxExtension: "md",
+        });
 
         // Mock a deprecated type
         vi.spyOn(GraphQL, "isDeprecated").mockReturnValueOnce(true);
@@ -2275,19 +2278,19 @@ describe("renderer", () => {
       test("handles hierarchical position management with multiple levels", async () => {
         expect.assertions(4);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          { objects: { Foo: "api-ops", Bar: "api-types" } },
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: { objects: { Foo: "api-ops", Bar: "api-types" } },
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Register root-level groups
         renderer["rootLevelPositionManager"].registerCategories([
@@ -2323,19 +2326,19 @@ describe("renderer", () => {
       test("still applies root-category prefixes when categorySort is not set", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: undefined,
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         renderer["rootLevelPositionManager"].registerCategories([
           "alpha",
@@ -2363,22 +2366,22 @@ describe("renderer", () => {
       test("works with custom groups across multiple types", async () => {
         expect.assertions(4);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: {
             objects: { User: "domain", Post: "domain" },
             interfaces: { Node: "system" },
           },
-          false,
-          {
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "md",
-        );
+          mdxExtension: "md",
+        });
 
         renderer["rootLevelPositionManager"].registerCategories([
           "domain",
@@ -2407,19 +2410,19 @@ describe("renderer", () => {
       test("isRegistered() correctly identifies pre-registered categories", async () => {
         expect.assertions(4);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Before registration, categories should not be registered
         expect(renderer["rootLevelPositionManager"].isRegistered("alpha")).toBe(
@@ -2447,19 +2450,19 @@ describe("renderer", () => {
       test("formatCategoryFolderName uses isRegistered to determine hierarchy level", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Register at root level
         renderer["rootLevelPositionManager"].registerCategories(["Query"]);
@@ -2530,19 +2533,19 @@ describe("renderer", () => {
       test("registerCategoriesWithManagers registers both root and nested when categorySort is set", async () => {
         expect.assertions(6);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "md",
-        );
+          mdxExtension: "md",
+        });
 
         const rootCategories = new Set(["query", "mutation", "subscription"]);
         const nestedCategories = new Set(["objects", "enums", "scalars"]);
@@ -2576,19 +2579,19 @@ describe("renderer", () => {
       test("registerCategoriesWithManagers respects categorySort not set with empty nested", async () => {
         expect.assertions(3);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         const rootCategories = new Set(["query"]);
         const nestedCategories = new Set<string>();
@@ -2614,19 +2617,19 @@ describe("renderer", () => {
 
         const mockGenerateIndexMetafile = vi.fn();
         mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Register and compute positions
         renderer["rootLevelPositionManager"].registerCategories([
@@ -2654,19 +2657,19 @@ describe("renderer", () => {
       test("mutation test: category metadata with explicit field values", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          { objects: { Custom: "custom-group" } },
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: { objects: { Custom: "custom-group" } },
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Register group categories
         renderer["rootLevelPositionManager"].registerCategories([
@@ -2690,19 +2693,19 @@ describe("renderer", () => {
 
         const mockGenerateIndexMetafile = vi.fn();
         mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         renderer["rootLevelPositionManager"].registerCategories(["objects"]);
         renderer["rootLevelPositionManager"].computePositions();
@@ -2729,19 +2732,19 @@ describe("renderer", () => {
 
         const mockGenerateIndexMetafile = vi.fn();
         mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Register categories in specific order
         renderer["rootLevelPositionManager"].registerCategories([
@@ -2780,19 +2783,19 @@ describe("renderer", () => {
 
         const mockGenerateIndexMetafile = vi.fn();
         mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         renderer["rootLevelPositionManager"].registerCategories(["objects"]);
         renderer["rootLevelPositionManager"].computePositions();
@@ -2817,18 +2820,18 @@ describe("renderer", () => {
 
         const mockGenerateIndexMetafile = vi.fn();
         mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             hierarchy: { [TypeHierarchy.FLAT]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         const dirPath = await renderer.generateCategoryMetafileType(
           {},
@@ -2864,19 +2867,19 @@ describe("renderer", () => {
 
         const mockGenerateIndexMetafile = vi.fn();
         mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         renderer["rootLevelPositionManager"].registerCategories([
           "objects",
@@ -2906,15 +2909,15 @@ describe("renderer", () => {
       test("mutation test: position manager early exit on second computePositions call", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         // Register categories and compute positions
         renderer["categoryPositionManager"].registerCategories(["objects"]);
@@ -2935,18 +2938,18 @@ describe("renderer", () => {
       test("mutation test: position manager handles base position", async () => {
         expect.assertions(3);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Register categories
         const categories = ["queries"];
@@ -2964,18 +2967,18 @@ describe("renderer", () => {
       test("mutation test: category path generation with different entity types", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Generate paths for different entity types
         const objectPath = await renderer.generateCategoryMetafileType(
@@ -2997,18 +3000,18 @@ describe("renderer", () => {
       test("mutation test: hierarchy option affects rendering", async () => {
         expect.assertions(1);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             hierarchy: {},
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Verify hierarchy is defined
         expect(renderer.options).toBeDefined();
@@ -3017,28 +3020,28 @@ describe("renderer", () => {
       test("mutation test: category sort option validation", async () => {
         expect.assertions(2);
 
-        const renderer1 = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer1 = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
-        const renderer2 = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer2 = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         // Verify categorySort values are different
         expect(renderer1.options?.categorySort).toBe("natural");
@@ -3048,15 +3051,15 @@ describe("renderer", () => {
       test("mutation test: position retrieval without precomputed state", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         // Register categories
         renderer["categoryPositionManager"].registerCategories(["test"]);
@@ -3098,18 +3101,18 @@ describe("renderer", () => {
       test("mutation test: category folderName formatting edge cases", async () => {
         expect.assertions(3);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Test multiple categories to verify all get prefixes when categorySort set
         renderer["rootLevelPositionManager"].registerCategories([
@@ -3143,15 +3146,15 @@ describe("renderer", () => {
       test("mutation test: boolean position cache state management", async () => {
         expect.assertions(5);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         const posManager = renderer["categoryPositionManager"];
 
@@ -3184,19 +3187,19 @@ describe("renderer", () => {
         const mockGenerateIndexMetafile = vi.fn();
         mockGenerateIndexMetafileHook(mockGenerateIndexMetafile);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
             categorySort: "natural",
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         // Generate metafiles for different entity types
         const objMetaPath = await renderer.generateCategoryMetafileType(
@@ -3224,15 +3227,15 @@ describe("renderer", () => {
       test("mutation test: collapsible option affects metadata generation", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         // Generate with collapsible true
         const pathWithCollapsible = await renderer.generateCategoryMetafileType(
@@ -3256,15 +3259,15 @@ describe("renderer", () => {
       test("mutation test: sidebarPosition configuration in metafile options", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         // Generate with explicit sidebarPosition
         const pathWithPosition = await renderer.generateCategoryMetafileType(
@@ -3287,15 +3290,15 @@ describe("renderer", () => {
       test("mutation test: positionsComputed flag is set correctly", async () => {
         expect.assertions(3);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         const posManager = renderer["categoryPositionManager"];
 
@@ -3318,18 +3321,18 @@ describe("renderer", () => {
       test("preCollectCategories skips registration for flat hierarchy", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             hierarchy: { [TypeHierarchy.FLAT]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         const rootTypeNames = ["queries", "mutations", "objects"];
         renderer.preCollectCategories(rootTypeNames);
@@ -3346,19 +3349,19 @@ describe("renderer", () => {
       test("preCollectCategories registers custom groups at root level", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          { objects: { Foo: "custom-group", Bar: "another-group" } },
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: { objects: { Foo: "custom-group", Bar: "another-group" } },
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         renderer.preCollectCategories(["objects"]);
 
@@ -3373,19 +3376,19 @@ describe("renderer", () => {
       test("preCollectCategories registers API groups correctly with custom groups", async () => {
         expect.assertions(4);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          { objects: { Foo: "custom" } },
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: { objects: { Foo: "custom" } },
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.API]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         renderer.preCollectCategories(["objects"]);
 
@@ -3409,19 +3412,19 @@ describe("renderer", () => {
       test("preCollectCategories registers API groups at root without custom groups", async () => {
         expect.assertions(3);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.API]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         renderer.preCollectCategories(["objects"]);
 
@@ -3441,19 +3444,19 @@ describe("renderer", () => {
       test("preCollectCategories registers entity categories at root without custom groups", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         renderer.preCollectCategories(["queries", "mutations"]);
 
@@ -3469,19 +3472,19 @@ describe("renderer", () => {
       test("preCollectCategories registers entity categories as nested with custom groups", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          { queries: { Query: "api-ops" } },
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: { queries: { Query: "api-ops" } },
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         renderer.preCollectCategories(["queries"]);
 
@@ -3497,20 +3500,20 @@ describe("renderer", () => {
       test("preCollectCategories registers deprecated at root when grouped", async () => {
         expect.assertions(1);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             deprecated: "group",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         renderer.preCollectCategories(["objects"]);
 
@@ -3522,20 +3525,20 @@ describe("renderer", () => {
       test("preCollectCategories does not register deprecated when not grouped", async () => {
         expect.assertions(1);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          {
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: {
             ...DEFAULT_RENDERER_OPTIONS,
             categorySort: "natural",
             deprecated: "default",
             hierarchy: { [TypeHierarchy.ENTITY]: {} },
           },
-          "mdx",
-        );
+          mdxExtension: "mdx",
+        });
 
         renderer.preCollectCategories(["objects"]);
 
@@ -3547,15 +3550,15 @@ describe("renderer", () => {
       test("registerCustomGroups handles empty group configuration", async () => {
         expect.assertions(1);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         const rootCategories = new Set<string>();
         renderer["registerCustomGroups"](rootCategories);
@@ -3566,15 +3569,15 @@ describe("renderer", () => {
       test("registerCustomGroups handles group with empty values", async () => {
         expect.assertions(1);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          { objects: { Foo: "", Bar: "valid-group" } },
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: { objects: { Foo: "", Bar: "valid-group" } },
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         const rootCategories = new Set<string>();
         renderer["registerCustomGroups"](rootCategories);
@@ -3586,15 +3589,15 @@ describe("renderer", () => {
       test("registerApiGroupCategories with custom groups nests API groups", async () => {
         expect.assertions(4);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         const rootCategories = new Set<string>();
         const nestedCategories = new Set<string>();
@@ -3614,15 +3617,15 @@ describe("renderer", () => {
       test("registerApiGroupCategories without custom groups puts API groups at root", async () => {
         expect.assertions(4);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         const rootCategories = new Set<string>();
         const nestedCategories = new Set<string>();
@@ -3642,15 +3645,15 @@ describe("renderer", () => {
       test("registerApiGroupCategories always nests entity categories", async () => {
         expect.assertions(3);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         const rootCategories = new Set<string>();
         const nestedCategories = new Set<string>();
@@ -3670,15 +3673,15 @@ describe("renderer", () => {
       test("registerEntityCategories with custom groups nests entity names", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         const rootCategories = new Set<string>();
         const nestedCategories = new Set<string>();
@@ -3697,15 +3700,15 @@ describe("renderer", () => {
       test("registerEntityCategories without custom groups puts entity names at root", async () => {
         expect.assertions(2);
 
-        const renderer = await getRenderer(
-          Printer as unknown as typeof IPrinter,
-          "/output",
-          baseURL,
-          undefined,
-          false,
-          DEFAULT_RENDERER_OPTIONS,
-          "mdx",
-        );
+        const renderer = await getRenderer({
+          printer: Printer as unknown as typeof IPrinter,
+          outputDir: "/output",
+          baseURL: baseURL,
+          group: undefined,
+          prettify: false,
+          docOptions: DEFAULT_RENDERER_OPTIONS,
+          mdxExtension: "mdx",
+        });
 
         const rootCategories = new Set<string>();
         const nestedCategories = new Set<string>();


### PR DESCRIPTION
# Description

Stacked on #3301 — fixes the last 2 of the 13 SonarCloud issues surfaced during that review's cleanup (both `S107`, same root cause), which were called out there as deliberately deferred.

`Renderer`'s constructor and its `getRenderer()` factory both took 8 positional parameters (`printer, outputDir, baseURL, group, prettify, docOptions, mdxExtension, outputAdapter`) — one over Sonar's limit of 7, and the real friction: a positional call site gives no indication which argument is which without checking the signature.

Introduced a `RendererOptions` interface bundling all 8 fields. Both the constructor and the factory now take one such object instead. Updated:
- The one production call site, in `generator.ts`
- Every test call site (~70 total, across `renderer.test.ts`, `renderer.generateCategoryMetafileType.spec.ts`, and the `getRenderer` spy assertions in `generator.test.ts`)
- Regenerated TypeDoc output for `renderer.md` and `generator.md`

Behavior is unchanged — verified against the full existing test suite (526 tests in `core` alone) plus a full `turbo run test:unit ts:check lint` across the workspace (41/41 tasks passing).

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my changes work.
- [x] New and existing unit tests pass locally with my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)