### PR TITLE
:bug: fix docs sidebar frontmatter and stale CLI example

### DIFF
--- a/docs/__api/__index.md
+++ b/docs/__api/__index.md
@@ -30,7 +30,7 @@ If you are targeting a formatter-based documentation stack such as Hugo, MkDocs,
 Using the CLI:
 
 ```bash
-graphql-markdown --schema ./schema.graphql --root ./docs
+npx gqlmd graphql-to-doc --schema ./schema.graphql --root ./docs
 ```
 
 For programmatic usage, you can use the CLI package:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-position: 90
+sidebar_position: 90
 pagination_prev: null
 pagination_next: null
 description: Solutions for common GraphQL-Markdown issues including duplicate graphql modules, missing type definitions, and configuration problems.


### PR DESCRIPTION
# Description

Two small documentation fixes found during a completeness/readability review of `docs/`:

- `docs/troubleshooting.md` used `position: 90` instead of `sidebar_position: 90` in its front matter, unlike every other doc page, which likely broke its intended sidebar placement.
- `docs/__api/__index.md`'s "Basic Usage" example invoked a non-existent `graphql-markdown` binary. The CLI is actually installed as `gqlmd` and invoked via the `graphql-to-doc` subcommand, matching usage shown elsewhere (e.g. `docs/advanced/integration-with-frameworks.md`).

# Checklist

- [x] My changes follow the [contributing guidelines](https://github.com/graphql-markdown/graphql-markdown/blob/main/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my changes work.
- [ ] New and existing unit tests pass locally with my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)